### PR TITLE
passwdのhash送信方法を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ YouTube: [@nikochan144](http://www.youtube.com/@nikochan144)
     ```sh
     MONGODB_URI="mongodb://localhost:27017"
     BACKEND_PREFIX="http://localhost:8787"
+    NODE_ENV="development"
     ```
 * 依存パッケージのインストール
     ```sh

--- a/app/common/passwdCache.ts
+++ b/app/common/passwdCache.ts
@@ -1,5 +1,11 @@
-function passwdKey(cid: string) {
+function v6PasswdKey(cid: string) {
   return "pass-" + cid;
+}
+function passwdKey(cid: string) {
+  return "ph-" + cid;
+}
+export function getV6Passwd(cid: string): string {
+  return localStorage.getItem(v6PasswdKey(cid)) || "";
 }
 export function getPasswd(cid: string): string {
   return localStorage.getItem(passwdKey(cid)) || "";
@@ -7,4 +13,5 @@ export function getPasswd(cid: string): string {
 
 export function setPasswd(cid: string, pw: string) {
   localStorage.setItem(passwdKey(cid), pw);
+  localStorage.removeItem(v6PasswdKey(cid));
 }

--- a/app/common/passwdCache.ts
+++ b/app/common/passwdCache.ts
@@ -10,8 +10,17 @@ export function getV6Passwd(cid: string): string {
 export function getPasswd(cid: string): string {
   return localStorage.getItem(passwdKey(cid)) || "";
 }
+export function preferSavePasswd(): boolean {
+  return !!Number(localStorage.getItem("preferSavePasswd"));
+}
 
 export function setPasswd(cid: string, pw: string) {
   localStorage.setItem(passwdKey(cid), pw);
   localStorage.removeItem(v6PasswdKey(cid));
+  localStorage.setItem("preferSavePasswd", "1");
+}
+export function unsetPasswd(cid: string) {
+  localStorage.removeItem(passwdKey(cid));
+  localStorage.removeItem(v6PasswdKey(cid));
+  localStorage.setItem("preferSavePasswd", "0");
 }

--- a/app/edit/metaTab.tsx
+++ b/app/edit/metaTab.tsx
@@ -163,6 +163,8 @@ export function MetaTab(props: Props2) {
           method: "POST",
           body: msgpack.serialize(props.chart),
           cache: "no-store",
+          credentials:
+            process.env.NODE_ENV === "development" ? "include" : "same-origin",
         }
       );
       if (res.ok) {
@@ -179,7 +181,13 @@ export function MetaTab(props: Props2) {
             props.setHasChange(false);
             fetch(
               process.env.BACKEND_PREFIX +
-                `/api/hashPasswd/${resBody.cid}?pw=${props.chart!.editPasswd}`
+                `/api/hashPasswd/${resBody.cid}?pw=${props.chart!.editPasswd}`,
+              {
+                credentials:
+                  process.env.NODE_ENV === "development"
+                    ? "include"
+                    : "same-origin",
+              }
             ).then(async (res) => {
               setPasswd(resBody.cid!, await res.text());
             });
@@ -209,6 +217,8 @@ export function MetaTab(props: Props2) {
           method: "POST",
           body: msgpack.serialize(props.chart),
           cache: "no-store",
+          credentials:
+            process.env.NODE_ENV === "development" ? "include" : "same-origin",
         }
       );
       if (res.ok) {
@@ -217,7 +227,13 @@ export function MetaTab(props: Props2) {
         // 次からは新しいパスワードが必要
         fetch(
           process.env.BACKEND_PREFIX +
-            `/api/hashPasswd/${props.cid}?pw=${props.chart!.editPasswd}`
+            `/api/hashPasswd/${props.cid}?pw=${props.chart!.editPasswd}`,
+          {
+            credentials:
+              process.env.NODE_ENV === "development"
+                ? "include"
+                : "same-origin",
+          }
         ).then(async (res) => {
           setPasswd(props.cid!, await res.text());
         });

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -6,7 +6,7 @@ import {
   Signature,
 } from "@/../chartFormat/command.js";
 import { FlexYouTube, YouTubePlayer } from "@/common/youtube.js";
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import FallingWindow from "./fallingWindow.js";
 import {
   findBpmIndexFromStep,
@@ -62,28 +62,16 @@ import {
 import { useDisplayMode } from "@/scale.js";
 import { Forbid, Move } from "@icon-park/react";
 import { linkStyle1 } from "@/common/linkStyle.js";
-import { useTheme } from "@/common/theme.js";
-import { useSearchParams } from "next/navigation";
+import { ThemeContext, useTheme } from "@/common/theme.js";
 import { GuideMain } from "./guide/guideMain.js";
 import { levelBgColors } from "@/common/levelColors.js";
 
-export default function Home() {
-  return (
-    <Suspense fallback={<Loading />}>
-      <Page />
-    </Suspense>
-  );
-}
-
-function Page() {
-  const searchParams = useSearchParams();
-  // cid が "new" の場合空のchartで編集をはじめて、post時にcidが振られる
-  const cidInitial = useRef<string>(searchParams.get("cid") || "");
-  const [cid, setCid] = useState<string | undefined>(
-    searchParams.get("cid") || ""
-  );
-  const { isTouch } = useDisplayMode();
+export default function EditAuth() {
   const themeContext = useTheme();
+
+  // cid が "new" の場合空のchartで編集をはじめて、post時にcidが振られる
+  const cidInitial = useRef<string>("");
+  const [cid, setCid] = useState<string | undefined>("");
 
   // chartのgetやpostに必要なパスワード
   // post時には前のchartのパスワードを入力し、その後は新しいパスワードを使う
@@ -96,13 +84,12 @@ function Page() {
   const [errorMsg, setErrorMsg] = useState<string>();
 
   const fetchChart = useCallback(
-    async (isFirst: boolean, bypass: boolean) => {
+    async (isFirst: boolean, bypass: boolean, editPasswd: string) => {
       if (cidInitial.current === "new") {
         setChart(emptyChart());
         setPasswdFailed(false);
         setLoading(false);
         setCid(undefined);
-        setGuidePage(1);
       } else {
         setPasswdFailed(false);
         setLoading(true);
@@ -166,9 +153,81 @@ function Page() {
         }
       }
     },
-    [editPasswd]
+    []
   );
-  useEffect(() => void fetchChart(true, false), []);
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const params = new URLSearchParams(url.search);
+    if (params.has("cid")) {
+      cidInitial.current = params.get("cid")!;
+      setCid(cidInitial.current);
+    }
+    void fetchChart(true, false, "");
+  }, []);
+
+  if (chart === undefined) {
+    if (loading) {
+      return <Loading />;
+    }
+    if (errorStatus !== undefined || errorMsg !== undefined) {
+      return <Error status={errorStatus} message={errorMsg} />;
+    }
+    return (
+      <CenterBoxOnlyPage>
+        <Header reload>Edit</Header>
+        <p>編集用パスワードを入力してください。</p>
+        {passwdFailed && <p>パスワードが違います。</p>}
+        <Input
+          actualValue={editPasswd}
+          updateValue={setEditPasswd}
+          left
+          passwd
+        />
+        <Button
+          text="進む"
+          onClick={() => fetchChart(false, false, editPasswd)}
+        />
+        {process.env.NODE_ENV === "development" && (
+          <p className="mt-2 ">
+            <button
+              className={linkStyle1 + "w-max m-auto "}
+              onClick={() => {
+                void (async () => {
+                  await fetchChart(false, true, editPasswd);
+                })();
+              }}
+            >
+              パスワード入力をスキップ (dev環境限定)
+            </button>
+          </p>
+        )}
+      </CenterBoxOnlyPage>
+    );
+  } else {
+    return (
+      <Page
+        chart={chart}
+        setChart={setChart}
+        cid={cid}
+        setCid={setCid}
+        themeContext={themeContext}
+        guidePageInit={cidInitial.current === "new" ? 1 : null}
+      />
+    );
+  }
+}
+
+interface Props {
+  chart: Chart;
+  setChart: (chart: Chart) => void;
+  cid: string | undefined;
+  setCid: (cid: string | undefined) => void;
+  themeContext: ThemeContext;
+  guidePageInit: number | null;
+}
+function Page(props: Props) {
+  const { chart, setChart, cid, setCid, themeContext } = props;
+  const { isTouch } = useDisplayMode();
 
   const [currentLevelIndex, setCurrentLevelIndex] = useState<number>(0);
   const currentLevel = chart?.levels.at(currentLevelIndex);
@@ -426,7 +485,9 @@ function Page() {
   }, [chart, currentLevelIndex]);
 
   const [tab, setTab] = useState<number>(0);
-  const [guidePage, setGuidePage] = useState<number | null>(null);
+  const [guidePage, setGuidePage] = useState<number | null>(
+    props.guidePageInit
+  );
   const tabNames = ["Meta", "Timing", "Levels", "Notes", "Code"];
   const isCodeTab = tab === 4;
   const openGuide = () => setGuidePage([2, 4, 5, 6, 7][tab]);
@@ -648,43 +709,6 @@ function Page() {
     }
     ref.current.focus();
   };
-
-  if (chart === undefined) {
-    if (loading) {
-      return <Loading />;
-    }
-    if (errorStatus !== undefined || errorMsg !== undefined) {
-      return <Error status={errorStatus} message={errorMsg} />;
-    }
-    return (
-      <CenterBoxOnlyPage>
-        <Header reload>Edit</Header>
-        <p>編集用パスワードを入力してください。</p>
-        {passwdFailed && <p>パスワードが違います。</p>}
-        <Input
-          actualValue={editPasswd}
-          updateValue={setEditPasswd}
-          left
-          passwd
-        />
-        <Button text="進む" onClick={() => fetchChart(false, false)} />
-        {process.env.NODE_ENV === "development" && (
-          <p className="mt-2 ">
-            <button
-              className={linkStyle1 + "w-max m-auto "}
-              onClick={() => {
-                void (async () => {
-                  await fetchChart(false, true);
-                })();
-              }}
-            >
-              パスワード入力をスキップ (dev環境限定)
-            </button>
-          </p>
-        )}
-      </CenterBoxOnlyPage>
-    );
-  }
 
   return (
     <main

--- a/chartFormat/chart.ts
+++ b/chartFormat/chart.ts
@@ -154,9 +154,6 @@ export async function hash(text: string) {
     .join(""); // バイト列を 16 進文字列に変換する
   return hashHex;
 }
-export async function hashPasswd(text: string) {
-  return await hash(text);
-}
 export async function hashLevel(level: Level) {
   return await hash(
     JSON.stringify([

--- a/route/api/app.ts
+++ b/route/api/app.ts
@@ -6,6 +6,7 @@ import chartFileApp from "./chartFile.js";
 import latestApp from "./latest.js";
 import newChartFileApp from "./newChartFile.js";
 import seqFileApp from "./seqFile.js";
+import hashPasswdApp from "./hashPasswd.js";
 
 const apiApp = new Hono<{ Bindings: Bindings }>({ strict: false })
   .use("/*", cors())
@@ -13,6 +14,7 @@ const apiApp = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route("/chartFile", chartFileApp)
   .route("/newChartFile", newChartFileApp)
   .route("/seqFile", seqFileApp)
-  .route("/latest", latestApp);
+  .route("/latest", latestApp)
+  .route("/hashPasswd", hashPasswdApp);
 
 export default apiApp;

--- a/route/api/app.ts
+++ b/route/api/app.ts
@@ -9,7 +9,13 @@ import seqFileApp from "./seqFile.js";
 import hashPasswdApp from "./hashPasswd.js";
 
 const apiApp = new Hono<{ Bindings: Bindings }>({ strict: false })
-  .use("/*", cors())
+  .use(
+    "/*",
+    cors({
+      origin: process.env.NODE_ENV === "development" ? (origin) => origin : "*",
+      credentials: process.env.NODE_ENV === "development",
+    })
+  )
   .route("/brief", briefApp)
   .route("/chartFile", chartFileApp)
   .route("/newChartFile", newChartFileApp)

--- a/route/api/chart.ts
+++ b/route/api/chart.ts
@@ -56,17 +56,8 @@ export async function getChartEntry(
     entryCompressed.published = false;
   }
 
-  let entry: ChartEntry;
-  let chart: Chart;
-  try {
-    entry = await unzipEntry(entryCompressed);
-    chart = entryToChart(entry);
-    chart = await validateChart(chart);
-  } catch {
-    return {
-      res: { message: "invalid chart data", status: 500 },
-    };
-  }
+  const entry = await unzipEntry(entryCompressed);
+  let chart = entryToChart(entry);
 
   if (
     p === null ||
@@ -79,6 +70,13 @@ export async function getChartEntry(
       p.v7HashKey !== undefined &&
       p.v7PasswdHash === (await hashPasswd(cid, chart.editPasswd, p.v7HashKey)))
   ) {
+    try {
+      chart = await validateChart(chart);
+    } catch {
+      return {
+        res: { message: "invalid chart data", status: 500 },
+      };
+    }
     return { entry, chart };
   } else {
     return { res: { message: "bad password", status: 401 } };

--- a/route/api/chart.ts
+++ b/route/api/chart.ts
@@ -2,7 +2,7 @@ import {
   Chart,
   ChartBrief,
   createBrief,
-  hashPasswd,
+  hash,
   validateChart,
 } from "../../chartFormat/chart.js";
 import { gzip, gunzip } from "node:zlib";
@@ -15,13 +15,30 @@ import {
 } from "../../chartFormat/command.js";
 import { Binary, Db } from "mongodb";
 
+export function hashPasswd(
+  cid: string,
+  pw: string,
+  hashKey: string
+): Promise<string> {
+  return hash(cid + pw + hashKey);
+}
+
+interface Passwd {
+  bypass?: boolean;
+  v6PasswdHash?: string;
+  rawPasswd?: string;
+  v7PasswdHash?: string;
+  v7HashKey?: string;
+}
 /**
- * pをnullにするとパスワードのチェックを行わない。
+ * パスワードについては chartFile のコメントを参照
+ *
+ * パスワードが不要なアクセス (/api/brief など) ではpをnullにする
  */
 export async function getChartEntry(
   db: Db,
   cid: string,
-  p: string | null
+  p: Passwd | null
 ): Promise<{
   res?: { message: string; status: 401 | 404 | 500 };
   entry?: ChartEntry;
@@ -51,16 +68,21 @@ export async function getChartEntry(
     };
   }
 
-  if (p === null) {
+  if (
+    p === null ||
+    p.bypass ||
+    (p.rawPasswd !== undefined && p.rawPasswd === chart.editPasswd) ||
+    (p.v6PasswdHash !== undefined &&
+      chart.ver <= 6 &&
+      p.v6PasswdHash === (await hash(chart.editPasswd))) ||
+    (p.v7PasswdHash !== undefined &&
+      p.v7HashKey !== undefined &&
+      p.v7PasswdHash === (await hashPasswd(cid, chart.editPasswd, p.v7HashKey)))
+  ) {
     return { entry, chart };
-  }
-  if (process.env.NODE_ENV === "development" && p === "bypass") {
-    return { entry, chart };
-  }
-  if (p !== (await hashPasswd(chart.editPasswd))) {
+  } else {
     return { res: { message: "bad password", status: 401 } };
   }
-  return { entry, chart };
 }
 
 /**

--- a/route/api/chartFile.ts
+++ b/route/api/chartFile.ts
@@ -10,18 +10,40 @@ import { MongoClient } from "mongodb";
 import { chartToEntry, getChartEntry, zipEntry } from "./chart.js";
 import { Bindings } from "../env.js";
 import { env } from "hono/adapter";
+import { getCookie } from "hono/cookie";
 
-// 他のAPIと違って編集用パスワードのチェックが入る
-// クエリパラメータのpで渡す
+/**
+ *
+ * v6まで /api/chartFile/cid?p=(sha256 of passwd) の形式で、
+ * sha256をそのままlocalStorageに保存していたのでlocalStorageを読めばアクセスできてしまう状態だった
+ *
+ * v7以降は直接アクセスするための /api/chartFile/cid?pw=(base64 of passwd) と、
+ * localStorageに保存できるハッシュ済みのtokenを使った /api/chartFile/cid?ph=(sha256 of cid + passwd + cookie)
+ * の2つの方法を用意する
+ * cookieは /api/hashPasswd でランダムにセットされる
+ *
+ * また、development環境に限り /api/chartFile/cid?pbypass=1 でスキップできる
+ */
 const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
   .get("/:cid", async (c) => {
     const cid = c.req.param("cid");
-    const passwdHash = c.req.query("p");
+    const v6PasswdHash = c.req.query("p");
+    const rawPasswd = c.req.query("pw");
+    const v7PasswdHash = c.req.query("ph");
+    const v7HashKey = getCookie(c, "hashKey", "host");
+    const bypass =
+      c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const client = new MongoClient(env(c).MONGODB_URI);
     try {
       await client.connect();
       const db = client.db("nikochan");
-      let { res, chart } = await getChartEntry(db, cid, passwdHash || "");
+      let { res, chart } = await getChartEntry(db, cid, {
+        bypass,
+        v6PasswdHash,
+        rawPasswd,
+        v7PasswdHash,
+        v7HashKey,
+      });
       if (!chart) {
         return c.json({ message: res?.message }, res?.status || 500);
       }
@@ -40,17 +62,24 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
   })
   .post("/:cid", async (c) => {
     const cid = c.req.param("cid");
-    const passwdHash = c.req.query("p");
+    const v6PasswdHash = c.req.query("p");
+    const rawPasswd = c.req.query("pw");
+    const v7PasswdHash = c.req.query("ph");
+    const v7HashKey = getCookie(c, "hashKey", "host");
+    const bypass =
+      c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const chartBuf = await c.req.arrayBuffer();
     const client = new MongoClient(env(c).MONGODB_URI);
     try {
       await client.connect();
       const db = client.db("nikochan");
-      const { res, entry, chart } = await getChartEntry(
-        db,
-        cid,
-        passwdHash || ""
-      );
+      const { res, entry, chart } = await getChartEntry(db, cid, {
+        bypass,
+        v6PasswdHash,
+        rawPasswd,
+        v7PasswdHash,
+        v7HashKey,
+      });
       if (!chart || !entry) {
         return c.json({ message: res?.message }, res?.status || 500);
       }
@@ -107,12 +136,23 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
   })
   .delete("/:cid", async (c) => {
     const cid = c.req.param("cid");
-    const passwdHash = c.req.query("p");
+    const v6PasswdHash = c.req.query("p");
+    const rawPasswd = c.req.query("pw");
+    const v7PasswdHash = c.req.query("ph");
+    const v7HashKey = getCookie(c, "hashKey", "host");
+    const bypass =
+      c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const client = new MongoClient(env(c).MONGODB_URI);
     try {
       await client.connect();
       const db = client.db("nikochan");
-      const { res, chart } = await getChartEntry(db, cid, passwdHash || "");
+      const { res, chart } = await getChartEntry(db, cid, {
+        bypass,
+        v6PasswdHash,
+        rawPasswd,
+        v7PasswdHash,
+        v7HashKey,
+      });
       if (!chart) {
         return c.json({ message: res?.message }, res?.status || 500);
       }

--- a/route/api/chartFile.ts
+++ b/route/api/chartFile.ts
@@ -30,7 +30,12 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
     const v6PasswdHash = c.req.query("p");
     const rawPasswd = c.req.query("pw");
     const v7PasswdHash = c.req.query("ph");
-    const v7HashKey = getCookie(c, "hashKey", "host");
+    let v7HashKey: string;
+    if (env(c).NODE_ENV === "development") {
+      v7HashKey = getCookie(c, "hashKey") || "";
+    } else {
+      v7HashKey = getCookie(c, "hashKey", "host") || "";
+    }
     const bypass =
       c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const client = new MongoClient(env(c).MONGODB_URI);
@@ -65,7 +70,13 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
     const v6PasswdHash = c.req.query("p");
     const rawPasswd = c.req.query("pw");
     const v7PasswdHash = c.req.query("ph");
-    const v7HashKey = getCookie(c, "hashKey", "host");
+    let v7HashKey: string;
+    if (env(c).NODE_ENV === "development") {
+      v7HashKey = getCookie(c, "hashKey") || "";
+    } else {
+      v7HashKey = getCookie(c, "hashKey", "host") || "";
+    }
+    console.log(v7PasswdHash,v7HashKey);
     const bypass =
       c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const chartBuf = await c.req.arrayBuffer();
@@ -139,7 +150,12 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
     const v6PasswdHash = c.req.query("p");
     const rawPasswd = c.req.query("pw");
     const v7PasswdHash = c.req.query("ph");
-    const v7HashKey = getCookie(c, "hashKey", "host");
+    let v7HashKey: string;
+    if (env(c).NODE_ENV === "development") {
+      v7HashKey = getCookie(c, "hashKey") || "";
+    } else {
+      v7HashKey = getCookie(c, "hashKey", "host") || "";
+    }
     const bypass =
       c.req.query("pbypass") === "1" && env(c).NODE_ENV === "development";
     const client = new MongoClient(env(c).MONGODB_URI);

--- a/route/api/hashPasswd.ts
+++ b/route/api/hashPasswd.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono";
+import { Bindings } from "../env.js";
+import { env } from "hono/adapter";
+import { getCookie, setCookie } from "hono/cookie";
+import { hashPasswd } from "./chart.js";
+
+/**
+ * chartFile のコメントを参照
+ */
+const hashPasswdApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
+  "/:cid",
+  async (c) => {
+    const cid = c.req.param("cid");
+    const pw = c.req.query("pw") || "";
+    let key: string;
+    if (env(c).NODE_ENV === "development") {
+      // secure がつかない
+      key = getCookie(c, "hashKey") || Math.random().toString(36).substring(2);
+      setCookie(c, "hashKey", key, {
+        httpOnly: true,
+        maxAge: 400 * 24 * 3600,
+        path: "/",
+        sameSite: "Strict",
+      });
+    } else {
+      key =
+        getCookie(c, "hashKey", "host") ||
+        Math.random().toString(36).substring(2);
+      setCookie(c, "hashKey", key, {
+        httpOnly: true,
+        maxAge: 400 * 24 * 3600,
+        path: "/",
+        secure: true,
+        sameSite: "Strict",
+        prefix: "host",
+      });
+    }
+    return c.text(await hashPasswd(cid, pw, key), 200, {
+      "cache-control": "no-store",
+    });
+  }
+);
+
+export default hashPasswdApp;

--- a/route/api/hashPasswd.ts
+++ b/route/api/hashPasswd.ts
@@ -19,8 +19,6 @@ const hashPasswdApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       setCookie(c, "hashKey", key, {
         httpOnly: true,
         maxAge: 400 * 24 * 3600,
-        path: "/",
-        sameSite: "Strict",
       });
     } else {
       key =

--- a/route/api/newChartFile.ts
+++ b/route/api/newChartFile.ts
@@ -26,7 +26,7 @@ const newChartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
       const db = client.db("nikochan");
 
       if (
-        /*process.env.NODE_ENV !== "development" &&*/
+        env(c).NODE_ENV !== "development" &&
         !(await updateIpLastCreate(db, ip))
       ) {
         return c.json(

--- a/route/env.ts
+++ b/route/env.ts
@@ -1,3 +1,4 @@
 export interface Bindings {
   MONGODB_URI: string;
+  NODE_ENV: "development" | "production";
 }


### PR DESCRIPTION
fix #196 
暗号化にはしていないが、
* localStorageに保存されたhashだけではアクセスできないようにした(追加でsecure&httpOnlyのcookieがhashに含まれているものと合致していないといけない)
* hashにcidを加え、同じパスワードでも別の譜面に同じhashを使いまわせないようにした
* ver6以下の譜面データに限り、旧仕様のパスワードハッシュでもアクセス可能
  * localStorageに保存されている旧仕様のパスワードハッシュ(pass-cid)は次回アクセス時に削除され新しいパスワードハッシュ(ph-cid)に置き換えられる
* パスワードを保存するかどうかをユーザーが選択できるようにした
  * preferSavePasswd としてlocalStorageに保存される
