### PR TITLE
メインページのテキストなどいろいろ修正

### DIFF
--- a/app/common/footer.tsx
+++ b/app/common/footer.tsx
@@ -34,18 +34,21 @@ export default function Footer(props: Props) {
           "footer-wide2:flex-row footer-wide2:items-baseline footer-wide2:space-x-3"
         }
       >
-        <Link
+        <a
           className={"relative w-max " + linkStyle2}
           href="https://github.com/na-trium-144/falling-nikochan"
+          target="_blank"
         >
           <Github className="absolute bottom-1 left-0" />
           <span className="ml-5">na-trium-144/falling-nikochan</span>
-        </Link>
-        <div className="hidden footer-wide:inline-block space-x-2">
-          <span>Build</span>
-          <span>{process.env.buildDate}</span>
-          <span>({process.env.buildCommit})</span>
-        </div>
+        </a>
+        <a
+          className={"hidden footer-wide:inline-block " + linkStyle2}
+          href="https://github.com/na-trium-144/falling-nikochan/commits/main/"
+          target="_blank"
+        >
+          Build {process.env.buildDate} ({process.env.buildCommit})
+        </a>
       </div>
     </footer>
   );

--- a/app/main/chartList.tsx
+++ b/app/main/chartList.tsx
@@ -19,6 +19,12 @@ export function ChartListItem(props: CProps) {
             {props.brief?.title}
           </span>
         </span>
+        {props.brief?.composer && (
+          <span className="hidden main-wide:inline-block ml-1 text-sm">
+            <span className="">/</span>
+            <span className="ml-1 font-title ">{props.brief.composer}</span>
+          </span>
+        )}
         {props.creator && (
           <span className="inline-block ml-2 text-sm">
             <span className="">by</span>

--- a/app/main/edit/page.tsx
+++ b/app/main/edit/page.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MetaEdit } from "@/edit/[cid]/metaTab";
-import Button, { buttonStyle } from "@/common/button";
+import { buttonStyle } from "@/common/button";
 import { useRouter } from "next/navigation";
-import msgpack from "@ygoe/msgpack";
 import Link from "next/link";
 import { getRecent, removeRecent } from "@/common/recent";
-import { Chart, ChartBrief, emptyChart, validCId } from "@/chartFormat/chart";
+import { ChartBrief, validCId } from "@/chartFormat/chart";
 import { IndexMain } from "../main";
-import { setPasswd } from "@/common/passwdCache";
 import Input from "@/common/input";
 import { ChartListItem } from "../chartList";
 import { rateLimitMin } from "@/api/dbRateLimit";
@@ -67,27 +64,9 @@ export default function EditTab() {
   const [uploadMsg, setUploadMsg] = useState<string>("");
   return (
     <IndexMain tab={2}>
-      <p className="mb-3 break-keep break-words">
-        Falling Nikochan の<wbr />
-        譜面
-        <wbr />
-        エディタに
-        <wbr />
-        ようこそ。
-        <wbr />
-        アカウント
-        <wbr />
-        登録
-        <wbr />
-        不要で
-        <wbr />
-        誰でも
-        <wbr />
-        譜面を
-        <wbr />
-        作成する
-        <wbr />
-        ことができます。
+      <p className="mb-3 text-justify">
+        Falling Nikochan の譜面エディタにようこそ。
+        アカウント登録不要で誰でも譜面を作成することができます。
       </p>
       <div className="mb-3">
         <h3 className="mb-2">
@@ -101,36 +80,9 @@ export default function EditTab() {
           />
           <span className="ml-1 inline-block">{cidErrorMsg}</span>
         </h3>
-        <p className="pl-2 break-keep break-words">
-          編集したい
-          <wbr />
-          譜面の
-          <wbr />
-          IDを
-          <wbr />
-          知って
-          <wbr />
-          いる
-          <wbr />
-          場合は
-          <wbr />
-          こちらに
-          <wbr />
-          入力して
-          <wbr />
-          ください。
-          <wbr />
-          ID
-          <wbr />
-          入力後、
-          <wbr />
-          編集用
-          <wbr />
-          パスワード
-          <wbr />も<wbr />
-          必要に
-          <wbr />
-          なります。
+        <p className="pl-2 text-justify">
+          編集したい譜面の ID を知っている場合はこちらに入力してください。 ID
+          入力後、編集用パスワードも必要になります。
         </p>
       </div>
       <div className="mb-3">
@@ -164,35 +116,10 @@ export default function EditTab() {
             新規作成
           </Link>
         </h3>
-        <p className="pl-2">
-          新しく
-          <wbr />
-          サーバーに
-          <wbr />
-          譜面を
-          <wbr />
-          保存
-          <wbr />
-          するのは {rateLimitMin} 分<wbr />
-          ごとに
-          <wbr />
-          1回
-          <wbr />
-          までに
-          <wbr />
-          制限して
-          <wbr />
-          います。 (1度
-          <wbr />
-          保存した
-          <wbr />
-          譜面の
-          <wbr />
-          上書きは
-          <wbr />
-          何回でも
-          <wbr />
-          できます。)
+        <p className="pl-2 text-justify">
+          新しくサーバーに譜面を保存するのは{rateLimitMin}
+          分ごとに1回までに制限しています。
+          (1度保存した譜面の上書きは何回でもできます。)
         </p>
       </div>
     </IndexMain>

--- a/app/main/main.tsx
+++ b/app/main/main.tsx
@@ -4,7 +4,6 @@ import Header from "@/common/header";
 import { Box } from "@/common/box";
 import Footer from "@/common/footer";
 import { useDisplayMode } from "@/scale";
-import Link from "next/link";
 import { ReactNode, useState } from "react";
 import { tabTitles, tabURLs } from "./const";
 import { useRouter } from "next/navigation";

--- a/app/main/play/page.tsx
+++ b/app/main/play/page.tsx
@@ -4,13 +4,36 @@ import { useEffect, useState } from "react";
 import { ChartBrief, validCId } from "@/chartFormat/chart";
 import { useRouter } from "next/navigation";
 import { getRecent, removeRecent } from "@/common/recent";
-import Link from "next/link";
 import Input from "@/common/input";
 import { IndexMain } from "../main";
 import { ChartListItem } from "../chartList";
 import { LoadingSlime } from "@/common/loadingSlime";
 
 const sampleCId = ["596134", "592994", "488006"];
+
+function InputIdDesc() {
+  const [hostname, setHostname] = useState("");
+  useEffect(() => setHostname(window.location.host), []);
+
+  return (
+    <>
+      <p className="pl-2 text-justify">
+        プレイしたい譜面の ID を知っている場合はこちらに入力してください。
+      </p>
+      <p className="pl-2 text-justify">
+        ※譜面のURL (
+        <span className="text-sm">
+          {hostname}&#47;
+          <wbr />
+          share
+          <wbr />
+          &#47;〜
+        </span>
+        ) にアクセスすることでもプレイできます。
+      </p>
+    </>
+  );
+}
 
 export default function PlayTab() {
   const [recentCId, setRecentCId] = useState<string[]>([]);
@@ -106,8 +129,10 @@ export default function PlayTab() {
       </div>
       <div className="mb-3">
         <h3 className="text-xl font-bold font-title mb-2">サンプル譜面</h3>
-        <p className="pl-2 mb-1">
-          Falling Nikochan の作者 (natrium144) が作った譜面です。
+        <p className="pl-2 mb-1 text-justify ">
+          Falling Nikochan の作者
+          <span className="text-sm mx-0.5">(na-trium-144)</span>
+          が作った譜面です。
           初めての方はこちらからどうぞ。
         </p>
         {fetching > 0 ? (
@@ -131,54 +156,5 @@ export default function PlayTab() {
         )}
       </div>
     </IndexMain>
-  );
-}
-
-function InputIdDesc() {
-  const [hostname, setHostname] = useState("");
-  useEffect(() => setHostname(window.location.host), []);
-
-  return (
-    <>
-      <p className="pl-2 break-keep break-words">
-        プレイしたい
-        <wbr />
-        譜面の
-        <wbr />
-        IDを
-        <wbr />
-        知って
-        <wbr />
-        いる
-        <wbr />
-        場合は
-        <wbr />
-        こちらに
-        <wbr />
-        入力して
-        <wbr />
-        ください。
-      </p>
-      <p className="pl-2 break-keep break-words">
-        ※譜面のURL (
-        <span className="text-sm">
-          {hostname}&#47;
-          <wbr />
-          share
-          <wbr />
-          &#47;〜
-        </span>
-        ) に<wbr />
-        アクセス
-        <wbr />
-        する
-        <wbr />
-        ことでも
-        <wbr />
-        プレイ
-        <wbr />
-        できます。
-      </p>
-    </>
   );
 }

--- a/app/main/policies/page.tsx
+++ b/app/main/policies/page.tsx
@@ -1,7 +1,6 @@
 import { metaDataTitle } from "@/common/title";
 import { tabTitles } from "../const";
 import { IndexMain } from "../main";
-import Link from "next/link";
 import { ReactNode } from "react";
 import { linkStyle2 } from "@/common/linkStyle";
 
@@ -15,7 +14,7 @@ interface PProps {
 }
 function Paragraph(props: PProps) {
   return (
-    <div className="mb-3">
+    <div className="mb-3 text-justify">
       <h3 className="text-xl font-bold font-title mb-2">{props.header}</h3>
       <ul className="pl-2 list-inside list-disc">{props.children}</ul>
     </div>
@@ -27,23 +26,25 @@ export default function PolicyTab() {
       <Paragraph header="ソフトウェアとして">
         <li>
           Falling Nikochan はオープンソースのソフトウェアであり、
-          <Link
+          <a
             className={"mx-1 text-blue-800 " + linkStyle2}
             href="https://github.com/na-trium-144/falling-nikochan"
+            target="_blank"
           >
             GitHub 上に
-          </Link>
+          </a>
           ソースコードを公開しています。
         </li>
         <li>
           MIT License で公開しており、複製、改変、再配布などをしても構いません。
           ライセンス本文は
-          <Link
+          <a
             className={"mx-1 text-blue-800 " + linkStyle2}
             href="https://github.com/na-trium-144/falling-nikochan/blob/main/LICENSE"
+            target="_blank"
           >
             こちら
-          </Link>
+          </a>
           を参照してください。
         </li>
         <li>
@@ -54,10 +55,22 @@ export default function PolicyTab() {
       </Paragraph>
       <Paragraph header="サービスとして">
         <li>
-          以下の規約は、作者が管理しているドメイン (nikochan.natrium144.org)
+          以下の規約は、作者が管理しているドメイン
+          <span className="text-sm mx-1">
+            (nikochan.
+            <wbr />
+            natrium
+            <wbr />
+            144.
+            <wbr />
+            org)
+          </span>
           で提供される Falling Nikochan のサービス (以下、本サービス)
-          を利用する利用者とサービス提供者 (= Falling Nikochan の作者,
-          na-trium-144) の間の関係に適用されます。
+          を利用する利用者とサービス提供者
+          <span className="text-sm mx-1">
+            (= Falling Nikochan の作者, na-trium-144)
+          </span>
+          の間の関係に適用されます。
         </li>
         <li>
           第三者がこれ以外のドメインで Falling Nikochan


### PR DESCRIPTION
* aboutページ以外の文章を wbr/ での改行をやめて両端揃え表示
* PC表示のとき曲名の横に作曲者表示
* GitHubへのリンクを新しいタブで開くように
* フッターのbuild表示をcommit履歴へのリンクに
* domainなど一部のテキストを小さくした
