### PR TITLE
body全体をscaleせずにレスポンシブ対応

### DIFF
--- a/app/common/box.tsx
+++ b/app/common/box.tsx
@@ -9,7 +9,11 @@ export function Box(props: Props) {
   return (
     <div
       className={"rounded-lg " + (props.className || "")}
-      style={{ background: "rgba(255, 255, 255, 0.5)", ...props.style }}
+      style={{
+        background: "rgba(255, 255, 255, 0.7)",
+        backdropFilter: "blur(1px)",
+        ...props.style,
+      }}
     >
       {props.children}
     </div>

--- a/app/common/box.tsx
+++ b/app/common/box.tsx
@@ -20,7 +20,7 @@ export function CenterBox(props: Props) {
   return (
     <Box
       className={
-        "absolute inset-0 w-max h-max m-auto p-6 text-center " +
+        "absolute inset-0 w-max h-max m-auto p-6 text-center z-20 " +
         (props.className || "")
       }
       style={props.style}

--- a/app/common/footer.tsx
+++ b/app/common/footer.tsx
@@ -5,12 +5,12 @@ import { Github } from "@icon-park/react";
 import Link from "next/link";
 
 export default function Footer() {
-  const { isMobile } = useDisplayMode();
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
   return (
     <footer className="">
       <div
         className={
-          isMobile
+          screenWidth < 45 * rem
             ? "flex flex-col items-center "
             : "flex flex-row justify-center space-x-3"
         }
@@ -22,11 +22,13 @@ export default function Footer() {
           <Github className="absolute bottom-1 left-0" />
           <span className="ml-5">na-trium-144/falling-nikochan</span>
         </Link>
-        <div className="space-x-2">
-          <span>Build</span>
-          <span>{process.env.buildDate}</span>
-          <span>({process.env.buildCommit})</span>
-        </div>
+        {screenWidth >= 25 * rem && (
+          <div className="space-x-2">
+            <span>Build</span>
+            <span>{process.env.buildDate}</span>
+            <span>({process.env.buildCommit})</span>
+          </div>
+        )}
       </div>
       <p className="my-1 text-center text-sm">
         ※ FallingNikochanは開発中です。

--- a/app/common/youtube.tsx
+++ b/app/common/youtube.tsx
@@ -14,9 +14,19 @@ interface Props {
   onReady?: () => void;
   onStart?: () => void;
   onStop?: () => void;
+  fixedSide: "width" | "height";
 }
 export function FlexYouTube(props: Props) {
-  const { isMobile, id, control, ytPlayer, onReady, onStart, onStop } = props;
+  const {
+    isMobile,
+    id,
+    control,
+    ytPlayer,
+    onReady,
+    onStart,
+    onStop,
+    fixedSide,
+  } = props;
   const { width, height, ref } = useResizeDetector();
   const resizeYouTube = useRef<() => void>();
   const onReadyRef = useRef<() => void>();
@@ -28,13 +38,18 @@ export function FlexYouTube(props: Props) {
       if (ytPlayer.current) {
         if (width && height) {
           const iframe = ytPlayer.current.getIframe();
-          iframe.width = String(width);
-          iframe.height = String((width * 9) / 16);
+          if (fixedSide === "width") {
+            iframe.width = String(width);
+            iframe.height = String((width * 9) / 16);
+          } else {
+            iframe.height = String(height);
+            iframe.width = String((height * 16) / 9);
+          }
         }
       }
     };
     resizeYouTube.current();
-  }, [width, height, ytPlayer]);
+  }, [width, height, ytPlayer, fixedSide]);
 
   onReadyRef.current = onReady;
   onStartRef.current = onStart;
@@ -65,7 +80,7 @@ export function FlexYouTube(props: Props) {
               }
             },
             onStateChange: () => {
-              console.log(ytPlayer.current?.getPlayerState())
+              console.log(ytPlayer.current?.getPlayerState());
               if (ytPlayer.current?.getPlayerState() === 1) {
                 if (onStartRef.current) {
                   onStartRef.current();
@@ -99,10 +114,14 @@ export function FlexYouTube(props: Props) {
   return (
     <div
       className={
-        props.className + " relative"
+        "relative " + props.className
         /* + " flex justify-center items-center"*/
       }
-      style={{ ...props.style, height: ((width || 1) * 9) / 16 }}
+      style={{
+        ...props.style,
+        width: fixedSide === "height" && height ? (height * 16) / 9 : undefined,
+        height: fixedSide === "width" && width ? (width * 9) / 16 : undefined,
+      }}
       ref={ref}
     >
       <div className="absolute inset-0">

--- a/app/edit/[cid]/page.tsx
+++ b/app/edit/[cid]/page.tsx
@@ -108,7 +108,8 @@ export default function Page(context: { params: Params }) {
     return () => window.removeEventListener("beforeunload", onUnload);
   }, [hasChange]);
 
-  const { scaledSize, isMobile } = useDisplayMode();
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < 50 * rem;
   const ref = useRef<HTMLDivElement>(null!);
 
   // 現在時刻 offsetを引く前
@@ -364,7 +365,7 @@ export default function Page(context: { params: Params }) {
   return (
     <main
       className={"overflow-x-hidden " + (isMobile ? "" : "overflow-y-hidden ")}
-      style={{ ...scaledSize, touchAction: "none" }}
+      style={{ touchAction: "none" }}
       tabIndex={0}
       ref={ref}
       onKeyDown={(e) => {
@@ -403,13 +404,13 @@ export default function Page(context: { params: Params }) {
     >
       <div
         className={
-          "w-full h-full " +
-          (isMobile ? "h-5/6 " : "flex items-stretch flex-row ")
+          "w-full " +
+          (isMobile ? "h-screen" : "h-full flex items-stretch flex-row ")
         }
       >
         <div
           className={
-            "basis-4/12 " +
+            (isMobile ? "h-full " : "basis-4/12 ") +
             "grow-0 shrink-0 h-full flex flex-col items-stretch p-3"
           }
         >
@@ -418,11 +419,13 @@ export default function Page(context: { params: Params }) {
           </BackButton>
           <div
             className={
-              "grow-0 shrink-0 p-3 bg-amber-700 rounded-lg flex " + "flex-col"
+              "grow-0 shrink-0 p-3 bg-amber-700 rounded-lg flex flex-col items-center " +
+              (isMobile ? "h-1/3 " : "")
             }
           >
             <FlexYouTube
-              className={"block "}
+              fixedSide={isMobile ? "height" : "width"}
+              className={isMobile ? "w-max h-full" : ""}
               isMobile={false}
               control={true}
               id={chart?.ytId}
@@ -550,7 +553,7 @@ export default function Page(context: { params: Params }) {
               )
             )}
           </div>
-          <Box className="flex-1 p-3">
+          <Box className="flex-1 p-3 overflow-auto">
             {tab === 0 ? (
               <MetaTab
                 chart={chart}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="overflow-hidden">
+      <body className="bg-gradient-to-t from-sky-50 to-sky-200 min-w-screen min-h-screen overflow-auto ">
         <AutoScaler>{children}</AutoScaler>
       </body>
     </html>

--- a/app/main/main.tsx
+++ b/app/main/main.tsx
@@ -12,20 +12,30 @@ interface Props {
   tab: number | undefined;
 }
 export function IndexMain(props: Props) {
-  const { isMobile, scaledSize } = useDisplayMode();
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
   const tabTitles = ["Falling Nikochan とは？", "プレイする", "譜面作成"];
   const tabURLs = ["/main/about/1", "/main/play", "/main/edit"];
 
+  const isMobile = screenWidth < 40 * rem;
+  console.log(isMobile);
+  console.log(screenWidth / rem);
   return (
-    <main className="flex flex-col" style={{ ...scaledSize }}>
+    <main className="flex flex-col w-full min-h-screen h-max">
       {!(isMobile && props.tab !== undefined) && (
-        <div className="basis-1/4 flex flex-row items-center justify-center">
+        <div className="flex-none basis-32 flex flex-row items-center justify-center">
           <div className="text-4xl">Falling Nikochan</div>
         </div>
       )}
-      <div className="flex flex-1 flex-row justify-center p-6 ">
+      <div
+        className={
+          (props.tab !== undefined ? "basis-96 " : "basis-auto ") +
+          (isMobile ? "" : "max-h-screen overflow-hidden ") +
+          "grow shrink-0 " +
+          "flex flex-row justify-center px-6 "
+        }
+      >
         {!(isMobile && props.tab !== undefined) && (
-          <div className="flex flex-col mt-3 justify-center">
+          <div className="flex flex-col justify-center w-56 shrink-0">
             {tabTitles.map((tabName, i) =>
               i === props.tab ? (
                 <Link key={i} href="/">
@@ -52,7 +62,10 @@ export function IndexMain(props: Props) {
         )}
         {props.tab !== undefined && (
           <Box
-            className={"flex flex-col p-6 " + (isMobile ? "w-full" : "shrink")}
+            className={
+              "flex flex-col p-6 overflow-auto " +
+              (isMobile ? "w-full my-6 " : "shrink ")
+            }
             style={{ flexBasis: isMobile ? undefined : 600 }}
           >
             {isMobile && (

--- a/app/play/[cid]/bpmSign.tsx
+++ b/app/play/[cid]/bpmSign.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useDisplayMode } from "@/scale";
+
+interface Props {
+  currentBpm?: number;
+}
+export default function BPMSign(props: Props) {
+  const { screenWidth, screenHeight } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  const scalingWidthThreshold = isMobile ? 500 : 750;
+  const scale = Math.min(screenWidth / scalingWidthThreshold, 1);
+
+  return (
+    <div
+      className="absolute origin-bottom-left"
+      style={{
+        bottom: "100%",
+        left: "1rem",
+        transform: scale < 1 ? `scale(${scale})` : undefined,
+      }}
+    >
+      <div
+        className="absolute inset-0 m-auto w-4 bg-amber-800 "
+        style={{ borderRadius: "100%/6px" }}
+      ></div>
+      <div
+        className={
+          "rounded-sm -translate-y-10 p-2 " +
+          "bg-gradient-to-t from-amber-700 to-amber-600 " +
+          "border-b-2 border-r-2 border-amber-900 " +
+          "flex flex-row items-baseline"
+        }
+      >
+        <span className="text-2xl font-title">♩</span>
+        <span className="text-xl ml-2 mr-1">=</span>
+        <span className="text-right text-3xl w-16">
+          {props.currentBpm !== undefined && Math.floor(props.currentBpm)}
+        </span>
+        <span className="text-lg">.</span>
+        <span className="text-lg w-3">
+          {props.currentBpm !== undefined &&
+            Math.floor(props.currentBpm * 10) % 10}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/play/[cid]/bpmSign.tsx
+++ b/app/play/[cid]/bpmSign.tsx
@@ -13,7 +13,7 @@ export default function BPMSign(props: Props) {
 
   return (
     <div
-      className="absolute origin-bottom-left"
+      className="-z-10 absolute origin-bottom-left"
       style={{
         bottom: "100%",
         left: "1rem",

--- a/app/play/[cid]/messageBox.tsx
+++ b/app/play/[cid]/messageBox.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { CenterBox } from "@/common/box";
 import Button from "@/common/button";
 import { Key } from "@/common/key";
+import { useDisplayMode } from "@/scale";
 
 interface MessageProps {
   isTouch: boolean;
@@ -12,11 +15,21 @@ export function ReadyMessage(props: MessageProps) {
     <CenterBox>
       <p className="mb-1">Ready to start!</p>
       <p>
-        <Button text="スタート" keyName="Space" onClick={() => props.start()} />
-        <Button text="やめる" keyName="Esc" onClick={() => props.exit()} />
+        <Button
+          text="スタート"
+          keyName={props.isTouch ? undefined : "Space"}
+          onClick={() => props.start()}
+        />
+        <Button
+          text="やめる"
+          keyName={props.isTouch ? undefined : "Esc"}
+          onClick={() => props.exit()}
+        />
       </p>
       <p className="mt-2">
-        (スタートされない場合はページを再読み込みしてください)
+        ※スタートされない場合は
+        <br />
+        ページを再読み込みしてください
       </p>
     </CenterBox>
   );
@@ -28,10 +41,14 @@ export function StopMessage(props: MessageProps) {
       <p>
         <Button
           text="再スタート"
-          keyName="Space"
+          keyName={props.isTouch ? undefined : "Space"}
           onClick={() => props.start()}
         />
-        <Button text="やめる" keyName="Esc" onClick={() => props.exit()} />
+        <Button
+          text="やめる"
+          keyName={props.isTouch ? undefined : "Esc"}
+          onClick={() => props.exit()}
+        />
       </p>
     </CenterBox>
   );

--- a/app/play/[cid]/page.tsx
+++ b/app/play/[cid]/page.tsx
@@ -72,6 +72,8 @@ export default function Home(context: { params: Params }) {
   const ref = useRef<HTMLDivElement>(null!);
   const { isTouch, screenWidth, screenHeight, rem } = useDisplayMode();
   const isMobile = screenWidth < screenHeight;
+  const statusHide = !isMobile && screenHeight < 32 * rem;
+  const statusOverlaps = !isMobile && screenHeight < 40 * rem && !statusHide;
 
   const [bestScoreState, setBestScoreState] = useState<number>(0);
   const reloadBestScore = useCallback(() => {
@@ -222,7 +224,7 @@ export default function Home(context: { params: Params }) {
 
   return (
     <main
-      className="overflow-hidden w-screen h-screen"
+      className="overflow-hidden w-screen h-screen relative"
       style={{ touchAction: "none" }}
       tabIndex={0}
       ref={ref}
@@ -291,7 +293,7 @@ export default function Home(context: { params: Params }) {
           {/*<div className={"text-right mr-4 " + (isMobile ? "" : "flex-1 ")}>
             {fps} FPS
           </div>*/}
-          {!isMobile && (
+          {!isMobile && !statusHide && (
             <>
               <StatusBox
                 className="z-10 flex-none m-3 self-end"
@@ -339,20 +341,16 @@ export default function Home(context: { params: Params }) {
       >
         <div
           className={
-            "absolute inset-x-0 bottom-0 " +
+            "-z-20 absolute inset-x-0 bottom-0 " +
             "bg-gradient-to-t from-lime-600 via-lime-500 to-lime-200 "
           }
           style={{ top: "-1rem" }}
         />
         <RhythmicalSlime
-          className="absolute "
+          className="-z-10 absolute "
           style={{
             bottom: "100%",
-            right: isMobile
-              ? "1rem"
-              : screenHeight < 40 * rem
-              ? (20 * rem) / ((40 * rem) / screenHeight)
-              : "1rem",
+            right: isMobile ? "1rem" : statusOverlaps ? 17 * rem : "1rem",
           }}
           num={4}
           getCurrentTimeSec={getCurrentTimeSec}
@@ -372,6 +370,18 @@ export default function Home(context: { params: Params }) {
           />
         )}
       </div>
+      {!isMobile && statusHide && showResult && (
+        <StatusBox
+          className="z-20 absolute my-auto h-max inset-y-0"
+          style={{ right: "0.75rem" }}
+          judgeCount={judgeCount}
+          bigCount={bigCount}
+          bigTotal={bigTotal}
+          notesTotal={notesAll.length}
+          isMobile={false}
+          isTouch={isTouch}
+        />
+      )}
     </main>
   );
 }

--- a/app/play/[cid]/page.tsx
+++ b/app/play/[cid]/page.tsx
@@ -20,6 +20,7 @@ import { addRecent } from "@/common/recent";
 import { useRouter, useSearchParams } from "next/navigation";
 import Result from "./result";
 import { getBestScore, setBestScore } from "@/common/bestScore";
+import BPMSign from "./bpmSign";
 
 export default function Home(context: { params: Params }) {
   const cid = context.params.cid;
@@ -69,7 +70,8 @@ export default function Home(context: { params: Params }) {
   }, [cid]);
 
   const ref = useRef<HTMLDivElement>(null!);
-  const { isMobile, isTouch, scaledSize } = useDisplayMode();
+  const { isTouch, screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
 
   const [bestScoreState, setBestScoreState] = useState<number>(0);
   const reloadBestScore = useCallback(() => {
@@ -220,8 +222,8 @@ export default function Home(context: { params: Params }) {
 
   return (
     <main
-      className="overflow-hidden flex flex-col "
-      style={{ ...scaledSize, touchAction: "none" }}
+      className="overflow-hidden w-screen h-screen"
+      style={{ touchAction: "none" }}
       tabIndex={0}
       ref={ref}
       onKeyDown={(e) => {
@@ -243,14 +245,17 @@ export default function Home(context: { params: Params }) {
     >
       <div
         className={
-          "flex-1 w-full h-full flex items-stretch " +
+          "w-full overflow-y-visible flex items-stretch " +
           (isMobile ? "flex-col" : "flex-row-reverse")
         }
+        style={{
+          height: isMobile ? screenHeight - 6 * rem : screenHeight * 0.9,
+        }}
       >
         <div
           className={
-            (isMobile ? "flex-none " : "basis-4/12 ") +
-            "grow-0 shrink-0 flex flex-col items-stretch"
+            (isMobile ? "" : "w-1/3 overflow-x-visible ") +
+            "flex-none flex flex-col items-stretch"
           }
         >
           <div
@@ -260,8 +265,9 @@ export default function Home(context: { params: Params }) {
             }
           >
             <FlexYouTube
+              fixedSide="width"
               className={
-                "z-10 block " + (isMobile ? "grow-0 shrink-0 basis-6/12" : "")
+                "z-10 " + (isMobile ? "grow-0 shrink-0 basis-6/12" : "w-full")
               }
               isMobile={isMobile}
               id={chartBrief?.ytId}
@@ -288,7 +294,7 @@ export default function Home(context: { params: Params }) {
           {!isMobile && (
             <>
               <StatusBox
-                className="z-10 grow-0 shrink-0 m-3 self-end"
+                className="z-10 flex-none m-3 self-end"
                 judgeCount={judgeCount}
                 bigCount={bigCount}
                 bigTotal={bigTotal}
@@ -300,7 +306,7 @@ export default function Home(context: { params: Params }) {
             </>
           )}
         </div>
-        <div className={"relative " + (isMobile ? "flex-1 " : "basis-8/12 ")}>
+        <div className={"relative flex-1"}>
           <FallingWindow
             className="absolute inset-0"
             notes={notesAll}
@@ -309,13 +315,8 @@ export default function Home(context: { params: Params }) {
             setFPS={setFps}
             barFlash={barFlash}
           />
-          <ScoreDisp
-            className="absolute top-0 right-3 "
-            score={score}
-            best={bestScoreState}
-            auto={auto}
-          />
-          <ChainDisp className="absolute top-0 left-3 " chain={chain} />
+          <ScoreDisp score={score} best={bestScoreState} auto={auto} />
+          <ChainDisp chain={chain} />
           {showResult ? (
             <Result
               baseScore={baseScore}
@@ -332,48 +333,33 @@ export default function Home(context: { params: Params }) {
           ) : null}
         </div>
       </div>
-      <div className={"relative w-full " + (isMobile ? "h-32 " : "h-16 ")}>
+      <div
+        className={"relative w-full "}
+        style={{ height: isMobile ? "6rem" : "10%" }}
+      >
         <div
           className={
             "absolute inset-x-0 bottom-0 " +
             "bg-gradient-to-t from-lime-600 via-lime-500 to-lime-200 "
           }
-          style={{ top: -15 }}
+          style={{ top: "-1rem" }}
         />
         <RhythmicalSlime
           className="absolute "
-          style={{ bottom: "100%", right: 15 }}
+          style={{
+            bottom: "100%",
+            right: isMobile
+              ? "1rem"
+              : screenHeight < 40 * rem
+              ? (20 * rem) / ((40 * rem) / screenHeight)
+              : "1rem",
+          }}
           num={4}
           getCurrentTimeSec={getCurrentTimeSec}
           playing={playing}
           bpmChanges={chartSeq?.bpmChanges}
         />
-        <div className="absolute " style={{ bottom: "100%", left: 15 }}>
-          <div
-            className="absolute inset-0 m-auto w-4 bg-amber-800 "
-            style={{ borderRadius: "100%/6px" }}
-          ></div>
-          <div
-            className={
-              "rounded-sm -translate-y-10 p-2 " +
-              "bg-gradient-to-t from-amber-700 to-amber-600 " +
-              "border-b-2 border-r-2 border-amber-900 " +
-              "flex flex-row items-baseline"
-            }
-          >
-            <span className="text-2xl font-title">♩</span>
-            <span className="text-xl ml-2 mr-1">=</span>
-            <span className="text-right text-3xl w-16">
-              {Math.floor(chartSeq?.bpmChanges[currentBpmIndex]?.bpm || 0)}
-            </span>
-            <span className="text-lg">.</span>
-            <span className="text-lg w-3">
-              {Math.floor(
-                (chartSeq?.bpmChanges[currentBpmIndex]?.bpm || 0) * 10
-              ) % 10}
-            </span>
-          </div>
-        </div>
+        <BPMSign currentBpm={chartSeq?.bpmChanges[currentBpmIndex]?.bpm} />
         {isMobile && (
           <StatusBox
             className="absolute inset-4 z-10"

--- a/app/play/[cid]/rhythmicalSlime.tsx
+++ b/app/play/[cid]/rhythmicalSlime.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { BPMChange } from "@/chartFormat/command";
 import { getTimeSec } from "@/chartFormat/seq";
 import { Step, stepAdd, stepSub, stepZero } from "@/chartFormat/step";
+import { useDisplayMode } from "@/scale";
 
 interface Props {
   className?: string;
@@ -94,6 +95,13 @@ export default function RhythmicalSlime(props: Props) {
       });
     }
   }, [bpmChanges, num, playing, getCurrentTimeSec]);
+
+
+  const { screenWidth, screenHeight } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  const scalingWidthThreshold = isMobile ? 500 : 750;
+  const scale = Math.min(screenWidth/scalingWidthThreshold, 1);
+
   return (
     <div
       className={props.className + " flex flex-row-reverse "}
@@ -106,15 +114,15 @@ export default function RhythmicalSlime(props: Props) {
           className={
             "transition-transform origin-bottom " +
             (jumpingSlime == i
-              ? "ease-out -translate-y-6 scale-y-110 "
+              ? "ease-out -translate-y-1/2 scale-y-110 "
               : preparingSlime == i
               ? "ease-out translate-y-0 scale-y-75 "
               : "ease-in translate-y-0 scale-y-100 ")
           }
           style={{
             transitionDuration: Math.round(transitionTimeMSec.current) + "ms",
-            height: 40,
-            marginLeft: 8,
+            height: 40 * scale,
+            marginLeft: 8 * scale,
           }}
         />
       ))}

--- a/app/play/[cid]/score.tsx
+++ b/app/play/[cid]/score.tsx
@@ -1,9 +1,45 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useDisplayMode } from "@/scale";
+import { ReactNode, useEffect, useRef, useState } from "react";
 
-interface Props {
+interface CProps {
   className?: string;
+  left?: boolean;
+  children: ReactNode;
+}
+function Cloud(props: CProps) {
+  const { screenWidth, screenHeight } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  const scalingWidthThreshold = isMobile ? 500 : 750;
+  const scale = Math.min(screenWidth / scalingWidthThreshold, 1);
+
+  return (
+    <div
+      className={
+        "absolute top-0 " +
+        (props.left ? "left-3 origin-top-left" : "right-3 origin-top-right")
+      }
+      style={{
+        transform: scale < 1 ? `scale(${scale})` : undefined,
+      }}
+    >
+      <div
+        className={props.className}
+        style={{
+          backgroundImage: "url(/cloud.svg)",
+          width: 225,
+          height: 115,
+          paddingLeft: 16,
+          paddingRight: 22,
+        }}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+}
+interface Props {
   style?: object;
   score: number;
   best: number;
@@ -12,59 +48,48 @@ interface Props {
 export function ScoreDisp(props: Props) {
   const { score, best } = props;
   return (
-    <div
-      className={props.className + " flex flex-col"}
-      style={{
-        backgroundImage: "url(/cloud.svg)",
-        width: 225,
-        height: 115,
-        paddingLeft: 16,
-        paddingRight: 22,
-      }}
-    >
-      <div className="flex flex-row items-baseline mt-1">
+    <Cloud className="flex flex-col">
+      <div className="flex flex-row items-baseline" style={{ marginTop: 4 }}>
         <span className="flex-1 text-md">Score</span>
         <NumDisp num={score} fontSize1={40} fontSize2={24} anim />
       </div>
       {props.auto ? (
         <div className="text-center">&lt;&lt; AutoPlay &gt;&gt;</div>
       ) : (
-        <div className="flex flex-row items-baseline mt-1">
-          <span className="flex-1 text-md mr-2">Best Score</span>
+        <div className="flex flex-row items-baseline" style={{ marginTop: 4 }}>
+          <span className="flex-1 " style={{ fontSize: 16, marginRight: 8 }}>
+            Best Score
+          </span>
           <NumDisp num={best} fontSize1={24} fontSize2={24} />
         </div>
       )}
-    </div>
+    </Cloud>
   );
 }
 interface ChainProps {
-  className?: string;
   style?: object;
   chain: number;
 }
 export function ChainDisp(props: ChainProps) {
   return (
-    <div
+    <Cloud
       className={
-        props.className +
-        " flex flex-col " +
-        (props.chain >= 100 ? "text-orange-500 " : "")
+        "flex flex-col " + (props.chain >= 100 ? "text-orange-500 " : "")
       }
-      style={{
-        backgroundImage: "url(/cloud.svg)",
-        width: 225,
-        height: 115,
-        paddingLeft: 16,
-        paddingRight: 22,
-      }}
+      left
     >
-      <div className="flex flex-row items-baseline justify-center mt-5 space-x-2">
-        <span className="w-28">
+      <div
+        className="flex flex-row items-baseline justify-center "
+        style={{ marginTop: 20 }}
+      >
+        <span className="" style={{ width: 112, marginRight: 8 }}>
           <NumDisp num={props.chain} fontSize1={40} fontSize2={null} anim />
         </span>
-        <span className="text-left text-md ">Chains</span>
+        <span className="text-left " style={{ fontSize: 16 }}>
+          Chains
+        </span>
       </div>
-    </div>
+    </Cloud>
   );
 }
 
@@ -110,7 +135,7 @@ function NumDisp(props: NumProps) {
             className={
               "inline-block transition duration-100 " +
               (numChanged[i]
-                ? "ease-out -translate-y-1"
+                ? "ease-out -translate-y-1/4"
                 : "ease-in translate-y-0")
             }
             style={{
@@ -131,14 +156,17 @@ function NumDisp(props: NumProps) {
           >
             .
           </span>
-          <div className="" style={{ width: 1.4 * props.fontSize2 }}>
+          <div
+            className="flex flex-row "
+            style={{ width: 1.4 * props.fontSize2 }}
+          >
             {[10, 100].map((a, i) => (
               <span
                 key={a}
                 className={
                   "inline-block transition duration-100 " +
                   (numChanged[i + digits - 2]
-                    ? "ease-out -translate-y-1"
+                    ? "ease-out -translate-y-1/4"
                     : "ease-in translate-y-0")
                 }
                 style={{

--- a/app/play/[cid]/statusBox.tsx
+++ b/app/play/[cid]/statusBox.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import { Box } from "@/common/box";
 import { Key } from "@/common/key";
+import { useDisplayMode } from "@/scale";
+import { ReactNode } from "react";
 
 interface Props {
   className?: string;
@@ -11,87 +15,117 @@ interface Props {
   isTouch: boolean;
 }
 export default function StatusBox(props: Props) {
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  let boxScale: number = 1;
+  let textScale: number = 1;
+  if (isMobile) {
+    textScale = Math.min(screenWidth / (31 * rem), 1);
+  } else {
+    // 計算めんどくなって適当に数字入れてでっちあげしている
+    boxScale = Math.min(
+      (screenHeight - screenWidth * (1 / 3) * (2 / 3) - 7 * rem) / (17 * rem),
+      1
+    );
+  }
+
   return (
     <Box
-      className={
-        props.className + (props.isMobile ? " " : " w-52 ") + "p-3 text-sm"
-      }
+      className={props.className + (isMobile ? "" : " origin-top-right")}
+      style={{
+        transform: boxScale < 1 ? `scale(${boxScale})` : undefined,
+        padding: (3 / 4) * rem * boxScale,
+        fontSize: textScale * rem,
+      }}
     >
-      {props.isTouch ? (
-        <p className="mb-2 text-center">
-          Tap the video to start/stop the game.
-        </p>
-      ) : (
-        [
-          ["Space", "start"],
-          ["Esc", "stop"],
-        ].map(([keyName, act], i) => (
-          <p key={i} className="mb-2 flex flex-row items-baseline">
-            <span className="basis-7/12 inline-block text-center">
-              <Key className="p-0.5 m-auto">{keyName}</Key>
-            </span>
-            <span className="">=</span>
-            <span className="basis-6/12 text-center">{act}</span>
-          </p>
-        ))
-      )}
-      <div className={props.isMobile ? "flex flex-row items-start justify-between " : ""}>
+      <div
+        className={
+          props.isMobile
+            ? "flex flex-row h-full items-center justify-between "
+            : "w-56"
+        }
+      >
         {["Good", "OK", "Bad", "Miss"].map((name, ji) => (
-          <p
-            key={ji}
-            className={
-              props.isMobile
-                ? "flex-1 flex flex-col mr-2 "
-                : "flex flex-row items-baseline mr-12"
-            }
-          >
-            <span className={props.isMobile ? "h-3 " : "flex-1"}>{name}</span>
-            <span className="text-2xl text-right">{props.judgeCount[ji]}</span>
-          </p>
+          <StatusItem key={ji}>
+            <StatusName>{name}</StatusName>
+            <StatusValue>{props.judgeCount[ji]}</StatusValue>
+          </StatusItem>
         ))}
-        <p
-          className={
-            props.isMobile
-              ? "flex-1 flex flex-col mr-2 "
-              : "flex flex-row items-baseline "
-          }
-        >
-          <span className={props.isMobile ? "h-3 " : "flex-1"}>
-            {props.isMobile ? "Big" : "Big Notes"}
-          </span>
-          <span className="text-2xl text-right">{props.bigCount}</span>
+        <StatusItem wide>
+          <StatusName>{props.isMobile ? "Big" : "Big Notes"}</StatusName>
+          <StatusValue>{props.bigCount}</StatusValue>
           {!props.isMobile && (
             <span className="w-12 pl-1 flex flex-row items-baseline">
               <span className="flex-1">/</span>
               <span>{props.bigTotal}</span>
             </span>
           )}
-        </p>
-        <p
-          className={
-            props.isMobile
-              ? "flex-1 flex flex-col "
-              : "flex flex-row items-baseline "
-          }
-        >
-          <span className={props.isMobile ? "h-3 " : "flex-1"}>Remains</span>
-          <span className="text-2xl text-right">
-            {props.notesTotal - props.judgeCount.reduce((sum, j) => sum + j, 0)}
+        </StatusItem>
+        {props.isMobile && screenWidth >= 39 * rem && (
+          <span className="flex-none w-12 pl-1 self-end translate-y-1 flex flex-row items-baseline mr-2">
+            <span className="flex-1">/</span>
+            <span>{props.bigTotal}</span>
           </span>
+        )}
+        <StatusItem wide>
+          <StatusName>Remains</StatusName>
+          <StatusValue>
+            {props.notesTotal - props.judgeCount.reduce((sum, j) => sum + j, 0)}
+          </StatusValue>
           {!props.isMobile && (
             <span className="w-12 pl-1 flex flex-row items-baseline">
               <span className="flex-1">/</span>
               <span>{props.notesTotal}</span>
             </span>
           )}
-        </p>
-        {props.isMobile && (
-          <span className="w-12 pl-1 self-end flex flex-row items-baseline">
+        </StatusItem>
+        {props.isMobile && screenWidth >= 35 * rem && (
+          <span className="flex-none w-12 pl-1 self-end translate-y-1 flex flex-row items-baseline">
             <span className="flex-1">/</span>
             <span>{props.notesTotal}</span>
           </span>
         )}
       </div>
     </Box>
+  );
+}
+
+function StatusItem(props: { wide?: boolean; children: ReactNode[] }) {
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  return (
+    <div
+      className={
+        isMobile
+          ? "flex-1 basis-1 flex flex-col mr-2"
+          : "flex flex-row items-baseline " + (props.wide ? "" : "mr-12")
+      }
+      style={{
+        fontSize: isMobile ? "0.8em" : undefined,
+        lineHeight: isMobile ? 1 : undefined,
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}
+function StatusName(props: { children: ReactNode }) {
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  return <span className={isMobile ? "h-3 " : "flex-1"}>{props.children}</span>;
+}
+function StatusValue(props: { children: ReactNode }) {
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  return (
+    <span
+      className="text-right mt-1"
+      style={{
+        fontSize: "2em",
+        lineHeight: 1,
+      }}
+    >
+      {props.children}
+    </span>
   );
 }

--- a/app/play/[cid]/statusBox.tsx
+++ b/app/play/[cid]/statusBox.tsx
@@ -7,6 +7,7 @@ import { ReactNode } from "react";
 
 interface Props {
   className?: string;
+  style?: object;
   judgeCount: number[];
   bigCount: number;
   bigTotal: number;
@@ -17,24 +18,18 @@ interface Props {
 export default function StatusBox(props: Props) {
   const { screenWidth, screenHeight, rem } = useDisplayMode();
   const isMobile = screenWidth < screenHeight;
-  let boxScale: number = 1;
   let textScale: number = 1;
   if (isMobile) {
     textScale = Math.min(screenWidth / (31 * rem), 1);
-  } else {
-    // 計算めんどくなって適当に数字入れてでっちあげしている
-    boxScale = Math.min(
-      (screenHeight - screenWidth * (1 / 3) * (2 / 3) - 7 * rem) / (17 * rem),
-      1
-    );
   }
 
   return (
     <Box
-      className={props.className + (isMobile ? "" : " origin-top-right")}
+      className={
+        props.className + " p-3 " + (isMobile ? "" : " origin-top-right")
+      }
       style={{
-        transform: boxScale < 1 ? `scale(${boxScale})` : undefined,
-        padding: (3 / 4) * rem * boxScale,
+        ...props.style,
         fontSize: textScale * rem,
       }}
     >

--- a/app/scale.tsx
+++ b/app/scale.tsx
@@ -9,22 +9,26 @@ import {
 } from "react";
 
 interface DisplayMode {
-  isMobile: boolean;
   isTouch: boolean;
-  scaledSize: { width: number; height: number };
+  screenWidth: number;
+  screenHeight: number;
+  rem: number;
 }
 const DisplayModeContext = createContext<DisplayMode>({
-  isMobile: false,
   isTouch: false,
-  scaledSize: { width: 1, height: 1 },
+  screenWidth: 1,
+  screenHeight: 1,
+  rem: 16,
 });
 export const useDisplayMode = () => useContext(DisplayModeContext);
 
 export function AutoScaler(props: { children: ReactNode }) {
-  const [size, setSize] = useState([0, 0]);
+  const [size, setSize] = useState([1, 1]);
+  const [rem, setRem] = useState<number>(16);
   useEffect(() => {
     function updateSize() {
       setSize([window.innerWidth, window.innerHeight]);
+      setRem(parseFloat(getComputedStyle(document.documentElement).fontSize));
     }
     window.addEventListener("resize", updateSize);
     updateSize();
@@ -32,38 +36,20 @@ export function AutoScaler(props: { children: ReactNode }) {
   }, []);
 
   const [width, height] = size;
-  // スクリーンが縦長かどうかで表示を切り替えている
-  const isMobile = width < height;
-  const globalScale = Math.min(height / 800, width / 500);
+
   // タッチ操作かどうか (操作説明が変わる)
   const isTouch = isTouchEventsEnabled();
-
-  const scaledWidth = width / globalScale;
-  const scaledHeight = height / globalScale;
 
   return (
     <DisplayModeContext.Provider
       value={{
-        isMobile,
         isTouch,
-        scaledSize: {
-          width: scaledWidth,
-          height: scaledHeight,
-        },
+        screenWidth: width,
+        screenHeight: height,
+        rem,
       }}
     >
-      <div
-        className="origin-top-left overflow-auto"
-        style={{
-          transform: `scale(${globalScale})`,
-          width: scaledWidth,
-          height: scaledHeight,
-        }}
-      >
-        <div className="bg-gradient-to-t from-sky-50 to-sky-200 min-w-full min-h-full">
-          {props.children}
-        </div>
-      </div>
+      {props.children}
     </DisplayModeContext.Provider>
   );
 }

--- a/app/share/[cid]/page.tsx
+++ b/app/share/[cid]/page.tsx
@@ -43,7 +43,8 @@ export default function ShareChart(context: { params: Params }) {
     })();
   }, [cid]);
 
-  const { scaledSize, isMobile } = useDisplayMode();
+  const { screenWidth, screenHeight, rem } = useDisplayMode();
+  const isMobile = screenWidth < 40 * rem;
 
   const ytPlayer = useRef<YouTubePlayer>();
 
@@ -54,22 +55,29 @@ export default function ShareChart(context: { params: Params }) {
   }
 
   return (
-    <main className="flex flex-col items-center" style={{ ...scaledSize }}>
-      <div className="flex-1 p-6 flex items-center justify-center">
+    <main className="flex flex-col items-center w-full min-h-screen h-max">
+      <div className={"flex-1 p-6 w-full flex items-center justify-center"}>
         <Box
-          className="m-auto flex flex-col p-6 shrink"
-          style={{ flexBasis: 800 }}
+          className="m-auto max-w-full flex flex-col p-6 shrink"
+          style={{ flexBasis: "60rem" }}
         >
           {isMobile && <BackButton href="/main/play">ID: {cid}</BackButton>}
-          <div className={isMobile ? "basis-3/12" : "flex flex-row-reverse "}>
+          <div className={isMobile ? "" : "flex flex-row-reverse items-center"}>
             <FlexYouTube
-              className={isMobile ? "my-2 " : "block basis-1/3 "}
+              fixedSide="width"
+              className={
+                isMobile
+                  ? "my-2 w-full"
+                  : screenWidth < 60 * rem
+                  ? "basis-1/3 "
+                  : "w-80 "
+              }
               isMobile={isMobile}
               id={brief?.ytId}
               control={true}
               ytPlayer={ytPlayer}
             />
-            <div className={isMobile ? "" : "basis-2/3"}>
+            <div className={isMobile ? "" : "flex-1 self-start"}>
               {!isMobile && (
                 <BackButton href="/main/play">ID: {cid}</BackButton>
               )}
@@ -84,13 +92,24 @@ export default function ShareChart(context: { params: Params }) {
             </div>
           </div>
           <p className="mt-2">
-            共有用リンク:
-            <Link
-              className="mx-2 text-blue-600 hover:underline"
-              href={`/share/${cid}`}
-            >
-              {origin}/share/{cid}
-            </Link>
+            {isMobile ? (
+              <Link
+                className="mx-2 text-blue-600 hover:underline"
+                href={`/share/${cid}`}
+              >
+                共有用リンク
+              </Link>
+            ) : (
+              <>
+                <span>共有用リンク:</span>
+                <Link
+                  className="mx-2 text-blue-600 hover:underline"
+                  href={`/share/${cid}`}
+                >
+                  {origin}/share/{cid}
+                </Link>
+              </>
+            )}
             {navigator.clipboard && (
               <Button
                 text="コピー"


### PR DESCRIPTION
* ブラウザのwidthにあわせてbody全体をscaleして一定のサイズにするというでっち上げ実装をやめてちゃんとレスポンシブな処理をした
* スマホ横表示 (横長で画面が小さい時) にstatusBoxの表示をするスペースがないのでresult時のみ表示するようにした
* Box の背景にblur追加したりした