### PR TITLE
譜面編集画面を開く挙動を修正

### DIFF
--- a/app/api/chartFile/[cid]/route.ts
+++ b/app/api/chartFile/[cid]/route.ts
@@ -47,6 +47,9 @@ async function getChart(
     };
   }
 
+  if (process.env.NODE_ENV === "development" && p === "bypass") {
+    return { chart };
+  }
   if (p !== (await hashPasswd(chart.editPasswd))) {
     return { res: new Response(null, { status: 401 }) };
   }

--- a/app/common/checkBox.tsx
+++ b/app/common/checkBox.tsx
@@ -13,7 +13,7 @@ export default function CheckBox(props: Props) {
       className={
         "ml-2 " +
         "hover:text-slate-500 disabled:text-slate-400 " +
-        "hover:dark:text-stone-400 disabled:text-stone-700 " +
+        "hover:dark:text-stone-400 disabled:dark:text-stone-700 " +
         props.className
       }
       onClick={() => props.onChange(!props.value)}

--- a/app/common/input.tsx
+++ b/app/common/input.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 
 // actualvalue: 実際の値 (フォーカスが外れたらこの値に戻る)
 // updatevalue: 値を更新 isValidがtrueの場合にのみ呼ばれる
+// updateinvalidvalue: isValidがfalseだった場合呼ばれる
 // isvalid: 値が有効かチェックする関数
 interface Props {
   actualValue: string;
   updateValue: (v: string) => void;
+  updateInvalidValue?: (v: string) => void;
   isValid?: (v: string) => boolean;
   left?: boolean;
   right?: boolean;
@@ -42,6 +44,8 @@ export default function Input(props: Props) {
         setValue(e.target.value);
         if (!props.isValid || props.isValid(e.target.value)) {
           props.updateValue(e.target.value);
+        } else if (props.updateInvalidValue) {
+          props.updateInvalidValue(e.target.value);
         }
       }}
       onFocus={() => setFocus(true)}

--- a/app/edit/[cid]/metaTab.tsx
+++ b/app/edit/[cid]/metaTab.tsx
@@ -135,11 +135,15 @@ export function MetaTab(props: Props2) {
           const resBody = await res.json();
           if (typeof resBody.cid === "string") {
             props.setCid(resBody.cid);
-            setPasswd(resBody.cid, await hashPasswd(props.chart!.editPasswd));
             history.replaceState(null, "", `/edit/${resBody.cid}`);
             setErrorMsg("保存しました！");
             addRecent("edit", resBody.cid);
             props.setHasChange(false);
+            try {
+              setPasswd(resBody.cid, await hashPasswd(props.chart!.editPasswd));
+            } catch (e) {
+              setErrorMsg(String(e));
+            }
           } else {
             setErrorMsg("Invalid response");
           }
@@ -167,7 +171,11 @@ export function MetaTab(props: Props2) {
         props.setHasChange(false);
         setErrorMsg("保存しました！");
         // 次からは新しいパスワードが必要
-        setPasswd(props.cid, await hashPasswd(props.chart!.editPasswd));
+        try {
+          setPasswd(props.cid, await hashPasswd(props.chart!.editPasswd));
+        } catch (e) {
+          setErrorMsg("保存しました！ (パスワードの保存は失敗)");
+        }
       } else {
         try {
           const resBody = await res.json();

--- a/app/edit/[cid]/page.tsx
+++ b/app/edit/[cid]/page.tsx
@@ -108,7 +108,11 @@ export default function Page(context: { params: Promise<Params> }) {
         try {
           const chart = msgpack.deserialize(await res.arrayBuffer());
           // validateはサーバー側でやってる
-          setPasswd(cidInitial.current, await hashPasswd(chart.editPasswd));
+          try {
+            setPasswd(cidInitial.current, await hashPasswd(chart.editPasswd));
+          } catch (e) {
+            // ignore hash error on iOS development mode
+          }
           setChart(chart);
           setErrorStatus(undefined);
           setErrorMsg(undefined);
@@ -647,6 +651,21 @@ export default function Page(context: { params: Promise<Params> }) {
             })();
           }}
         />
+        {process.env.NODE_ENV === "development" && (
+          <p className="mt-2 ">
+            <button
+              className={linkStyle1 + "w-max m-auto "}
+              onClick={() => {
+                void (async () => {
+                  setPasswd(cidInitial.current || "", "bypass");
+                  await fetchChart(false);
+                })();
+              }}
+            >
+              パスワード入力をスキップ (dev環境限定)
+            </button>
+          </p>
+        )}
       </CenterBoxOnlyPage>
     );
   }

--- a/app/edit/[cid]/page.tsx
+++ b/app/edit/[cid]/page.tsx
@@ -87,7 +87,7 @@ export default function Page(context: { params: Promise<Params> }) {
   const [errorStatus, setErrorStatus] = useState<number>();
   const [errorMsg, setErrorMsg] = useState<string>();
 
-  const fetchChart = useCallback(async () => {
+  const fetchChart = useCallback(async (isFirst: boolean) => {
     if (cidInitial.current === "new") {
       setChart(emptyChart());
       setPasswdFailed(false);
@@ -120,7 +120,9 @@ export default function Page(context: { params: Promise<Params> }) {
         }
       } else {
         if (res.status === 401) {
-          setPasswdFailed(true);
+          if (!isFirst) {
+            setPasswdFailed(true);
+          }
           setChart(undefined);
         } else {
           setChart(undefined);
@@ -134,7 +136,7 @@ export default function Page(context: { params: Promise<Params> }) {
       }
     }
   }, []);
-  useEffect(() => void fetchChart(), [fetchChart]);
+  useEffect(() => void fetchChart(true), [fetchChart]);
 
   const [currentLevelIndex, setCurrentLevelIndex] = useState<number>(0);
   const currentLevel = chart?.levels.at(currentLevelIndex);
@@ -641,7 +643,7 @@ export default function Page(context: { params: Promise<Params> }) {
           onClick={() => {
             void (async () => {
               setPasswd(cidInitial.current || "", await hashPasswd(editPasswd));
-              await fetchChart();
+              await fetchChart(false);
             })();
           }}
         />

--- a/app/edit/[cid]/timeBar.tsx
+++ b/app/edit/[cid]/timeBar.tsx
@@ -294,12 +294,12 @@ export default function TimeBar(props: Props) {
                 >
                   <span className="absolute bottom-0">
                     {len.map((len, i) => (
-                      <>
+                      <span key={i}>
                         {i >= 1 && <span className="mx-0.5">+</span>}
                         <span>{stepImproper(len)}</span>
                         <span>/</span>
                         <span>{len.denominator * 4}</span>
-                      </>
+                      </span>
                     ))}
                   </span>
                 </span>

--- a/app/main/edit/page.tsx
+++ b/app/main/edit/page.tsx
@@ -65,20 +65,24 @@ export default function EditTab() {
 
   const [cidErrorMsg, setCIdErrorMsg] = useState<string>("");
   const [cidFetching, setCidFetching] = useState<boolean>(false);
+  const [inputCId, setInputCId] = useState<string>("");
   const gotoCId = async (cid: string) => {
     setCIdErrorMsg("");
     setCidFetching(true);
     const res = await fetch(`/api/brief/${cid}`, { cache: "no-store" });
+    setCidFetching(false);
     if (res.ok) {
       // router.push(`/edit/${cid}`);
-      window.open(`/edit/${cid}`, "_blank")?.focus();
+      window.open(`/edit/${cid}`, "_blank")?.focus(); // これで新しいタブが開かない場合がある
+      setCIdErrorMsg("");
+      setInputCId(cid);
     } else {
-      setCidFetching(false);
       try {
         setCIdErrorMsg((await res.json()).message);
       } catch {
         setCIdErrorMsg("");
       }
+      setInputCId("");
     }
   };
 
@@ -93,11 +97,18 @@ export default function EditTab() {
           <span className="text-xl font-bold font-title ">譜面IDを入力:</span>
           <Input
             className="ml-4 w-20"
-            actualValue=""
+            actualValue={inputCId}
             updateValue={gotoCId}
+            updateInvalidValue={() => setInputCId("")}
             isValid={validCId}
             left
           />
+          <ExternalLink
+            className={"ml-1 " + (inputCId !== "" ? "" : "hidden ")}
+            href={`/edit/${inputCId}`}
+          >
+            新しいタブで開く
+          </ExternalLink>
           <span className={cidFetching ? "inline-block " : "hidden "}>
             <LoadingSlime />
             Loading...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falling-nikochan",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falling-nikochan",
-      "version": "5.23.0",
+      "version": "5.24.0",
       "dependencies": {
         "@icon-park/react": "^1.4.2",
         "@prisma/client": "^5.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falling-nikochan",
-  "version": "5.23.0",
+  "version": "5.24.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- iOSでID入力して譜面編集画面が開かないので、ID入力後に開くボタンが表示されるようにした
- 編集画面を開いて最初は「パスワードが間違っています」を表示しないようにした
- dev環境でのみパスワードのチェックをスキップするようにした (iOSがhttpでcryptoを使えないので)
- lightテーマのチェックボックスの色を修正
