### PR TITLE
mainpageでbriefをfetchしている間の表示を改善

### DIFF
--- a/app/common/recent.ts
+++ b/app/common/recent.ts
@@ -20,6 +20,9 @@ export function addRecent(key: string, cid: string) {
   newRecent.push(cid);
   localStorage.setItem(recentKey(key), JSON.stringify(newRecent));
 }
+export function updateRecent(key: string, cids: string[]){
+  localStorage.setItem(recentKey(key), JSON.stringify(cids));
+}
 export function removeRecent(key: string, cid: string) {
   const recent = getRecent(key);
   if (recent.indexOf(cid) >= 0) {

--- a/app/main/play/clientPage.tsx
+++ b/app/main/play/clientPage.tsx
@@ -21,7 +21,6 @@ export interface ChartLineBrief {
 
 export async function fetchBrief(cid: string): Promise<ChartLineBrief | null> {
   const res = await fetch(`/api/brief/${cid}`, { cache: "default" }); // todo: /api/brief からのレスポンスにmax-ageがないので意味ない?
-  await new Promise((resolve) => setTimeout(resolve, 1000));
   if (res.ok) {
     // cidからタイトルなどを取得
     const resBody = await res.json();

--- a/app/main/play/clientPage.tsx
+++ b/app/main/play/clientPage.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ChartBrief, validCId } from "@/chartFormat/chart";
 import { useRouter } from "next/navigation";
-import { getRecent, removeRecent } from "@/common/recent";
+import { getRecent, removeRecent, updateRecent } from "@/common/recent";
 import Input from "@/common/input";
 import { IndexMain } from "../main";
 import { ChartList, ChartListItem } from "../chartList";
@@ -12,70 +12,97 @@ import { Youtube } from "@icon-park/react";
 import { ExternalLink } from "@/common/extLink";
 import { numLatest } from "@/api/latest/const";
 
+export const chartListMaxRow = 5;
+export interface ChartLineBrief {
+  cid: string;
+  fetched: boolean;
+  brief?: ChartBrief;
+}
+
+export async function fetchBrief(cid: string): Promise<ChartLineBrief | null> {
+  const res = await fetch(`/api/brief/${cid}`, { cache: "default" }); // todo: /api/brief からのレスポンスにmax-ageがないので意味ない?
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (res.ok) {
+    // cidからタイトルなどを取得
+    const resBody = await res.json();
+    return { cid, fetched: true, brief: resBody as ChartBrief };
+  } else if (res.status === 404) {
+    return null;
+  } else {
+    return { cid, fetched: true };
+  }
+}
+export async function fetchAndFilterBriefs(
+  recentBrief: ChartLineBrief[],
+  fetchAll: boolean
+): Promise<{ changed: boolean; briefs: ChartLineBrief[] }> {
+  let changed = false;
+  const recentBriefNew: (ChartLineBrief | null)[] = recentBrief.slice();
+  await Promise.all(
+    recentBrief.map(async ({ cid, fetched, brief }, i) => {
+      if (fetched) {
+        return;
+      } else if (!fetchAll && i >= chartListMaxRow) {
+        return;
+      } else {
+        const brief = await fetchBrief(cid);
+        recentBriefNew[i] = brief;
+        changed = true;
+      }
+    })
+  );
+  return {
+    changed,
+    briefs: recentBriefNew.filter((brief) => brief !== null),
+  };
+}
+
 export default function PlayTab(props: {
   sampleBrief: { cid: string; brief: ChartBrief | undefined }[];
   originalBrief: { cid: string; brief: ChartBrief | undefined }[];
 }) {
-  const [recentCIdAdditional, setRecentCIdAdditional] = useState<string[]>([]);
-  const [recentBrief, setRecentBrief] =
-    useState<{ cid?: string; brief?: ChartBrief }[]>();
-  const [recentBriefAdditional, setRecentBriefAdditional] =
-    useState<{ cid?: string; brief?: ChartBrief }[]>();
-  const [latestCIdAdditional, setLatestCIdAdditional] = useState<string[]>([]);
-  const [latestBrief, setLatestBrief] =
-    useState<{ cid?: string; brief?: ChartBrief }[]>();
-  const [latestBriefAdditional, setLatestBriefAdditional] =
-    useState<{ cid?: string; brief?: ChartBrief }[]>();
+  const [recentBrief, setRecentBrief] = useState<ChartLineBrief[]>([]);
+  const [fetchRecentAll, setFetchRecentAll] = useState<boolean>(false);
+  const [latestBrief, setLatestBrief] = useState<ChartLineBrief[]>([]);
+  const [fetchLatestAll, setFetchLatestAll] = useState<boolean>(false);
   const router = useRouter();
 
-  const fetchBrief = useCallback(async (cid: string) => {
-    const res = await fetch(`/api/brief/${cid}`, { cache: "default" }); // todo: /api/brief からのレスポンスにmax-ageがないので意味ない?
-    if (res.ok) {
-      // cidからタイトルなどを取得
-      const resBody = await res.json();
-      return { cid, brief: resBody as ChartBrief };
-    } else if (res.status === 404) {
-      return {};
-    } else {
-      return { cid };
-    }
-  }, []);
   useEffect(() => {
-    const recentCIdAll = getRecent("play").reverse();
-    const recentCId = recentCIdAll.slice(0, 5);
-    const recentCIdAdditional = recentCIdAll.slice(5);
-    setRecentCIdAdditional(recentCIdAdditional);
+    const recentCId = getRecent("play").reverse();
+    setRecentBrief(recentCId.map((cid) => ({ cid, fetched: false })));
     void (async () => {
-      setRecentBrief(
-        await Promise.all(recentCId.map((cid) => fetchBrief(cid)))
-      );
-    })();
-    void (async () => {
-      const latestCIdAll = (await (
+      const latestCId = (await (
         await fetch(`/api/latest`, { cache: "default" })
       ).json()) as { cid: string }[];
-      const latestCId = latestCIdAll.slice(0, 5);
-      const latestCIdAdditional = latestCIdAll.slice(5);
-      setLatestCIdAdditional(latestCIdAdditional.map(({ cid }) => cid));
-      setLatestBrief(
-        await Promise.all(latestCId.map(({ cid }) => fetchBrief(cid)))
-      );
+      setLatestBrief(latestCId.map(({ cid }) => ({ cid, fetched: false })));
     })();
-  }, [fetchBrief]);
-  const fetchAdditional = () => {
+  }, []);
+  useEffect(() => {
     void (async () => {
-      setRecentBriefAdditional(
-        await Promise.all(recentCIdAdditional.map((cid) => fetchBrief(cid)))
+      const { changed, briefs } = await fetchAndFilterBriefs(
+        recentBrief,
+        fetchRecentAll
       );
+      if (changed) {
+        setRecentBrief(briefs);
+        updateRecent(
+          "play",
+          briefs.map(({ cid }) => cid)
+        );
+      }
     })();
-  };
-  const fetchLatestAdditional = () => {
+  }, [recentBrief, fetchRecentAll]);
+  useEffect(() => {
     void (async () => {
-      setLatestBriefAdditional(
-        await Promise.all(latestCIdAdditional.map((cid) => fetchBrief(cid)))
+      const { changed, briefs } = await fetchAndFilterBriefs(
+        latestBrief,
+        fetchLatestAll
       );
+      if (changed) {
+        setLatestBrief(briefs);
+      }
     })();
-  };
+  }, [latestBrief, fetchLatestAll]);
 
   const [cidErrorMsg, setCIdErrorMsg] = useState<string>("");
   const [cidFetching, setCidFetching] = useState<boolean>(false);
@@ -142,9 +169,8 @@ export default function PlayTab(props: {
         </h3>
         <ChartList
           recentBrief={recentBrief}
-          recentBriefAdditional={recentBriefAdditional}
-          hasRecentAdditional={recentCIdAdditional.length}
-          fetchAdditional={fetchAdditional}
+          maxRow={chartListMaxRow}
+          fetchAdditional={() => setFetchRecentAll(true)}
           creator
           href={(cid) => `/share/${cid}`}
         />
@@ -161,9 +187,8 @@ export default function PlayTab(props: {
         </p>
         <ChartList
           recentBrief={latestBrief}
-          recentBriefAdditional={latestBriefAdditional}
-          hasRecentAdditional={latestCIdAdditional.length}
-          fetchAdditional={fetchLatestAdditional}
+          maxRow={chartListMaxRow}
+          fetchAdditional={() => setFetchLatestAll(true)}
           creator
           href={(cid) => `/share/${cid}`}
         />

--- a/app/play/musicArea.tsx
+++ b/app/play/musicArea.tsx
@@ -21,6 +21,7 @@ export function MusicArea(props: Props) {
   const { rem } = useDisplayMode();
   const ytHalf = width && width / 2 < 200;
   const largeTitle = props.isMobile && height && height > 8 * rem;
+  console.log(largeTitle, height, rem)
 
   const [currentSec, setCurrentSec] = useState<number>(0);
   const levelLength =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falling-nikochan",
-  "version": "6.11.0",
+  "version": "6.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falling-nikochan",
-      "version": "6.11.0",
+      "version": "6.12.0",
       "dependencies": {
         "@icon-park/react": "^1.4.2",
         "@vercel/analytics": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falling-nikochan",
-  "version": "6.11.0",
+  "version": "6.12.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
briefをfetchしている間、UI上でbriefを表示する分のスペースを確保することで、fetch前と後で表示位置がずれないようにする
