### PR TITLE
chart7: 音符の表示開始位置を上か下で選べるようにする

### DIFF
--- a/app/common/box.tsx
+++ b/app/common/box.tsx
@@ -46,7 +46,7 @@ export function CenterBoxOnlyPage(props: {
   );
 }
 
-export function Error(props: { status?: number | string; message?: string }) {
+export function ErrorPage(props: { status?: number | string; message?: string }) {
   return (
     <CenterBoxOnlyPage>
       <p>
@@ -57,7 +57,7 @@ export function Error(props: { status?: number | string; message?: string }) {
   );
 }
 export function NotFound() {
-  return <Error status={404} message={"Not Found"} />;
+  return <ErrorPage status={404} message={"Not Found"} />;
 }
 
 export function Loading() {

--- a/app/common/select.tsx
+++ b/app/common/select.tsx
@@ -1,19 +1,21 @@
 import { Down } from "@icon-park/react";
-import { buttonStyle } from "./button.js";
+import { buttonStyle, buttonStyleDisabled } from "./button.js";
 
 interface Props {
   options: string[];
   values: string[];
   value: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }
 export default function Select(props: Props) {
   return (
     <span className="inline-block relative">
       <select
-        className={buttonStyle + "pr-6"}
+        className={(props.disabled ? buttonStyleDisabled : buttonStyle) + "pr-6"}
         value={props.value}
         onChange={(e) => props.onChange(e.target.value)}
+        disabled={props.disabled}
       >
         {props.options.map((option, i) => {
           return (

--- a/app/edit/guide/6-noteTab.tsx
+++ b/app/edit/guide/6-noteTab.tsx
@@ -26,6 +26,10 @@ export function GuideContent6() {
       </li>
       <li>Big にチェックを入れると大きい音符になります。</li>
       <li>
+        出現位置を「上から」にすると音符は画面上側から降ってくるのみになり、
+        「下から」にすると画面下側から投げ上げるような形になります。
+      </li>
+      <li>
         左に表示されている音符のプレビューからマウス操作で音符の位置や速度を変更することもできます。
         現在のカーソル位置に音符がある状態でプレビュー画面内をドラッグすると音符の位置が動き、
         <Key className="text-sm p-0.5 mx-0.5">Shift</Key>
@@ -33,9 +37,10 @@ export function GuideContent6() {
         <br />
         タッチ操作の場合は
         <span className="inline-block w-5 translate-y-0.5 ">
-          <Move  />
+          <Move />
         </span>
-        Touch ボタンを押すと音符の位置/速度をタッチ操作で動かせるモードに切り替えることができます。
+        Touch
+        ボタンを押すと音符の位置/速度をタッチ操作で動かせるモードに切り替えることができます。
       </li>
       <li>
         下にある Copy, Paste, 1 〜 9

--- a/app/edit/guide/7-codeTab.tsx
+++ b/app/edit/guide/7-codeTab.tsx
@@ -37,8 +37,8 @@ export function GuideContent7() {
       </li>
       <li>Falling Nikochan 特有のコマンドは以下の通りです。</li>
       <li className="ml-6">
-        <Code>Note(x, vx, vy, big)</Code>: 音符を置きます。 x, vx, vy は数値、
-        big は<Code>true</Code>または<Code>false</Code>
+        <Code>Note(x, vx, vy, big, fall)</Code>: 音符を置きます。 x, vx, vy は数値、
+        big, fall は<Code>true</Code>または<Code>false</Code>
         を指定してください。
       </li>
       <li className="ml-6">

--- a/app/edit/metaTab.tsx
+++ b/app/edit/metaTab.tsx
@@ -264,7 +264,6 @@ export function MetaTab(props: Props2) {
         }
         newChart = await validateChart(content);
       } catch (e) {
-        console.error(e);
         console.warn("fallback to msgpack deserialize");
         try {
           const content = msgpack.deserialize(buffer);

--- a/app/edit/noteTab.tsx
+++ b/app/edit/noteTab.tsx
@@ -7,6 +7,7 @@ import { Key } from "@/common/key.js";
 import { Mouse } from "@icon-park/react";
 import CheckBox from "@/common/checkBox.js";
 import { getSignatureState } from "@/../chartFormat/seq.js";
+import Select from "@/common/select";
 
 interface Props {
   currentNoteIndex: number;
@@ -257,6 +258,16 @@ function NoteEdit(props: Props) {
             <span>Big</span>
             <Key className="text-xs p-0.5 ml-1 ">B</Key>
           </CheckBox>
+        </p>
+        <p>
+          <span>出現位置:</span>
+          <Select
+            value={n.fall ? "1" : "0"}
+            values={["0", "1"]}
+            options={["下から", "上から"]}
+            onChange={(v) => props.updateNote({ ...n, fall: !!Number(v) })}
+            disabled={!noteEditable}
+          />
         </p>
         {props.currentLevel?.notes[props.currentNoteIndex] && !noteEditable && (
           <p className="ml-2 mt-4 text-sm">

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -17,7 +17,7 @@ import TimeBar from "./timeBar.js";
 import Input from "@/common/input.js";
 import TimingTab from "./timingTab.js";
 import NoteTab from "./noteTab.js";
-import { Box, CenterBoxOnlyPage, Error, Loading } from "@/common/box.js";
+import { Box, CenterBoxOnlyPage, ErrorPage, Loading } from "@/common/box.js";
 import { MetaTab } from "./metaTab.js";
 import msgpack from "@ygoe/msgpack";
 import { addRecent } from "@/common/recent.js";
@@ -641,7 +641,7 @@ function Page() {
       return <Loading />;
     }
     if (errorStatus !== undefined || errorMsg !== undefined) {
-      return <Error status={errorStatus} message={errorMsg} />;
+      return <ErrorPage status={errorStatus} message={errorMsg} />;
     }
     return (
       <CenterBoxOnlyPage>

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  defaultNoteCommand,
-  NoteCommand,
-  Signature,
-} from "@/../chartFormat/command.js";
+import { defaultNoteCommand, NoteCommand } from "@/../chartFormat/command.js";
 import { FlexYouTube, YouTubePlayer } from "@/common/youtube.js";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import FallingWindow from "./fallingWindow.js";
@@ -67,6 +63,7 @@ import { useTheme } from "@/common/theme.js";
 import { useSearchParams } from "next/navigation";
 import { GuideMain } from "./guide/guideMain.js";
 import { levelBgColors } from "@/common/levelColors.js";
+import { Signature } from "../../chartFormat/signature.js";
 
 export default function Home() {
   return (

--- a/app/edit/page.tsx
+++ b/app/edit/page.tsx
@@ -28,6 +28,7 @@ import {
   hashPasswd,
   Level,
   levelTypes,
+  validateChart,
 } from "@/../chartFormat/chart.js";
 import { Step, stepAdd, stepCmp, stepZero } from "@/../chartFormat/step.js";
 import Header from "@/common/header.js";
@@ -64,6 +65,9 @@ import { useSearchParams } from "next/navigation";
 import { GuideMain } from "./guide/guideMain.js";
 import { levelBgColors } from "@/common/levelColors.js";
 import { Signature } from "../../chartFormat/signature.js";
+import { Chart5 } from "../../chartFormat/legacy/chart5.js";
+import { Chart6 } from "../../chartFormat/legacy/chart6.js";
+import { Chart7 } from "../../chartFormat/legacy/chart7.js";
 
 export default function Home() {
   return (
@@ -92,6 +96,7 @@ function Page() {
   const [chart, setChart] = useState<Chart>();
   const [errorStatus, setErrorStatus] = useState<number>();
   const [errorMsg, setErrorMsg] = useState<string>();
+  const [convertedFrom, setConvertedFrom] = useState<number>(7);
 
   const fetchChart = useCallback(async (isFirst: boolean) => {
     if (cidInitial.current === "new") {
@@ -113,8 +118,9 @@ function Page() {
       setLoading(false);
       if (res.ok) {
         try {
-          const chart = msgpack.deserialize(await res.arrayBuffer());
-          // validateはサーバー側でやってる
+          const chartRes: Chart5 | Chart6 | Chart7 = msgpack.deserialize(await res.arrayBuffer());
+          setConvertedFrom(chartRes.ver);
+          const chart: Chart = await validateChart(chartRes);
           try {
             setPasswd(cidInitial.current, await hashPasswd(chart.editPasswd));
           } catch {
@@ -986,6 +992,8 @@ function Page() {
                 fileSize={fileSize}
                 chart={chart}
                 setChart={changeChart}
+                convertedFrom={convertedFrom}
+                setConvertedFrom={setConvertedFrom}
                 cid={cid}
                 setCid={(newCid: string) => setCid(newCid)}
                 hasChange={hasChange}

--- a/app/edit/timeBar.tsx
+++ b/app/edit/timeBar.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/../chartFormat/step.js";
 import { Chart, Level } from "@/../chartFormat/chart.js";
 import { useDisplayMode } from "@/scale.js";
-import { getBarLength } from "@/../chartFormat/command.js";
+import { getBarLength } from "@/../chartFormat/signature.js";
 
 interface Props {
   currentTimeSecWithoutOffset: number;

--- a/app/edit/timingTab.tsx
+++ b/app/edit/timingTab.tsx
@@ -18,7 +18,7 @@ import {
   Signature,
   SignatureWithLua,
   toStepArray,
-} from "@/../chartFormat/command.js";
+} from "@/../chartFormat/signature.js";
 import { useEffect, useRef, useState } from "react";
 import { Close, CornerDownLeft } from "@icon-park/react";
 

--- a/app/errorPlaceholder/page.tsx
+++ b/app/errorPlaceholder/page.tsx
@@ -1,8 +1,8 @@
-import { Error } from "@/common/box.js";
+import { ErrorPage } from "@/common/box.js";
 import { metaDataTitle } from "@/common/title.js";
 
 export const metadata = metaDataTitle(`PLACEHOLDER_TITLE`);
 
 export default function NotFoundPage() {
-  return <Error status="PLACEHOLDER_STATUS" message="PLACEHOLDER_MESSAGE" />;;
+  return <ErrorPage status="PLACEHOLDER_STATUS" message="PLACEHOLDER_MESSAGE" />;;
 }

--- a/app/main/play/page.tsx
+++ b/app/main/play/page.tsx
@@ -161,6 +161,27 @@ export default function PlayTab() {
           ) にアクセスすることでもプレイできます。
         </p>
       </div>
+      {process.env.NODE_ENV === "development" && (
+        <div className="mb-3 ml-2">
+          <h4 className="mb-2">
+            <span className="text-lg font-bold font-title">
+              譜面IDを指定し直接プレイ画面に飛ぶ:
+            </span>
+            <Input
+              className="ml-4 w-20"
+              actualValue=""
+              updateValue={(cid) =>
+                window.open(`/play?cid=${cid}&lvIndex=0`, "_blank")?.focus()
+              }
+              isValid={validCId}
+              left
+            />
+          </h4>
+          <p className="pl-2 text-justify">
+            (dev環境限定、 /share/cid のパスが使えない代わり)
+          </p>
+        </div>
+      )}
       <div className="mb-3">
         <h3 className="text-xl font-bold font-title mb-2">
           最近プレイした譜面

--- a/app/play/fallingWindow.tsx
+++ b/app/play/fallingWindow.tsx
@@ -1,23 +1,27 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  Note,
-  DisplayNote,
-  targetY,
-  displayNote,
-  bigScale,
-} from "@/../chartFormat/seq.js";
+import { targetY, bigScale } from "@/../chartFormat/seq.js";
 import { useResizeDetector } from "react-resize-detector";
 import TargetLine from "@/common/targetLine.js";
 import { useDisplayMode } from "@/scale.js";
 import { bonusMax } from "@/../chartFormat/gameConstant.js";
 import { ThemeContext } from "@/common/theme.js";
+import {
+  displayNote6,
+  DisplayNote6,
+  Note6,
+} from "../../chartFormat/legacy/seq6.js";
+import {
+  displayNote7,
+  DisplayNote7,
+  Note7,
+} from "../../chartFormat/legacy/seq7.js";
 
 interface Props {
   className?: string;
   style?: object;
-  notes: Note[];
+  notes: Note6[] | Note7[];
   getCurrentTimeSec: () => number | undefined;
   playing: boolean;
   setFPS?: (fps: number) => void;
@@ -27,7 +31,9 @@ interface Props {
 
 export default function FallingWindow(props: Props) {
   const { notes, playing, getCurrentTimeSec, setFPS } = props;
-  const [displayNotes, setDisplayNotes] = useState<DisplayNote[]>([]);
+  const [displayNotes, setDisplayNotes] = useState<
+    DisplayNote6[] | DisplayNote7[]
+  >([]);
   const { width, height, ref } = useResizeDetector();
   const boxSize: number | undefined =
     width && height && Math.min(width, height);
@@ -52,7 +58,11 @@ export default function FallingWindow(props: Props) {
         now !== undefined
       ) {
         setDisplayNotes(
-          notes.map((n) => displayNote(n, now)).filter((n) => n !== null)
+          notes
+            .map((n) =>
+              n.ver === 6 ? displayNote6(n, now) : displayNote7(n, now)
+            )
+            .filter((n) => n !== null)
         );
       } else {
         setDisplayNotes([]);
@@ -107,9 +117,9 @@ export default function FallingWindow(props: Props) {
 }
 
 interface NProps {
-  displayNote: DisplayNote;
+  displayNote: DisplayNote6 | DisplayNote7;
   noteSize: number;
-  note: Note;
+  note: Note6 | Note7;
   marginX: number;
   marginY: number;
   boxSize: number;

--- a/app/play/musicArea.tsx
+++ b/app/play/musicArea.tsx
@@ -22,7 +22,6 @@ export function MusicArea(props: Props) {
   const { rem } = useDisplayMode();
   const ytHalf = width && width / 2 < 200;
   const largeTitle = props.isMobile && height && height > 8 * rem;
-  console.log(largeTitle, height, rem)
 
   const [currentSec, setCurrentSec] = useState<number>(0);
   const levelLength =

--- a/app/play/rhythmicalSlime.tsx
+++ b/app/play/rhythmicalSlime.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { BPMChange, Signature } from "@/../chartFormat/command.js";
+import { BPMChange } from "@/../chartFormat/bpm.js";
+import { Signature } from "@/../chartFormat/signature.js";
 import { getSignatureState, getTimeSec } from "@/../chartFormat/seq.js";
 import { Step, stepAdd, stepSub, stepZero } from "@/../chartFormat/step.js";
 import { useDisplayMode } from "@/scale.js";

--- a/chartFormat/bpm.ts
+++ b/chartFormat/bpm.ts
@@ -1,0 +1,51 @@
+import { BPMChange1 } from "./legacy/chart1.js";
+import { BPMChangeWithLua3 } from "./legacy/chart3.js";
+import { stepCmp, stepToFloat, validateStep } from "./step.js";
+
+/**
+ * timeSec +=
+ *  (60 / bpmChanges[bi].bpm) *
+ *  (bpmChanges[bi + 1].step - bpmChanges[bi].step);
+ */
+export type BPMChange = BPMChange1;
+export type BPMChangeWithLua = BPMChangeWithLua3;
+
+export function validateBpmChange(b: BPMChangeWithLua) {
+  validateStep(b.step);
+  if (typeof b.timeSec !== "number") throw "BpmChange.timeSec is invalid";
+  if (typeof b.bpm !== "number") throw "BpmChange.bpm is invalid";
+  if (typeof b.luaLine !== "number" && b.luaLine !== null)
+    throw "note.luaLine is invalid";
+}
+
+/**
+ * stepが正しいとしてtimeSecを再計算
+ */
+export function updateBpmTimeSec(
+  bpmChanges: BPMChange[],
+  scaleChanges: BPMChange[]
+) {
+  let timeSum = 0;
+  let si = 0;
+  for (let bi = 0; bi < bpmChanges.length; bi++) {
+    bpmChanges[bi].timeSec = timeSum;
+    while (
+      si < scaleChanges.length &&
+      (bi + 1 >= bpmChanges.length ||
+        stepCmp(scaleChanges[si].step, bpmChanges[bi + 1].step) < 0)
+    ) {
+      scaleChanges[si].timeSec =
+        timeSum +
+        (60 / bpmChanges[bi].bpm) *
+          (stepToFloat(scaleChanges[si].step) -
+            stepToFloat(bpmChanges[bi].step));
+      si++;
+    }
+    if (bi + 1 < bpmChanges.length) {
+      timeSum +=
+        (60 / bpmChanges[bi].bpm) *
+        (stepToFloat(bpmChanges[bi + 1].step) -
+          stepToFloat(bpmChanges[bi].step));
+    }
+  }
+}

--- a/chartFormat/chart.ts
+++ b/chartFormat/chart.ts
@@ -1,24 +1,17 @@
-import {
-  BPMChangeWithLua,
-  NoteCommandWithLua,
-  RestStep,
-  SignatureWithLua,
-  updateBpmTimeSec,
-  validateBpmChange,
-  validateNoteCommand,
-  validateRestStep,
-  validateSignature,
-} from "./command.js";
+import { updateBpmTimeSec, validateBpmChange } from "./bpm.js";
+import { validateNoteCommand, validateRestStep } from "./command.js";
 import { difficulty } from "./difficulty.js";
-import { Chart1, convert1To2 } from "./legacy/chart1.js";
-import { Chart2, convert2To3 } from "./legacy/chart2.js";
-import { Chart3, convert3To4 } from "./legacy/chart3.js";
-import { Chart4, convert4To5 } from "./legacy/chart4.js";
-import { Chart5, convert5To6 } from "./legacy/chart5.js";
+import { Chart1 } from "./legacy/chart1.js";
+import { Chart2, convert1To2 } from "./legacy/chart2.js";
+import { Chart3, convert2To3 } from "./legacy/chart3.js";
+import { Chart4, convert3To4 } from "./legacy/chart4.js";
+import { Chart5, convert4To5 } from "./legacy/chart5.js";
+import { Chart6, Level6, convert5To6 } from "./legacy/chart6.js";
 import { luaAddBpmChange } from "./lua/bpm.js";
 import { luaAddBeatChange } from "./lua/signature.js";
 import { luaAddSpeedChange } from "./lua/speed.js";
 import { getTimeSec } from "./seq.js";
+import { validateSignature } from "./signature.js";
 import { stepZero } from "./step.js";
 
 /**
@@ -75,29 +68,8 @@ export function pageTitle(cid: string, brief: ChartBrief) {
  * クライアント側は全く使わない
  *
  */
-export interface Chart {
-  falling: "nikochan"; // magic
-  ver: 6;
-  levels: Level[];
-  offset: number;
-  ytId: string;
-  title: string;
-  composer: string;
-  chartCreator: string;
-  editPasswd: string;
-  published: boolean;
-}
-export interface Level {
-  name: string;
-  type: string;
-  notes: NoteCommandWithLua[];
-  rest: RestStep[];
-  bpmChanges: BPMChangeWithLua[];
-  speedChanges: BPMChangeWithLua[];
-  signature: SignatureWithLua[];
-  lua: string[];
-  unlisted: boolean;
-}
+export type Chart = Chart6;
+export type Level = Level6;
 export const levelTypes = ["Single", "Double", "Maniac"];
 
 export const chartMaxSize = 1000000;
@@ -208,7 +180,7 @@ export function emptyLevel(prevLevel?: Level): Level {
       level = luaAddSpeedChange(level, change)!;
     }
     for (const s of prevLevel.signature) {
-      level = luaAddBeatChange(level, s)!;
+      level = luaAddBeatChange(level, s)! as Level;
     }
   } else {
     level = luaAddBpmChange(level, { bpm: 120, step: stepZero(), timeSec: 0 })!;
@@ -222,7 +194,7 @@ export function emptyLevel(prevLevel?: Level): Level {
       offset: stepZero(),
       barNum: 0,
       bars: [[4, 4, 4, 4]],
-    })!;
+    })! as Level;
   }
   return level;
 }

--- a/chartFormat/chart.ts
+++ b/chartFormat/chart.ts
@@ -2,12 +2,12 @@ import { updateBpmTimeSec, validateBpmChange } from "./bpm.js";
 import { validateNoteCommand, validateRestStep } from "./command.js";
 import { difficulty } from "./difficulty.js";
 import { Chart1 } from "./legacy/chart1.js";
-import { Chart2, convert1To2 } from "./legacy/chart2.js";
-import { Chart3, convert2To3 } from "./legacy/chart3.js";
-import { Chart4, convert3To4 } from "./legacy/chart4.js";
-import { Chart5, convert4To5 } from "./legacy/chart5.js";
-import { Chart6, convert5To6 } from "./legacy/chart6.js";
-import { Chart7, convert6To7, hashLevel7, Level7 } from "./legacy/chart7.js";
+import { Chart2 } from "./legacy/chart2.js";
+import { Chart3 } from "./legacy/chart3.js";
+import { Chart4 } from "./legacy/chart4.js";
+import { Chart5 } from "./legacy/chart5.js";
+import { Chart6 } from "./legacy/chart6.js";
+import { Chart7, convertTo7, hashLevel7, Level7 } from "./legacy/chart7.js";
 import { luaAddBpmChange } from "./lua/bpm.js";
 import { luaAddBeatChange } from "./lua/signature.js";
 import { luaAddSpeedChange } from "./lua/speed.js";
@@ -79,12 +79,7 @@ export async function validateChart(
   chart: Chart | Chart1 | Chart2 | Chart3 | Chart4 | Chart5 | Chart6
 ): Promise<Chart> {
   if (chart.falling !== "nikochan") throw "not a falling nikochan data";
-  if (chart.ver === 1) chart = convert1To2(chart);
-  if (chart.ver === 2) chart = convert2To3(chart);
-  if (chart.ver === 3) chart = await convert3To4(chart);
-  if (chart.ver === 4) chart = convert4To5(chart);
-  if (chart.ver === 5) chart = convert5To6(chart);
-  if (chart.ver === 6) chart = convert6To7(chart);
+  if (chart.ver !== 7) chart = await convertTo7(chart);
   if (chart.ver !== 7) throw "chart.ver is invalid";
   if (!Array.isArray(chart.levels)) throw "chart.levels is invalid";
   chart.levels.forEach((l) => validateLevel(l));

--- a/chartFormat/chart.ts
+++ b/chartFormat/chart.ts
@@ -6,7 +6,8 @@ import { Chart2, convert1To2 } from "./legacy/chart2.js";
 import { Chart3, convert2To3 } from "./legacy/chart3.js";
 import { Chart4, convert3To4 } from "./legacy/chart4.js";
 import { Chart5, convert4To5 } from "./legacy/chart5.js";
-import { Chart6, Level6, convert5To6 } from "./legacy/chart6.js";
+import { Chart6, convert5To6 } from "./legacy/chart6.js";
+import { Chart7, convert6To7, hashLevel7, Level7 } from "./legacy/chart7.js";
 import { luaAddBpmChange } from "./lua/bpm.js";
 import { luaAddBeatChange } from "./lua/signature.js";
 import { luaAddSpeedChange } from "./lua/speed.js";
@@ -68,14 +69,14 @@ export function pageTitle(cid: string, brief: ChartBrief) {
  * クライアント側は全く使わない
  *
  */
-export type Chart = Chart6;
-export type Level = Level6;
+export type Chart = Chart7;
+export type Level = Level7;
 export const levelTypes = ["Single", "Double", "Maniac"];
 
 export const chartMaxSize = 1000000;
 
 export async function validateChart(
-  chart: Chart | Chart1 | Chart2 | Chart3 | Chart4 | Chart5
+  chart: Chart | Chart1 | Chart2 | Chart3 | Chart4 | Chart5 | Chart6
 ): Promise<Chart> {
   if (chart.falling !== "nikochan") throw "not a falling nikochan data";
   if (chart.ver === 1) chart = convert1To2(chart);
@@ -83,7 +84,8 @@ export async function validateChart(
   if (chart.ver === 3) chart = await convert3To4(chart);
   if (chart.ver === 4) chart = convert4To5(chart);
   if (chart.ver === 5) chart = convert5To6(chart);
-  if (chart.ver !== 6) throw "chart.ver is invalid";
+  if (chart.ver === 6) chart = convert6To7(chart);
+  if (chart.ver !== 7) throw "chart.ver is invalid";
   if (!Array.isArray(chart.levels)) throw "chart.levels is invalid";
   chart.levels.forEach((l) => validateLevel(l));
   if (typeof chart.offset !== "number") chart.offset = 0;
@@ -129,16 +131,7 @@ export async function hash(text: string) {
 export async function hashPasswd(text: string) {
   return await hash(text);
 }
-export async function hashLevel(level: Level) {
-  return await hash(
-    JSON.stringify([
-      level.notes,
-      level.bpmChanges,
-      level.speedChanges,
-      level.signature,
-    ])
-  );
-}
+export const hashLevel = hashLevel7;
 
 export function validCId(cid: string) {
   return cid.length === 6 && Number(cid) >= 100000 && Number(cid) < 1000000;
@@ -147,7 +140,7 @@ export function validCId(cid: string) {
 export function emptyChart(): Chart {
   let chart: Chart = {
     falling: "nikochan",
-    ver: 6,
+    ver: 7,
     levels: [emptyLevel()],
     offset: 0,
     ytId: "",

--- a/chartFormat/command.ts
+++ b/chartFormat/command.ts
@@ -1,13 +1,9 @@
 import {
-  Step,
-  stepAdd,
-  stepCmp,
-  stepSimplify,
-  stepSub,
-  stepToFloat,
-  stepZero,
-  validateStep,
-} from "./step.js";
+  NoteCommand3,
+  NoteCommandWithLua3,
+  RestStep3,
+} from "./legacy/chart3.js";
+import { Step, stepZero, validateStep } from "./step.js";
 
 /**
  * 音符コマンド
@@ -20,16 +16,9 @@ import {
  * accelY: Y加速度
  * timeScale: { 時刻(判定時刻 - step数), VX,VY,accelYの倍率 } のリスト
  */
-export interface NoteCommand {
-  step: Step;
-  big: boolean;
-  hitX: number;
-  hitVX: number;
-  hitVY: number;
-}
-export interface NoteCommandWithLua extends NoteCommand {
-  luaLine: number | null;
-}
+export type NoteCommand = NoteCommand3;
+export type NoteCommandWithLua = NoteCommandWithLua3;
+
 export function validateNoteCommand(n: NoteCommandWithLua) {
   validateStep(n.step);
   if (typeof n.big !== "boolean") throw "note.big is invalid";
@@ -52,162 +41,11 @@ export function defaultNoteCommand(
   };
 }
 
-export interface RestStep {
-  begin: Step;
-  duration: Step;
-  luaLine: number | null;
-}
+export type RestStep = RestStep3;
+
 export function validateRestStep(n: RestStep) {
   validateStep(n.begin);
   validateStep(n.duration);
   if (typeof n.luaLine !== "number" && n.luaLine !== null)
     throw "note.luaLine is invalid";
-}
-
-/**
- * 例: 15/8 = 4/4 + 7/8 の場合
- * (4分, 4分, 4分, 4分) + (4分, 4分, 4分, 8分)
- * → [[4, 4, 4, 4], [4, 4, 4, 8]]
- * 4分、8分、16分の和で表せる拍子のみしか対応しない。
- *
- * step: 変化位置
- * offset: n拍目からカウントを始める
- *  (step - offset がこのSignatureの1拍目になる)
- *
- * barNum: このSignatureが始まる時点の小節番号
- *
- */
-export interface Signature {
-  step: Step;
-  offset: Step;
-  barNum: number;
-  bars: (4 | 8 | 16)[][];
-}
-export interface SignatureWithLua extends Signature {
-  luaLine: number | null;
-}
-export function validateSignature(s: SignatureWithLua) {
-  validateStep(s.step);
-  validateStep(s.offset);
-  if (!Array.isArray(s.bars)) throw "signature.bars is invalid";
-  s.bars.forEach((b) => {
-    if (!Array.isArray(b)) throw "signature.bars is invalid";
-    b.forEach((bs) => {
-      if (bs !== 4 && bs !== 8 && bs !== 16) throw "signature.bars is invalid";
-    });
-  });
-  if (typeof s.luaLine !== "number" && s.luaLine !== null)
-    throw "signature.luaLine is invalid";
-}
-export function getBarLength(s: Signature): Step[] {
-  const barLength = toStepArray(s).map((b) =>
-    b.reduce((len, bs) => stepAdd(len, bs), stepZero())
-  );
-  barLength.forEach((len) => {
-    if (stepCmp(len, stepZero()) <= 0) {
-      throw new Error("Invalid signature (empty bar): " + JSON.stringify(s));
-    }
-  });
-  return barLength;
-}
-export function toStepArray(s: Signature): Step[][] {
-  return s.bars.map((b) =>
-    b.map((bs) =>
-      stepSimplify({ fourth: 0, numerator: 1, denominator: bs / 4 })
-    )
-  );
-}
-export function barFromLength(len: Step): (4 | 8 | 16)[] {
-  const newBar: (4 | 8 | 16)[] = [];
-  for (const d of [4, 8, 16]) {
-    while (
-      stepCmp(len, {
-        fourth: 0,
-        numerator: 1,
-        denominator: d / 4,
-      }) >= 0
-    ) {
-      len = stepSub(len, {
-        fourth: 0,
-        numerator: 1,
-        denominator: d / 4,
-      });
-      newBar.push(d as 4 | 8 | 16);
-    }
-  }
-  return newBar;
-}
-export function updateBarNum(signatures: Signature[]) {
-  let barNum = 0;
-  signatures[0].barNum = 0;
-  for (let si = 1; si < signatures.length; si++) {
-    let prevBarBegin = stepSub(
-      signatures[si - 1].step,
-      signatures[si - 1].offset
-    );
-    const prevBarLength = getBarLength(signatures[si - 1]);
-    let bi = 0;
-    while (stepCmp(prevBarBegin, signatures[si].step) < 0) {
-      barNum += 1;
-      prevBarBegin = stepAdd(
-        prevBarBegin,
-        prevBarLength[bi % prevBarLength.length]
-      );
-      bi += 1;
-    }
-    signatures[si].barNum = barNum;
-  }
-}
-
-/**
- * timeSec +=
- *  (60 / bpmChanges[bi].bpm) *
- *  (bpmChanges[bi + 1].step - bpmChanges[bi].step);
- */
-export interface BPMChange {
-  step: Step;
-  timeSec: number;
-  bpm: number;
-}
-export interface BPMChangeWithLua extends BPMChange {
-  luaLine: number | null;
-}
-export function validateBpmChange(b: BPMChangeWithLua) {
-  validateStep(b.step);
-  if (typeof b.timeSec !== "number") throw "BpmChange.timeSec is invalid";
-  if (typeof b.bpm !== "number") throw "BpmChange.bpm is invalid";
-  if (typeof b.luaLine !== "number" && b.luaLine !== null)
-    throw "note.luaLine is invalid";
-}
-
-/**
- * stepが正しいとしてtimeSecを再計算
- */
-export function updateBpmTimeSec(
-  bpmChanges: BPMChange[],
-  scaleChanges: BPMChange[]
-) {
-  let timeSum = 0;
-  let si = 0;
-  for (let bi = 0; bi < bpmChanges.length; bi++) {
-    bpmChanges[bi].timeSec = timeSum;
-    while (
-      si < scaleChanges.length &&
-      (bi + 1 >= bpmChanges.length ||
-        stepCmp(scaleChanges[si].step, bpmChanges[bi + 1].step) < 0)
-    ) {
-      scaleChanges[si].timeSec =
-        timeSum +
-        (60 / bpmChanges[bi].bpm) *
-          (stepToFloat(scaleChanges[si].step) -
-            stepToFloat(bpmChanges[bi].step));
-      si++;
-    }
-    if (bi + 1 < bpmChanges.length) {
-      timeSum +=
-        (60 / bpmChanges[bi].bpm) *
-        (stepToFloat(bpmChanges[bi + 1].step) -
-          stepToFloat(bpmChanges[bi].step));
-    }
-  }
 }

--- a/chartFormat/command.ts
+++ b/chartFormat/command.ts
@@ -1,8 +1,5 @@
-import {
-  NoteCommand3,
-  NoteCommandWithLua3,
-  RestStep3,
-} from "./legacy/chart3.js";
+import { RestStep3 } from "./legacy/chart3.js";
+import { NoteCommand7, NoteCommandWithLua7 } from "./legacy/chart7.js";
 import { Step, stepZero, validateStep } from "./step.js";
 
 /**
@@ -15,9 +12,10 @@ import { Step, stepZero, validateStep } from "./step.js";
  * (accelX = 0)
  * accelY: Y加速度
  * timeScale: { 時刻(判定時刻 - step数), VX,VY,accelYの倍率 } のリスト
+ * fall: 音符出現位置を画面上にする(true) or 下にする(false)
  */
-export type NoteCommand = NoteCommand3;
-export type NoteCommandWithLua = NoteCommandWithLua3;
+export type NoteCommand = NoteCommand7;
+export type NoteCommandWithLua = NoteCommandWithLua7;
 
 export function validateNoteCommand(n: NoteCommandWithLua) {
   validateStep(n.step);
@@ -37,6 +35,7 @@ export function defaultNoteCommand(
     hitX: -3,
     hitVX: +1,
     hitVY: +3,
+    fall: true,
     // luaLine
   };
 }

--- a/chartFormat/legacy/chart1.ts
+++ b/chartFormat/legacy/chart1.ts
@@ -1,12 +1,10 @@
-import { BPMChange } from "../command.js";
-import { stepZero } from "../step.js";
-import { Chart2, NoteCommand2 } from "./chart2.js";
+import { Step } from "../step.js";
 
 export interface Chart1 {
   falling: "nikochan"; // magic
   ver: 1;
-  notes: NoteCommand2[];
-  bpmChanges: BPMChange[];
+  notes: NoteCommand1[];
+  bpmChanges: BPMChange1[];
   offset: number;
   waveOffset: number;
   ytId: string;
@@ -15,26 +13,16 @@ export interface Chart1 {
   chartCreator: string;
   editPasswd: string;
 }
-
-export function convert1To2(chart: Chart1): Chart2 {
-  return {
-    falling: "nikochan",
-    ver: 2,
-    notes: chart.notes.map((n) => ({
-      step: n.step,
-      big: n.big,
-      hitX: n.hitX * 10 - 5,
-      hitVX: n.hitVX * 4,
-      hitVY: n.hitVY * 4,
-      accelY: n.accelY * 4,
-    })),
-    bpmChanges: chart.bpmChanges,
-    scaleChanges: [{ step: stepZero(), timeSec: 0, bpm: 120 }],
-    offset: chart.offset,
-    ytId: chart.ytId,
-    title: chart.title,
-    composer: chart.composer,
-    chartCreator: chart.chartCreator,
-    editPasswd: chart.editPasswd,
-  };
+export interface NoteCommand1 {
+  step: Step;
+  big: boolean;
+  hitX: number;
+  hitVX: number;
+  hitVY: number;
+  accelY: number;
+}
+export interface BPMChange1 {
+  step: Step;
+  timeSec: number;
+  bpm: number;
 }

--- a/chartFormat/legacy/chart2.ts
+++ b/chartFormat/legacy/chart2.ts
@@ -15,7 +15,7 @@ export interface Chart2 {
   editPasswd: string;
 }
 
-export function convert1To2(chart: Chart1): Chart2 {
+export function convertTo2(chart: Chart1): Chart2 {
   return {
     falling: "nikochan",
     ver: 2,

--- a/chartFormat/legacy/chart3.ts
+++ b/chartFormat/legacy/chart3.ts
@@ -4,8 +4,8 @@ import { luaAddNote } from "../lua/note.js";
 import { luaAddSpeedChange } from "../lua/speed.js";
 import { findBpmIndexFromStep, getTimeSec } from "../seq.js";
 import { Step, stepZero } from "../step.js";
-import { BPMChange1 } from "./chart1.js";
-import { Chart2 } from "./chart2.js";
+import { BPMChange1, Chart1 } from "./chart1.js";
+import { Chart2, convertTo2 } from "./chart2.js";
 
 export interface Chart3 {
   falling: "nikochan"; // magic
@@ -42,7 +42,8 @@ export interface RestStep3 {
   luaLine: number | null;
 }
 
-export function convert2To3(chart: Chart2): Chart3 {
+export function convertTo3(chart: Chart1 | Chart2): Chart3 {
+  if(chart.ver !== 2) chart = convertTo2(chart);
   let newChart: Chart3 = {
     falling: "nikochan",
     ver: 3,

--- a/chartFormat/legacy/chart4.ts
+++ b/chartFormat/legacy/chart4.ts
@@ -1,8 +1,5 @@
-import { hash, Level } from "../chart.js";
-import { BPMChangeWithLua, NoteCommandWithLua, RestStep } from "../command.js";
-import { luaAddBeatChange } from "../lua/signature.js";
-import { stepZero } from "../step.js";
-import { Chart5 } from "./chart5.js";
+import { hash } from "../chart.js";
+import { BPMChangeWithLua3, Chart3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
 
 export interface Chart4 {
   falling: "nikochan"; // magic
@@ -20,29 +17,11 @@ export interface Level4 {
   name: string;
   type: string;
   hash: string;
-  notes: NoteCommandWithLua[];
-  rest: RestStep[];
-  bpmChanges: BPMChangeWithLua[];
-  speedChanges: BPMChangeWithLua[];
+  notes: NoteCommandWithLua3[];
+  rest: RestStep3[];
+  bpmChanges: BPMChangeWithLua3[];
+  speedChanges: BPMChangeWithLua3[];
   lua: string[];
-}
-
-export function convert4To5(chart: Chart4): Chart5 {
-  return {
-    ...chart,
-    ver: 5,
-    levels: chart.levels.map((l) => {
-      let newLevel: Level = { ...l, signature: [], unlisted: false };
-      newLevel =
-        luaAddBeatChange(newLevel, {
-          step: stepZero(),
-          offset: stepZero(),
-          barNum: 0,
-          bars: [[4, 4, 4, 4]],
-        }) || newLevel;
-      return { ...newLevel, hash: l.hash };
-    }),
-  };
 }
 
 export async function hashLevel4(level: Level4) {
@@ -50,3 +29,32 @@ export async function hashLevel4(level: Level4) {
     JSON.stringify([level.notes, level.bpmChanges, level.speedChanges])
   );
 }
+
+export async function convert3To4(chart: Chart3): Promise<Chart4> {
+  const newChart: Chart4 = {
+    falling: "nikochan",
+    ver: 4,
+    levels: [
+      {
+        name: "",
+        hash: "",
+        type: "Single",
+        notes: chart.notes,
+        rest: chart.rest,
+        bpmChanges: chart.bpmChanges,
+        speedChanges: chart.speedChanges,
+        lua: chart.lua,
+      },
+    ],
+    offset: chart.offset,
+    ytId: chart.ytId,
+    title: chart.title,
+    composer: chart.composer,
+    chartCreator: chart.chartCreator,
+    editPasswd: chart.editPasswd,
+    updatedAt: 0,
+  };
+  newChart.levels[0].hash = await hashLevel4(newChart.levels[0]);
+  return newChart;
+}
+

--- a/chartFormat/legacy/chart4.ts
+++ b/chartFormat/legacy/chart4.ts
@@ -1,5 +1,13 @@
 import { hash } from "../chart.js";
-import { BPMChangeWithLua3, Chart3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
+import { Chart1 } from "./chart1.js";
+import { Chart2 } from "./chart2.js";
+import {
+  BPMChangeWithLua3,
+  Chart3,
+  convertTo3,
+  NoteCommandWithLua3,
+  RestStep3,
+} from "./chart3.js";
 
 export interface Chart4 {
   falling: "nikochan"; // magic
@@ -30,7 +38,10 @@ export async function hashLevel4(level: Level4) {
   );
 }
 
-export async function convert3To4(chart: Chart3): Promise<Chart4> {
+export async function convertTo4(
+  chart: Chart1 | Chart2 | Chart3
+): Promise<Chart4> {
+  if (chart.ver !== 3) chart = convertTo3(chart);
   const newChart: Chart4 = {
     falling: "nikochan",
     ver: 4,
@@ -57,4 +68,3 @@ export async function convert3To4(chart: Chart3): Promise<Chart4> {
   newChart.levels[0].hash = await hashLevel4(newChart.levels[0]);
   return newChart;
 }
-

--- a/chartFormat/legacy/chart5.ts
+++ b/chartFormat/legacy/chart5.ts
@@ -1,8 +1,10 @@
 import { hash } from "../chart.js";
 import { luaAddBeatChange } from "../lua/signature.js";
 import { Step, stepZero } from "../step.js";
-import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
-import { Chart4 } from "./chart4.js";
+import { Chart1 } from "./chart1.js";
+import { Chart2 } from "./chart2.js";
+import { BPMChangeWithLua3, Chart3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
+import { Chart4, convertTo4 } from "./chart4.js";
 import { Level6 } from "./chart6.js";
 
 export interface Chart5 {
@@ -50,7 +52,8 @@ export async function hashLevel5(level: Level5 | Level6) {
   );
 }
 
-export function convert4To5(chart: Chart4): Chart5 {
+export async function convertTo5(chart: Chart1 | Chart2 | Chart3 | Chart4): Promise<Chart5> {
+  if (chart.ver !== 4) chart = await convertTo4(chart);
   return {
     ...chart,
     ver: 5,

--- a/chartFormat/legacy/chart5.ts
+++ b/chartFormat/legacy/chart5.ts
@@ -1,10 +1,7 @@
-import {
-  BPMChangeWithLua,
-  NoteCommandWithLua,
-  RestStep,
-  SignatureWithLua,
-} from "../command.js";
-import { Chart6 } from "./chart6.js";
+import { luaAddBeatChange } from "../lua/signature.js";
+import { Step, stepZero } from "../step.js";
+import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
+import { Chart4 } from "./chart4.js";
 
 export interface Chart5 {
   falling: "nikochan"; // magic
@@ -22,23 +19,38 @@ export interface Level5 {
   name: string;
   type: string;
   hash: string;
-  notes: NoteCommandWithLua[];
-  rest: RestStep[];
-  bpmChanges: BPMChangeWithLua[];
-  speedChanges: BPMChangeWithLua[];
-  signature: SignatureWithLua[];
+  notes: NoteCommandWithLua3[];
+  rest: RestStep3[];
+  bpmChanges: BPMChangeWithLua3[];
+  speedChanges: BPMChangeWithLua3[];
+  signature: SignatureWithLua5[];
   lua: string[];
   unlisted?: boolean;
 }
+export interface Signature5 {
+  step: Step;
+  offset: Step;
+  barNum: number;
+  bars: (4 | 8 | 16)[][];
+}
+export interface SignatureWithLua5 extends Signature5 {
+  luaLine: number | null;
+}
 
-export function convert5To6(chart: Chart5): Chart6 {
+export function convert4To5(chart: Chart4): Chart5 {
   return {
     ...chart,
-    levels: chart.levels.map((level) => ({
-      ...level,
-      unlisted: !!level.unlisted,
-    })),
-    ver: 6,
-    published: false,
+    ver: 5,
+    levels: chart.levels.map((l) => {
+      let newLevel: Level5 = { ...l, signature: [], unlisted: false };
+      newLevel =
+        (luaAddBeatChange(newLevel, {
+          step: stepZero(),
+          offset: stepZero(),
+          barNum: 0,
+          bars: [[4, 4, 4, 4]],
+        }) as Level5) || newLevel;
+      return { ...newLevel, hash: l.hash };
+    }),
   };
 }

--- a/chartFormat/legacy/chart5.ts
+++ b/chartFormat/legacy/chart5.ts
@@ -1,7 +1,9 @@
+import { hash } from "../chart.js";
 import { luaAddBeatChange } from "../lua/signature.js";
 import { Step, stepZero } from "../step.js";
 import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
 import { Chart4 } from "./chart4.js";
+import { Level6 } from "./chart6.js";
 
 export interface Chart5 {
   falling: "nikochan"; // magic
@@ -35,6 +37,17 @@ export interface Signature5 {
 }
 export interface SignatureWithLua5 extends Signature5 {
   luaLine: number | null;
+}
+
+export async function hashLevel5(level: Level5 | Level6) {
+  return await hash(
+    JSON.stringify([
+      level.notes,
+      level.bpmChanges,
+      level.speedChanges,
+      level.signature,
+    ])
+  );
 }
 
 export function convert4To5(chart: Chart4): Chart5 {

--- a/chartFormat/legacy/chart6.ts
+++ b/chartFormat/legacy/chart6.ts
@@ -1,5 +1,13 @@
-import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
-import { Chart5, SignatureWithLua5 } from "./chart5.js";
+import { Chart1 } from "./chart1.js";
+import { Chart2 } from "./chart2.js";
+import {
+  BPMChangeWithLua3,
+  Chart3,
+  NoteCommandWithLua3,
+  RestStep3,
+} from "./chart3.js";
+import { Chart4 } from "./chart4.js";
+import { Chart5, convertTo5, SignatureWithLua5 } from "./chart5.js";
 
 export interface Chart6 {
   falling: "nikochan"; // magic
@@ -25,7 +33,10 @@ export interface Level6 {
   unlisted: boolean;
 }
 
-export function convert5To6(chart: Chart5): Chart6 {
+export async function convertTo6(
+  chart: Chart1 | Chart2 | Chart3 | Chart4 | Chart5
+): Promise<Chart6> {
+  if (chart.ver !== 5) chart = await convertTo5(chart);
   return {
     ...chart,
     levels: chart.levels.map((level) => ({

--- a/chartFormat/legacy/chart7.ts
+++ b/chartFormat/legacy/chart7.ts
@@ -64,7 +64,9 @@ export async function convertTo7(
       ...level,
       notes: level.notes.map((note) => ({
         ...note,
-        fall: true,
+        // 新規譜面のfallのデフォルト値はtrueだが、
+        // 既存の譜面についてはfalseとする
+        fall: false,
       })),
     })),
     ver: 7,

--- a/chartFormat/legacy/chart7.ts
+++ b/chartFormat/legacy/chart7.ts
@@ -1,10 +1,10 @@
 import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
-import { Chart5, SignatureWithLua5 } from "./chart5.js";
+import { SignatureWithLua5 } from "./chart5.js";
 
-export interface Chart6 {
+export interface Chart7 {
   falling: "nikochan"; // magic
-  ver: 6;
-  levels: Level6[];
+  ver: 7;
+  levels: Level7[];
   offset: number;
   ytId: string;
   title: string;
@@ -13,7 +13,7 @@ export interface Chart6 {
   editPasswd: string;
   published: boolean;
 }
-export interface Level6 {
+export interface Level7 {
   name: string;
   type: string;
   notes: NoteCommandWithLua3[];
@@ -23,16 +23,4 @@ export interface Level6 {
   signature: SignatureWithLua5[];
   lua: string[];
   unlisted: boolean;
-}
-
-export function convert5To6(chart: Chart5): Chart6 {
-  return {
-    ...chart,
-    levels: chart.levels.map((level) => ({
-      ...level,
-      unlisted: !!level.unlisted,
-    })),
-    ver: 6,
-    published: false,
-  };
 }

--- a/chartFormat/legacy/chart7.ts
+++ b/chartFormat/legacy/chart7.ts
@@ -1,5 +1,8 @@
-import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "./chart3.js";
+import { hash } from "../chart.js";
+import { Step } from "../step.js";
+import { BPMChangeWithLua3, RestStep3 } from "./chart3.js";
 import { SignatureWithLua5 } from "./chart5.js";
+import { Chart6 } from "./chart6.js";
 
 export interface Chart7 {
   falling: "nikochan"; // magic
@@ -16,11 +19,49 @@ export interface Chart7 {
 export interface Level7 {
   name: string;
   type: string;
-  notes: NoteCommandWithLua3[];
+  notes: NoteCommandWithLua7[];
   rest: RestStep3[];
   bpmChanges: BPMChangeWithLua3[];
   speedChanges: BPMChangeWithLua3[];
   signature: SignatureWithLua5[];
   lua: string[];
   unlisted: boolean;
+}
+
+export interface NoteCommand7 {
+  step: Step;
+  big: boolean;
+  hitX: number;
+  hitVX: number;
+  hitVY: number;
+  fall: boolean;
+}
+export interface NoteCommandWithLua7 extends NoteCommand7 {
+  luaLine: number | null;
+}
+
+export async function hashLevel7(level: Level7) {
+  return await hash(
+    JSON.stringify([
+      level.notes,
+      level.bpmChanges,
+      level.speedChanges,
+      level.signature,
+    ])
+  );
+}
+
+export function convert6To7(chart: Chart6): Chart7 {
+  return {
+    ...chart,
+    levels: chart.levels.map((level) => ({
+      ...level,
+      notes: level.notes.map((note) => ({
+        ...note,
+        fall: true, //todo!,
+      })),
+    })),
+    ver: 7,
+    published: false,
+  };
 }

--- a/chartFormat/legacy/chart7.ts
+++ b/chartFormat/legacy/chart7.ts
@@ -1,8 +1,11 @@
 import { hash } from "../chart.js";
 import { Step } from "../step.js";
-import { BPMChangeWithLua3, RestStep3 } from "./chart3.js";
-import { SignatureWithLua5 } from "./chart5.js";
-import { Chart6 } from "./chart6.js";
+import { Chart1 } from "./chart1.js";
+import { Chart2 } from "./chart2.js";
+import { BPMChangeWithLua3, Chart3, RestStep3 } from "./chart3.js";
+import { Chart4 } from "./chart4.js";
+import { Chart5, SignatureWithLua5 } from "./chart5.js";
+import { Chart6, convertTo6 } from "./chart6.js";
 
 export interface Chart7 {
   falling: "nikochan"; // magic
@@ -51,14 +54,17 @@ export async function hashLevel7(level: Level7) {
   );
 }
 
-export function convert6To7(chart: Chart6): Chart7 {
+export async function convertTo7(
+  chart: Chart1 | Chart2 | Chart3 | Chart4 | Chart5 | Chart6
+): Promise<Chart7> {
+  if (chart.ver !== 6) chart = await convertTo6(chart);
   return {
     ...chart,
     levels: chart.levels.map((level) => ({
       ...level,
       notes: level.notes.map((note) => ({
         ...note,
-        fall: true, //todo!,
+        fall: true,
       })),
     })),
     ver: 7,

--- a/chartFormat/legacy/seq6.ts
+++ b/chartFormat/legacy/seq6.ts
@@ -1,0 +1,207 @@
+import { getTimeSec, Pos } from "../seq.js";
+import { BPMChange1 } from "./chart1.js";
+import { Signature5 } from "./chart5.js";
+import { Chart6 } from "./chart6.js";
+
+export interface ChartSeqData6 {
+  ver: 6;
+  notes: Note6[];
+  bpmChanges: BPMChange1[];
+  signature: Signature5[];
+  offset: number;
+}
+
+/**
+ * ゲーム中で使用する音符の管理
+ * id: 通し番号
+ * hitTimeSec: 判定時刻
+ * appearTimeSec: 画面に表示し始める時刻
+ * display: 現在時刻→画面上の位置
+ * done: 判定結果 0:まだ 1:Good 2:OK 3:bad 4:miss
+ */
+export interface Note6 {
+  ver: 6;
+  id: number;
+  big: boolean;
+  bigDone: boolean;
+  hitTimeSec: number;
+  appearTimeSec: number;
+  targetX: number;
+  hitPos?: Pos;
+  done: number;
+  baseScore?: number;
+  chainBonus?: number;
+  bigBonus?: number;
+  chain?: number;
+  display: DisplayParam6[];
+}
+interface DisplayParam6 {
+  // 時刻(判定時刻 - 秒数)
+  timeSecBefore: number;
+  // x = a0 + a1 t, y = b0 + b1 t + b2 t^2
+  a: [number, number];
+  b: [number, number, number];
+}
+
+/**
+ * 画面上でその瞬間に表示する音符の管理
+ * (画面の状態をstateにするため)
+ * 時刻の情報を持たない
+ */
+export interface DisplayNote6 {
+  id: number;
+  pos: Pos;
+  done: number;
+  bigDone: boolean;
+  baseScore?: number;
+  chainBonus?: number;
+  bigBonus?: number;
+  chain?: number;
+}
+
+/**
+ * chartを読み込む
+ */
+export function loadChart6(chart: Chart6, levelIndex: number): ChartSeqData6 {
+  const notes: Note6[] = [];
+  const level = chart.levels.at(levelIndex);
+  if (!level) {
+    return {
+      ver: 6,
+      notes: [],
+      bpmChanges: [],
+      signature: [],
+      offset: chart.offset,
+    };
+  }
+  for (let id = 0; id < level.notes.length; id++) {
+    const c = level.notes[id];
+
+    // hitの時刻
+    const hitTimeSec: number = getTimeSec(level.bpmChanges, c.step);
+
+    const display: DisplayParam6[] = [];
+    let tBegin = hitTimeSec;
+    // noteCommandの座標系 (-5<=x<=5) から
+    //  displayの座標系に変換するのもここでやる
+    let x = (c.hitX + 5) / 10;
+    const targetX = x;
+    let y = 0;
+    let vx = c.hitVX;
+    let vy = c.hitVY;
+    const ay = 1;
+    let appearTimeSec = hitTimeSec;
+    for (let ti = level.speedChanges.length - 1; ti >= 0; ti--) {
+      const ts = level.speedChanges[ti];
+      if (ts.timeSec >= hitTimeSec && ti >= 1) {
+        continue;
+      }
+      const tEnd = ts.timeSec;
+
+      const vx_ = (vx * ts.bpm) / 4 / 120;
+      const vy_ = (vy * ts.bpm) / 4 / 120;
+      const ay_ = (ay * ts.bpm * ts.bpm) / 4 / 120 / 120;
+
+      // tEnd <= 時刻 <= tBegin の間、
+      //  t = tBegin - 時刻  > 0
+      //  x = x(tBegin) + vx * t
+      //  y = y(tBegin) + vy * t - (ay * t * t) / 2;
+      display.push({
+        timeSecBefore: hitTimeSec - tBegin,
+        a: [x, vx_],
+        b: [y, vy_, -ay_ / 2],
+      });
+
+      // tを少しずつ変えながら、x,yが画面内に入っているかをチェック
+      for (let t = 0; t < tBegin - tEnd; t += 0.01) {
+        const xt = x + vx_ * t;
+        const yt = y + vy_ * t - (ay_ * t * t) / 2;
+        if (xt >= -0.5 && xt < 1.5 && yt >= -0.5 && yt < 1.5) {
+          appearTimeSec = tBegin - t;
+        }
+      }
+      if (ti == 0) {
+        // tを少しずつ変えながら、x,yが画面内に入っているかをチェック
+        for (let t = 0; t < 999; t += 0.01) {
+          const xt = x + vx_ * t;
+          const yt = y + vy_ * t - (ay_ * t * t) / 2;
+          if (xt >= -0.5 && xt < 1.5 && yt >= -0.5 && yt < 1.5) {
+            appearTimeSec = tBegin - t;
+          } else {
+            break;
+          }
+        }
+      }
+
+      const dt = tBegin - tEnd;
+      x += vx_ * dt;
+      // y += ∫ (vy + ay * t) dt
+      y += vy_ * dt - (ay_ * dt * dt) / 2;
+      vy -= ((ay * ts.bpm) / 120) * dt;
+
+      tBegin = tEnd;
+    }
+    notes.push({
+      ver: 6,
+      id,
+      big: c.big,
+      hitTimeSec,
+      appearTimeSec,
+      done: 0,
+      bigDone: false,
+      display,
+      targetX,
+    });
+  }
+  return {
+    ver: 6,
+    offset: chart.offset,
+    signature: level.signature,
+    bpmChanges: level.bpmChanges,
+    notes,
+  };
+}
+export function displayNote6(
+  note: Note6,
+  timeSec: number
+): DisplayNote6 | null {
+  if (timeSec - note.hitTimeSec > 0.5) {
+    return null;
+  } else if (note.done >= 1 && note.done <= 3) {
+    return {
+      id: note.id,
+      pos: note.hitPos || { x: -1, y: -1 },
+      done: note.done,
+      bigDone: note.bigDone,
+      chain: note.chain,
+      baseScore: note.baseScore,
+      chainBonus: note.chainBonus,
+      bigBonus: note.bigBonus,
+    };
+  } else if (timeSec < note.appearTimeSec) {
+    return null;
+  } else {
+    let di = 0;
+    for (; di + 1 < note.display.length; di++) {
+      if (timeSec > note.hitTimeSec - note.display[di + 1].timeSecBefore) {
+        break;
+      }
+    }
+    const dispParam = note.display[di];
+    const { a, b } = dispParam;
+    const t = note.hitTimeSec - dispParam.timeSecBefore - timeSec;
+    return {
+      id: note.id,
+      pos: {
+        x: a[0] + a[1] * t,
+        y: b[0] + b[1] * t + b[2] * t * t,
+      },
+      done: note.done,
+      bigDone: note.bigDone,
+      chain: note.chain,
+      baseScore: note.baseScore,
+      chainBonus: note.chainBonus,
+      bigBonus: note.bigBonus,
+    };
+  }
+}

--- a/chartFormat/legacy/seq7.ts
+++ b/chartFormat/legacy/seq7.ts
@@ -1,0 +1,209 @@
+import { getTimeSec, Pos } from "../seq.js";
+import { BPMChange1 } from "./chart1.js";
+import { Signature5 } from "./chart5.js";
+import { Chart7 } from "./chart7.js";
+
+export interface ChartSeqData7 {
+  ver: 7;
+  notes: Note7[];
+  bpmChanges: BPMChange1[];
+  signature: Signature5[];
+  offset: number;
+}
+
+/**
+ * ゲーム中で使用する音符の管理
+ * id: 通し番号
+ * hitTimeSec: 判定時刻
+ * appearTimeSec: 画面に表示し始める時刻
+ * display: 現在時刻→画面上の位置
+ * done: 判定結果 0:まだ 1:Good 2:OK 3:bad 4:miss
+ */
+export interface Note7 {
+  ver: 7;
+  id: number;
+  big: boolean;
+  bigDone: boolean;
+  hitTimeSec: number;
+  appearTimeSec: number;
+  targetX: number;
+  vx: number;
+  vy: number;
+  ay: number;
+  display: DisplayParam7[];
+  hitPos?: Pos;
+  done: number;
+  baseScore?: number;
+  chainBonus?: number;
+  bigBonus?: number;
+  chain?: number;
+}
+interface DisplayParam7 {
+  // 時刻(判定時刻 - 秒数)
+  timeSecBefore: number;
+  // u = u0 + du t
+  u0: number;
+  du: number;
+}
+
+/**
+ * 画面上でその瞬間に表示する音符の管理
+ * (画面の状態をstateにするため)
+ * 時刻の情報を持たない
+ */
+export interface DisplayNote7 {
+  id: number;
+  pos: Pos;
+  done: number;
+  bigDone: boolean;
+  baseScore?: number;
+  chainBonus?: number;
+  bigBonus?: number;
+  chain?: number;
+}
+
+/**
+ * chartを読み込む
+ */
+export function loadChart7(chart: Chart7, levelIndex: number): ChartSeqData7 {
+  const notes: Note7[] = [];
+  const level = chart.levels.at(levelIndex);
+  if (!level) {
+    return {
+      ver: 7,
+      notes: [],
+      bpmChanges: [],
+      signature: [],
+      offset: chart.offset,
+    };
+  }
+  for (let id = 0; id < level.notes.length; id++) {
+    const c = level.notes[id];
+
+    // hitの時刻
+    const hitTimeSec: number = getTimeSec(level.bpmChanges, c.step);
+
+    const display: DisplayParam7[] = [];
+    let tBegin = hitTimeSec;
+    // noteCommandの座標系 (-5<=x<=5) から
+    //  displayの座標系に変換するのもここでやる
+    const targetX = (c.hitX + 5) / 10;
+    const targetY = 0;
+    const vx = c.hitVX / 4;
+    const vy = c.hitVY / 4;
+    const ay = 1 / 4;
+    let u = 0;
+    // u(t) = ∫t→tBegin, dt * speed / 120
+    // x(t) = targetX + vx * u(t)
+    // y(t) = targetY + vy * u(t) - (ay * u(t)^2) / 2
+
+    let uAppear: number;
+    if (c.fall) {
+      // dy/du = 0 or y(t) = 1.5 or x(t) = 2 or x(t) = -0.5
+      const uTop = vy / ay;
+      const uAppearY =
+        (vy - Math.sqrt(vy * vy + 2 * ay * (targetY - 1.5))) / ay;
+      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
+      uAppear = Math.min(uAppearX, isNaN(uAppearY) ? uTop : uAppearY);
+    } else {
+      // y(t) = -0.5 or x(t) = 2 or x(t) = -0.5
+      const uAppearY =
+        (vy + Math.sqrt(vy * vy + 2 * ay * (targetY - -0.5))) / ay;
+      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
+      uAppear = Math.max(uAppearX, uAppearY);
+    }
+
+    let appearTimeSec = hitTimeSec;
+    for (let ti = level.speedChanges.length - 1; ti >= 0; ti--) {
+      const ts = level.speedChanges[ti];
+      if (ts.timeSec >= hitTimeSec && ti >= 1) {
+        continue;
+      }
+      const tEnd = ts.timeSec;
+      const du = ts.bpm / 120;
+      // tEnd <= 時刻 <= tBegin の間、
+      //  t = tBegin - 時刻  > 0
+      //  u = u(tBegin) + du * t
+      display.push({
+        timeSecBefore: hitTimeSec - tBegin,
+        u0: u,
+        du: du,
+      });
+
+      const uEnd = u + du * (tBegin - tEnd);
+
+      if (u < uAppear && uEnd > uAppear) {
+        const tAppear = (uAppear - u) / du;
+        appearTimeSec = tBegin - tAppear;
+      }
+      tBegin = tEnd;
+      u = uEnd;
+    }
+    notes.push({
+      ver: 7,
+      id,
+      big: c.big,
+      hitTimeSec,
+      appearTimeSec,
+      done: 0,
+      bigDone: false,
+      display,
+      targetX,
+      vx,
+      vy,
+      ay,
+    });
+  }
+  return {
+    ver: 7,
+    offset: chart.offset,
+    signature: level.signature,
+    bpmChanges: level.bpmChanges,
+    notes,
+  };
+}
+export function displayNote7(
+  note: Note7,
+  timeSec: number
+): DisplayNote7 | null {
+  if (timeSec - note.hitTimeSec > 0.5) {
+    return null;
+  } else if (note.done >= 1 && note.done <= 3) {
+    return {
+      id: note.id,
+      pos: note.hitPos || { x: -1, y: -1 },
+      done: note.done,
+      bigDone: note.bigDone,
+      chain: note.chain,
+      baseScore: note.baseScore,
+      chainBonus: note.chainBonus,
+      bigBonus: note.bigBonus,
+    };
+  } else if (timeSec < note.appearTimeSec) {
+    return null;
+  } else {
+    let di = 0;
+    for (; di + 1 < note.display.length; di++) {
+      if (timeSec > note.hitTimeSec - note.display[di + 1].timeSecBefore) {
+        break;
+      }
+    }
+    const dispParam = note.display[di];
+    const { u0, du } = dispParam;
+    const t = note.hitTimeSec - dispParam.timeSecBefore - timeSec;
+    const u = u0 + du * t;
+    return {
+      id: note.id,
+      pos: {
+        x: note.targetX + note.vx * u,
+        y: note.vy * u - (note.ay * u * u) / 2,
+      },
+      done: note.done,
+      bigDone: note.bigDone,
+      chain: note.chain,
+      baseScore: note.baseScore,
+      chainBonus: note.chainBonus,
+      bigBonus: note.bigBonus,
+    };
+  }
+}

--- a/chartFormat/lua/api.ts
+++ b/chartFormat/lua/api.ts
@@ -1,15 +1,18 @@
-import { NoteCommandWithLua } from "../command.js";
 import { Step, stepAdd, stepSimplify } from "../step.js";
 import { Result } from "./exec.js";
 
 export function luaNote(state: Result, ...args: any[]) {
+  if (args.length === 5) {
+    args.push(false);
+  }
   if (
-    args.length === 5 &&
+    args.length === 6 &&
     (typeof args[0] === "number" || args[0] === null) &&
     typeof args[1] === "number" &&
     typeof args[2] === "number" &&
     typeof args[3] === "number" &&
-    typeof args[4] === "boolean"
+    typeof args[4] === "boolean" &&
+    typeof args[5] === "boolean"
   ) {
     state.notes.push({
       hitX: args[1],
@@ -18,7 +21,8 @@ export function luaNote(state: Result, ...args: any[]) {
       big: !!args[4],
       step: { ...state.step },
       luaLine: args[0],
-    } as NoteCommandWithLua);
+      fall: args[5],
+    });
   } else {
     throw "invalid argument for Note()";
   }

--- a/chartFormat/lua/bpm.ts
+++ b/chartFormat/lua/bpm.ts
@@ -2,11 +2,15 @@ import { Level } from "../chart.js";
 import { BPMChange, updateBpmTimeSec } from "../bpm.js";
 import { stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
+import { Chart3 } from "../legacy/chart3.js";
 
 function bpmLuaCommand(bpm: number) {
   return `BPM(${bpm})`;
 }
-export function luaAddBpmChange(chart: Level, change: BPMChange) {
+export function luaAddBpmChange<L extends Level | Chart3>(
+  chart: L,
+  change: BPMChange
+): L | null {
   const insert = findInsertLine(chart, change.step);
   if (insert.luaLine === null) {
     return null;

--- a/chartFormat/lua/bpm.ts
+++ b/chartFormat/lua/bpm.ts
@@ -1,5 +1,5 @@
 import { Level } from "../chart.js";
-import { BPMChange, updateBpmTimeSec } from "../command.js";
+import { BPMChange, updateBpmTimeSec } from "../bpm.js";
 import { stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
 

--- a/chartFormat/lua/edit.ts
+++ b/chartFormat/lua/edit.ts
@@ -1,4 +1,5 @@
 import { Level } from "../chart.js";
+import { Chart3 } from "../legacy/chart3.js";
 import { Level5 } from "../legacy/chart5.js";
 import {
   Step,
@@ -34,7 +35,11 @@ export function findStepFromLua(chart: Level, line: number): Step | null {
 }
 
 // コマンドを挿入
-export function insertLua<L extends Level | Level5>(chart: L, line: number, content: string) {
+export function insertLua<L extends Level | Level5 | Chart3>(
+  chart: L,
+  line: number,
+  content: string
+) {
   chart.lua = chart.lua
     .slice(0, line)
     .concat([content])
@@ -62,7 +67,11 @@ export function insertLua<L extends Level | Level5>(chart: L, line: number, cont
   });
 }
 // コマンドを置き換え
-export function replaceLua<L extends Level | Level5>(chart: L, line: number, content: string) {
+export function replaceLua<L extends Level | Level5 | Chart3>(
+  chart: L,
+  line: number,
+  content: string
+) {
   chart.lua = chart.lua
     .slice(0, line)
     .concat([content])
@@ -118,7 +127,7 @@ function stepLuaCommand(s: Step) {
 // 挿入する行、またはnullを返す。
 // 既存のStepコマンドを分割する必要がある場合は分割し、
 // Stepコマンドを追加する必要がある場合は追加する。
-export function findInsertLine<L extends Level | Level5>(
+export function findInsertLine<L extends Level | Level5 | Chart3>(
   chart: L,
   step: Step
 ): { chart: L; luaLine: number | null } {

--- a/chartFormat/lua/edit.ts
+++ b/chartFormat/lua/edit.ts
@@ -1,4 +1,5 @@
 import { Level } from "../chart.js";
+import { Level5 } from "../legacy/chart5.js";
 import {
   Step,
   stepAdd,
@@ -33,7 +34,7 @@ export function findStepFromLua(chart: Level, line: number): Step | null {
 }
 
 // コマンドを挿入
-export function insertLua(chart: Level, line: number, content: string) {
+export function insertLua<L extends Level | Level5>(chart: L, line: number, content: string) {
   chart.lua = chart.lua
     .slice(0, line)
     .concat([content])
@@ -61,7 +62,7 @@ export function insertLua(chart: Level, line: number, content: string) {
   });
 }
 // コマンドを置き換え
-export function replaceLua(chart: Level, line: number, content: string) {
+export function replaceLua<L extends Level | Level5>(chart: L, line: number, content: string) {
   chart.lua = chart.lua
     .slice(0, line)
     .concat([content])
@@ -117,10 +118,10 @@ function stepLuaCommand(s: Step) {
 // 挿入する行、またはnullを返す。
 // 既存のStepコマンドを分割する必要がある場合は分割し、
 // Stepコマンドを追加する必要がある場合は追加する。
-export function findInsertLine(
-  chart: Level,
+export function findInsertLine<L extends Level | Level5>(
+  chart: L,
   step: Step
-): { chart: Level; luaLine: number | null } {
+): { chart: L; luaLine: number | null } {
   for (let ri = 0; ri < chart.rest.length; ri++) {
     const rest = chart.rest[ri];
     if (stepCmp(rest.begin, step) === 0) {

--- a/chartFormat/lua/exec.ts
+++ b/chartFormat/lua/exec.ts
@@ -1,14 +1,9 @@
 import { LuaFactory } from "wasmoon";
-import {
-  BPMChangeWithLua,
-  NoteCommandWithLua,
-  RestStep,
-  SignatureWithLua,
-  updateBarNum,
-  updateBpmTimeSec,
-} from "../command.js";
+import { NoteCommandWithLua, RestStep } from "../command.js";
 import { Step, stepZero } from "../step.js";
 import { luaAccel, luaBeat, luaBPM, luaNote, luaStep } from "./api.js";
+import { BPMChangeWithLua, updateBpmTimeSec } from "../bpm.js";
+import { SignatureWithLua, updateBarNum } from "../signature.js";
 
 export interface Result {
   stdout: string[];
@@ -79,10 +74,7 @@ export async function luaExec(code: string): Promise<Result> {
           `$1BeatStatic(${ln},$2)$3`
         )
         .replace(/^( *)BPM\(( *[\d.]+ *)\)( *)$/, `$1BPMStatic(${ln},$2)$3`)
-        .replace(
-          /^( *)Accel\(( *[\d.]+ *)\)( *)$/,
-          `$1AccelStatic(${ln},$2)$3`
-        )
+        .replace(/^( *)Accel\(( *[\d.]+ *)\)( *)$/, `$1AccelStatic(${ln},$2)$3`)
     );
     console.log(codeStatic);
     await lua.doString(codeStatic.join("\n"));

--- a/chartFormat/lua/exec.ts
+++ b/chartFormat/lua/exec.ts
@@ -62,7 +62,7 @@ export async function luaExec(code: string): Promise<Result> {
     const codeStatic = code.split("\n").map((lineStr, ln) =>
       lineStr
         .replace(
-          /^( *)Note\(( *-?[\d.]+ *(?:, *-?[\d.]+ *){2}, *(?:true|false) *)\)( *)$/,
+          /^( *)Note\(( *-?[\d.]+ *(?:, *-?[\d.]+ *){2}(?:, *(?:true|false) *){1,2})\)( *)$/,
           `$1NoteStatic(${ln},$2)$3`
         )
         .replace(

--- a/chartFormat/lua/note.ts
+++ b/chartFormat/lua/note.ts
@@ -5,7 +5,17 @@ import { Step, stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
 
 function noteLuaCommand(n: NoteCommand | NoteCommand3) {
-  return `Note(${n.hitX}, ${n.hitVX}, ${n.hitVY}, ${n.big ? "true" : "false"})`;
+  if ("fall" in n) {
+    return (
+      `Note(${n.hitX}, ${n.hitVX}, ${n.hitVY}, ` +
+      `${n.big ? "true" : "false"}, ${n.fall ? "true" : "false"})`
+    );
+  } else {
+    return (
+      `Note(${n.hitX}, ${n.hitVX}, ${n.hitVY}, ` +
+      `${n.big ? "true" : "false"})`
+    );
+  }
 }
 export function luaAddNote<
   L extends Level | Chart3,

--- a/chartFormat/lua/note.ts
+++ b/chartFormat/lua/note.ts
@@ -1,16 +1,16 @@
 import { Level } from "../chart.js";
-import { NoteCommand } from "../command.js";
+import { NoteCommand, NoteCommandWithLua } from "../command.js";
+import { Chart3, NoteCommand3 } from "../legacy/chart3.js";
 import { Step, stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
 
-function noteLuaCommand(n: NoteCommand) {
+function noteLuaCommand(n: NoteCommand | NoteCommand3) {
   return `Note(${n.hitX}, ${n.hitVX}, ${n.hitVY}, ${n.big ? "true" : "false"})`;
 }
-export function luaAddNote(
-  chart: Level,
-  n: NoteCommand,
-  step: Step
-): Level | null {
+export function luaAddNote<
+  L extends Level | Chart3,
+  N extends NoteCommand | NoteCommand3
+>(chart: L, n: N, step: Step): L | null {
   const insert = findInsertLine(chart, step);
   if (insert.luaLine === null) {
     return null;
@@ -20,7 +20,7 @@ export function luaAddNote(
   const newNote = { ...n, step, luaLine: insert.luaLine };
   insertLua(chart, insert.luaLine, noteLuaCommand(n));
 
-  chart.notes.push(newNote);
+  chart.notes.push(newNote as NoteCommandWithLua);
   chart.notes = chart.notes.sort((a, b) => stepCmp(a.step, b.step));
   return chart;
 }

--- a/chartFormat/lua/signature.ts
+++ b/chartFormat/lua/signature.ts
@@ -1,5 +1,6 @@
 import { Level } from "../chart.js";
-import { Signature, updateBarNum } from "../command.js";
+import { Signature, updateBarNum } from "../signature.js";
+import { Level5 } from "../legacy/chart5.js";
 import { stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
 
@@ -22,7 +23,10 @@ function beatLuaCommand(s: Signature) {
       .join(", ")}}, ${num}, ${denom})`;
   }
 }
-export function luaAddBeatChange(chart: Level, change: Signature) {
+export function luaAddBeatChange<L extends Level | Level5>(
+  chart: L,
+  change: Signature
+): L | null {
   const insert = findInsertLine(chart, change.step);
   if (insert.luaLine === null) {
     return null;

--- a/chartFormat/lua/speed.ts
+++ b/chartFormat/lua/speed.ts
@@ -2,11 +2,15 @@ import { Level } from "../chart.js";
 import { BPMChange } from "../bpm.js";
 import { stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
+import { Chart3 } from "../legacy/chart3.js";
 
 function accelLuaCommand(bpm: number) {
   return `Accel(${bpm})`;
 }
-export function luaAddSpeedChange(chart: Level, change: BPMChange) {
+export function luaAddSpeedChange<L extends Level | Chart3>(
+  chart: L,
+  change: BPMChange
+): L | null {
   const insert = findInsertLine(chart, change.step);
   if (insert.luaLine === null) {
     return null;

--- a/chartFormat/lua/speed.ts
+++ b/chartFormat/lua/speed.ts
@@ -1,5 +1,5 @@
 import { Level } from "../chart.js";
-import { BPMChange } from "../command.js";
+import { BPMChange } from "../bpm.js";
 import { stepCmp } from "../step.js";
 import { deleteLua, findInsertLine, insertLua, replaceLua } from "./edit.js";
 

--- a/chartFormat/seq.ts
+++ b/chartFormat/seq.ts
@@ -1,4 +1,3 @@
-import { Chart } from "./chart.js";
 import { getBarLength, Signature, toStepArray } from "./signature.js";
 import { BPMChange } from "./bpm.js";
 import {
@@ -9,13 +8,12 @@ import {
   stepToFloat,
   stepZero,
 } from "./step.js";
+import { displayNote7, DisplayNote7, loadChart7, Note7 } from "./legacy/seq7.js";
 
-export interface ChartSeqData {
-  notes: Note[];
-  bpmChanges: BPMChange[];
-  signature: Signature[];
-  offset: number;
-}
+export type Note = Note7;
+export type DisplayNote = DisplayNote7;
+export const displayNote = displayNote7;
+export const loadChart = loadChart7;
 
 /**
  * 判定線の位置
@@ -35,55 +33,6 @@ export function bigScale(big: boolean) {
 export interface Pos {
   x: number;
   y: number;
-}
-/**
- * ゲーム中で使用する音符の管理
- * id: 通し番号
- * hitTimeSec: 判定時刻
- * appearTimeSec: 画面に表示し始める時刻
- * display: 現在時刻→画面上の位置
- * done: 判定結果 0:まだ 1:Good 2:OK 3:bad 4:miss
- */
-export interface Note {
-  id: number;
-  big: boolean;
-  bigDone: boolean;
-  hitTimeSec: number;
-  appearTimeSec: number;
-  targetX: number;
-  vx: number;
-  vy: number;
-  ay: number;
-  display: DisplayParam[];
-  hitPos?: Pos;
-  done: number;
-  baseScore?: number;
-  chainBonus?: number;
-  bigBonus?: number;
-  chain?: number;
-}
-interface DisplayParam {
-  // 時刻(判定時刻 - 秒数)
-  timeSecBefore: number;
-  // u = u0 + du t
-  u0: number;
-  du: number;
-}
-
-/**
- * 画面上でその瞬間に表示する音符の管理
- * (画面の状態をstateにするため)
- * 時刻の情報を持たない
- */
-export interface DisplayNote {
-  id: number;
-  pos: Pos;
-  done: number;
-  bigDone: boolean;
-  baseScore?: number;
-  chainBonus?: number;
-  bigBonus?: number;
-  chain?: number;
 }
 
 function defaultBpmChange(): BPMChange {
@@ -212,138 +161,4 @@ export function findBpmIndexFromStep(
     return 0;
   }
   return targetBpmIndex;
-}
-/**
- * chartを読み込む
- */
-export function loadChart(chart: Chart, levelIndex: number): ChartSeqData {
-  const notes: Note[] = [];
-  const level = chart.levels.at(levelIndex);
-  if (!level) {
-    return { notes: [], bpmChanges: [], signature: [], offset: chart.offset };
-  }
-  for (let id = 0; id < level.notes.length; id++) {
-    const c = level.notes[id];
-
-    // hitの時刻
-    const hitTimeSec: number = getTimeSec(level.bpmChanges, c.step);
-
-    const display: DisplayParam[] = [];
-    let tBegin = hitTimeSec;
-    // noteCommandの座標系 (-5<=x<=5) から
-    //  displayの座標系に変換するのもここでやる
-    const targetX = (c.hitX + 5) / 10;
-    const targetY = 0;
-    const vx = c.hitVX / 4;
-    const vy = c.hitVY / 4;
-    const ay = 1 / 4;
-    let u = 0;
-    // u(t) = ∫t→tBegin, dt * speed / 120
-    // x(t) = targetX + vx * u(t)
-    // y(t) = targetY + vy * u(t) - (ay * u(t)^2) / 2
-
-    let uAppear: number;
-    if (c.fall) {
-      // dy/du = 0 or y(t) = 1.5 or x(t) = 2 or x(t) = -0.5
-      const uTop = vy / ay;
-      const uAppearY =
-        (vy - Math.sqrt(vy * vy + 2 * ay * (targetY - 1.5))) / ay;
-      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
-      uAppear = Math.min(uAppearX, isNaN(uAppearY) ? uTop : uAppearY);
-    } else {
-      // y(t) = -0.5 or x(t) = 2 or x(t) = -0.5
-      const uAppearY =
-        (vy + Math.sqrt(vy * vy + 2 * ay * (targetY - -0.5))) / ay;
-      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
-      uAppear = Math.max(uAppearX, uAppearY);
-    }
-
-    let appearTimeSec = hitTimeSec;
-    for (let ti = level.speedChanges.length - 1; ti >= 0; ti--) {
-      const ts = level.speedChanges[ti];
-      if (ts.timeSec >= hitTimeSec && ti >= 1) {
-        continue;
-      }
-      const tEnd = ts.timeSec;
-      const du = ts.bpm / 120;
-      // tEnd <= 時刻 <= tBegin の間、
-      //  t = tBegin - 時刻  > 0
-      //  u = u(tBegin) + du * t
-      display.push({
-        timeSecBefore: hitTimeSec - tBegin,
-        u0: u,
-        du: du,
-      });
-
-      const uEnd = u + du * (tBegin - tEnd);
-
-      if (u < uAppear && uEnd > uAppear) {
-        const tAppear = (uAppear - u) / du;
-        appearTimeSec = tBegin - tAppear;
-      }
-      tBegin = tEnd;
-      u = uEnd;
-    }
-    notes.push({
-      id,
-      big: c.big,
-      hitTimeSec,
-      appearTimeSec,
-      done: 0,
-      bigDone: false,
-      display,
-      targetX,
-      vx,
-      vy,
-      ay,
-    });
-  }
-  return {
-    offset: chart.offset,
-    signature: level.signature,
-    bpmChanges: level.bpmChanges,
-    notes,
-  };
-}
-export function displayNote(note: Note, timeSec: number): DisplayNote | null {
-  if (timeSec - note.hitTimeSec > 0.5) {
-    return null;
-  } else if (note.done >= 1 && note.done <= 3) {
-    return {
-      id: note.id,
-      pos: note.hitPos || { x: -1, y: -1 },
-      done: note.done,
-      bigDone: note.bigDone,
-      chain: note.chain,
-      baseScore: note.baseScore,
-      chainBonus: note.chainBonus,
-      bigBonus: note.bigBonus,
-    };
-  } else if (timeSec < note.appearTimeSec) {
-    return null;
-  } else {
-    let di = 0;
-    for (; di + 1 < note.display.length; di++) {
-      if (timeSec > note.hitTimeSec - note.display[di + 1].timeSecBefore) {
-        break;
-      }
-    }
-    const dispParam = note.display[di];
-    const { u0, du } = dispParam;
-    const t = note.hitTimeSec - dispParam.timeSecBefore - timeSec;
-    const u = u0 + du * t;
-    return {
-      id: note.id,
-      pos: {
-        x: note.targetX + note.vx * u,
-        y: note.vy * u - (note.ay * u * u) / 2,
-      },
-      done: note.done,
-      bigDone: note.bigDone,
-      chain: note.chain,
-      baseScore: note.baseScore,
-      chainBonus: note.chainBonus,
-      bigBonus: note.bigBonus,
-    };
-  }
 }

--- a/chartFormat/seq.ts
+++ b/chartFormat/seq.ts
@@ -1,6 +1,14 @@
 import { Chart } from "./chart.js";
-import { BPMChange, getBarLength, Signature, toStepArray } from "./command.js";
-import { Step, stepAdd, stepCmp, stepSub, stepToFloat, stepZero } from "./step.js";
+import { getBarLength, Signature, toStepArray } from "./signature.js";
+import { BPMChange } from "./bpm.js";
+import {
+  Step,
+  stepAdd,
+  stepCmp,
+  stepSub,
+  stepToFloat,
+  stepZero,
+} from "./step.js";
 
 export interface ChartSeqData {
   notes: Note[];

--- a/chartFormat/signature.ts
+++ b/chartFormat/signature.ts
@@ -1,0 +1,99 @@
+import { Signature5, SignatureWithLua5 } from "./legacy/chart5.js";
+import {
+  Step,
+  stepAdd,
+  stepCmp,
+  stepSimplify,
+  stepSub,
+  stepZero,
+  validateStep,
+} from "./step.js";
+
+/**
+ * 例: 15/8 = 4/4 + 7/8 の場合
+ * (4分, 4分, 4分, 4分) + (4分, 4分, 4分, 8分)
+ * → [[4, 4, 4, 4], [4, 4, 4, 8]]
+ * 4分、8分、16分の和で表せる拍子のみしか対応しない。
+ *
+ * step: 変化位置
+ * offset: n拍目からカウントを始める
+ *  (step - offset がこのSignatureの1拍目になる)
+ *
+ * barNum: このSignatureが始まる時点の小節番号
+ *
+ */
+export type Signature = Signature5;
+export type SignatureWithLua = SignatureWithLua5;
+
+export function validateSignature(s: SignatureWithLua) {
+  validateStep(s.step);
+  validateStep(s.offset);
+  if (!Array.isArray(s.bars)) throw "signature.bars is invalid";
+  s.bars.forEach((b) => {
+    if (!Array.isArray(b)) throw "signature.bars is invalid";
+    b.forEach((bs) => {
+      if (bs !== 4 && bs !== 8 && bs !== 16) throw "signature.bars is invalid";
+    });
+  });
+  if (typeof s.luaLine !== "number" && s.luaLine !== null)
+    throw "signature.luaLine is invalid";
+}
+export function getBarLength(s: Signature): Step[] {
+  const barLength = toStepArray(s).map((b) =>
+    b.reduce((len, bs) => stepAdd(len, bs), stepZero())
+  );
+  barLength.forEach((len) => {
+    if (stepCmp(len, stepZero()) <= 0) {
+      throw new Error("Invalid signature (empty bar): " + JSON.stringify(s));
+    }
+  });
+  return barLength;
+}
+export function toStepArray(s: Signature): Step[][] {
+  return s.bars.map((b) =>
+    b.map((bs) =>
+      stepSimplify({ fourth: 0, numerator: 1, denominator: bs / 4 })
+    )
+  );
+}
+export function barFromLength(len: Step): (4 | 8 | 16)[] {
+  const newBar: (4 | 8 | 16)[] = [];
+  for (const d of [4, 8, 16]) {
+    while (
+      stepCmp(len, {
+        fourth: 0,
+        numerator: 1,
+        denominator: d / 4,
+      }) >= 0
+    ) {
+      len = stepSub(len, {
+        fourth: 0,
+        numerator: 1,
+        denominator: d / 4,
+      });
+      newBar.push(d as 4 | 8 | 16);
+    }
+  }
+  return newBar;
+}
+export function updateBarNum(signatures: Signature[]) {
+  let barNum = 0;
+  signatures[0].barNum = 0;
+  for (let si = 1; si < signatures.length; si++) {
+    let prevBarBegin = stepSub(
+      signatures[si - 1].step,
+      signatures[si - 1].offset
+    );
+    const prevBarLength = getBarLength(signatures[si - 1]);
+    let bi = 0;
+    while (stepCmp(prevBarBegin, signatures[si].step) < 0) {
+      barNum += 1;
+      prevBarBegin = stepAdd(
+        prevBarBegin,
+        prevBarLength[bi % prevBarLength.length]
+      );
+      bi += 1;
+    }
+    signatures[si].barNum = barNum;
+  }
+}

--- a/route/api/chart.ts
+++ b/route/api/chart.ts
@@ -7,13 +7,9 @@ import {
 } from "../../chartFormat/chart.js";
 import { gzip, gunzip } from "node:zlib";
 import { promisify } from "node:util";
-import {
-  BPMChangeWithLua,
-  NoteCommandWithLua,
-  RestStep,
-  SignatureWithLua,
-} from "../../chartFormat/command.js";
 import { Binary, Db } from "mongodb";
+import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "../../chartFormat/legacy/chart3.js";
+import { SignatureWithLua5 } from "../../chartFormat/legacy/chart5.js";
 
 /**
  * pをnullにするとパスワードのチェックを行わない。
@@ -95,11 +91,11 @@ export interface ChartEntryCompressed {
   }[];
 }
 export interface ChartLevelCore {
-  notes: NoteCommandWithLua[];
-  rest: RestStep[];
-  bpmChanges: BPMChangeWithLua[];
-  speedChanges: BPMChangeWithLua[];
-  signature: SignatureWithLua[];
+  notes: NoteCommandWithLua3[];
+  rest: RestStep3[];
+  bpmChanges: BPMChangeWithLua3[];
+  speedChanges: BPMChangeWithLua3[];
+  signature: SignatureWithLua5[];
   lua: string[];
 }
 export type ChartEntry = ChartEntryCompressed & { levels: ChartLevelCore[] };

--- a/route/api/chart.ts
+++ b/route/api/chart.ts
@@ -3,13 +3,21 @@ import {
   ChartBrief,
   createBrief,
   hashPasswd,
-  validateChart,
 } from "../../chartFormat/chart.js";
 import { gzip, gunzip } from "node:zlib";
 import { promisify } from "node:util";
 import { Binary, Db } from "mongodb";
-import { BPMChangeWithLua3, NoteCommandWithLua3, RestStep3 } from "../../chartFormat/legacy/chart3.js";
-import { SignatureWithLua5 } from "../../chartFormat/legacy/chart5.js";
+import {
+  BPMChangeWithLua3,
+  NoteCommandWithLua3,
+  RestStep3,
+} from "../../chartFormat/legacy/chart3.js";
+import { Chart5, SignatureWithLua5 } from "../../chartFormat/legacy/chart5.js";
+import {
+  Chart7,
+  NoteCommandWithLua7,
+} from "../../chartFormat/legacy/chart7.js";
+import { Chart6 } from "../../chartFormat/legacy/chart6.js";
 
 /**
  * pをnullにするとパスワードのチェックを行わない。
@@ -21,7 +29,7 @@ export async function getChartEntry(
 ): Promise<{
   res?: { message: string; status: 401 | 404 | 500 };
   entry?: ChartEntry;
-  chart?: Chart;
+  chart?: Chart5 | Chart6 | Chart7;
 }> {
   const entryCompressed = (await db
     .collection("chart")
@@ -36,11 +44,10 @@ export async function getChartEntry(
   }
 
   let entry: ChartEntry;
-  let chart: Chart;
+  let chart: Chart5 | Chart6 | Chart7;
   try {
     entry = await unzipEntry(entryCompressed);
     chart = entryToChart(entry);
-    chart = await validateChart(chart);
   } catch {
     return {
       res: { message: "invalid chart data", status: 500 },
@@ -69,7 +76,7 @@ export interface ChartEntryCompressed {
   levelsCompressed: Binary | null;
   deleted: boolean;
   published: boolean;
-  ver: 6;
+  ver: 5 | 6 | 7;
   offset: number;
   ytId: string;
   title: string;
@@ -90,7 +97,7 @@ export interface ChartEntryCompressed {
     unlisted: boolean;
   }[];
 }
-export interface ChartLevelCore {
+export interface ChartLevelCore5 {
   notes: NoteCommandWithLua3[];
   rest: RestStep3[];
   bpmChanges: BPMChangeWithLua3[];
@@ -98,7 +105,20 @@ export interface ChartLevelCore {
   signature: SignatureWithLua5[];
   lua: string[];
 }
-export type ChartEntry = ChartEntryCompressed & { levels: ChartLevelCore[] };
+export interface ChartLevelCore7 {
+  notes: NoteCommandWithLua7[];
+  rest: RestStep3[];
+  bpmChanges: BPMChangeWithLua3[];
+  speedChanges: BPMChangeWithLua3[];
+  signature: SignatureWithLua5[];
+  lua: string[];
+}
+
+export type ChartEntry = ChartEntryCompressed &
+  (
+    | { ver: 5 | 6; levels: ChartLevelCore5[] }
+    | { ver: 7; levels: ChartLevelCore7[] }
+  );
 
 export async function unzipEntry(
   entry: ChartEntryCompressed
@@ -108,14 +128,12 @@ export async function unzipEntry(
   }
   const decodedChart = entry.levelsCompressed.buffer;
   const decompressedChart = await promisify(gunzip)(decodedChart);
-  const levels: ChartLevelCore[] = JSON.parse(
-    new TextDecoder().decode(decompressedChart)
-  );
+  const levels = JSON.parse(new TextDecoder().decode(decompressedChart));
   return {
     ...entry,
     levelsCompressed: null,
     levels,
-  };
+  } as ChartEntry;
 }
 
 export async function zipEntry(
@@ -139,31 +157,6 @@ export async function zipEntry(
     playCount: entry.playCount,
     levelBrief: entry.levelBrief,
     levelsCompressed: new Binary(levelsCompressed),
-  };
-}
-
-export function entryToChart(entry: ChartEntry): Chart {
-  return {
-    falling: "nikochan",
-    ver: entry.ver,
-    published: entry.published,
-    levels: entry.levels.map((level, i) => ({
-      name: entry.levelBrief.at(i)?.name || "",
-      type: entry.levelBrief.at(i)?.type || "",
-      unlisted: entry.levelBrief.at(i)?.unlisted || false,
-      notes: level.notes,
-      rest: level.rest,
-      bpmChanges: level.bpmChanges,
-      speedChanges: level.speedChanges,
-      signature: level.signature,
-      lua: level.lua,
-    })),
-    offset: entry.offset,
-    ytId: entry.ytId,
-    title: entry.title,
-    composer: entry.composer,
-    chartCreator: entry.chartCreator,
-    editPasswd: entry.editPasswd,
   };
 }
 
@@ -199,7 +192,6 @@ export async function chartToEntry(
     levelBrief: chartBrief.levels,
   };
 }
-
 export function entryToBrief(entry: ChartEntryCompressed): ChartBrief {
   return {
     ytId: entry.ytId,
@@ -211,4 +203,79 @@ export function entryToBrief(entry: ChartEntryCompressed): ChartBrief {
     playCount: entry.playCount,
     published: entry.published,
   };
+}
+
+export function entryToChart(entry: ChartEntry): Chart5 | Chart6 | Chart7 {
+  switch (entry.ver) {
+    case 5:
+      return {
+        falling: "nikochan",
+        ver: entry.ver,
+        levels: entry.levels.map((level, i) => ({
+          name: entry.levelBrief.at(i)?.name || "",
+          hash: entry.levelBrief.at(i)?.hash || "",
+          type: entry.levelBrief.at(i)?.type || "",
+          unlisted: entry.levelBrief.at(i)?.unlisted || false,
+          notes: level.notes,
+          rest: level.rest,
+          bpmChanges: level.bpmChanges,
+          speedChanges: level.speedChanges,
+          signature: level.signature,
+          lua: level.lua,
+        })),
+        offset: entry.offset,
+        ytId: entry.ytId,
+        title: entry.title,
+        composer: entry.composer,
+        chartCreator: entry.chartCreator,
+        editPasswd: entry.editPasswd,
+        updatedAt: entry.updatedAt,
+      };
+    case 6:
+      return {
+        falling: "nikochan",
+        ver: entry.ver,
+        published: entry.published,
+        levels: entry.levels.map((level, i) => ({
+          name: entry.levelBrief.at(i)?.name || "",
+          type: entry.levelBrief.at(i)?.type || "",
+          unlisted: entry.levelBrief.at(i)?.unlisted || false,
+          notes: level.notes,
+          rest: level.rest,
+          bpmChanges: level.bpmChanges,
+          speedChanges: level.speedChanges,
+          signature: level.signature,
+          lua: level.lua,
+        })),
+        offset: entry.offset,
+        ytId: entry.ytId,
+        title: entry.title,
+        composer: entry.composer,
+        chartCreator: entry.chartCreator,
+        editPasswd: entry.editPasswd,
+      };
+    case 7:
+      return {
+        falling: "nikochan",
+        ver: entry.ver,
+        published: entry.published,
+        levels: entry.levels.map((level, i) => ({
+          name: entry.levelBrief.at(i)?.name || "",
+          type: entry.levelBrief.at(i)?.type || "",
+          unlisted: entry.levelBrief.at(i)?.unlisted || false,
+          notes: level.notes,
+          rest: level.rest,
+          bpmChanges: level.bpmChanges,
+          speedChanges: level.speedChanges,
+          signature: level.signature,
+          lua: level.lua,
+        })),
+        offset: entry.offset,
+        ytId: entry.ytId,
+        title: entry.title,
+        composer: entry.composer,
+        chartCreator: entry.chartCreator,
+        editPasswd: entry.editPasswd,
+      };
+  }
 }

--- a/route/api/chartFile.ts
+++ b/route/api/chartFile.ts
@@ -25,11 +25,6 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
       if (!chart) {
         return c.json({ message: res?.message }, res?.status || 500);
       }
-      try {
-        chart = await validateChart(chart);
-      } catch {
-        return c.json({ message: "invalid chart data" }, 500);
-      }
       return c.body(new Blob([msgpack.serialize(chart)]).stream());
     } catch (e) {
       console.error(e);

--- a/route/api/seqFile.ts
+++ b/route/api/seqFile.ts
@@ -1,11 +1,12 @@
 import msgpack from "@ygoe/msgpack";
-import { validateChart } from "../../chartFormat/chart.js";
-import { loadChart } from "../../chartFormat/seq.js";
 import { MongoClient } from "mongodb";
 import { getChartEntry } from "./chart.js";
 import { Bindings } from "../env.js";
 import { Hono } from "hono";
 import { env } from "hono/adapter";
+import { convertTo6 } from "../../chartFormat/legacy/chart6.js";
+import { ChartSeqData6, loadChart6 } from "../../chartFormat/legacy/seq6.js";
+import { ChartSeqData7, loadChart7 } from "../../chartFormat/legacy/seq7.js";
 
 const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   "/:cid/:lvIndex",
@@ -22,14 +23,21 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       }
 
       if (!chart.levels.at(lvIndex)) {
-        return c.json(
-          {
-            message: "Level not found",
-          },
-          404
-        );
+        return c.json({ message: "Level not found" }, 404);
       }
-      const seq = loadChart(chart, lvIndex);
+
+      let seq: ChartSeqData6 | ChartSeqData7;
+      switch (chart.ver) {
+        case 5:
+          seq = loadChart6(await convertTo6(chart), lvIndex);
+          break;
+        case 6:
+          seq = loadChart6(chart, lvIndex);
+          break;
+        case 7:
+          seq = loadChart7(chart, lvIndex);
+          break;
+      }
 
       await db
         .collection("chart")

--- a/route/api/seqFile.ts
+++ b/route/api/seqFile.ts
@@ -21,11 +21,6 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         return c.json({ message: res?.message }, res?.status || 500);
       }
 
-      try {
-        chart = await validateChart(chart);
-      } catch {
-        return c.json({ message: "invalid chart data" }, 500);
-      }
       if (!chart.levels.at(lvIndex)) {
         return c.json(
           {


### PR DESCRIPTION
close #192
* ChartFormatのバージョン管理を改善
  * 従来のコードは例えばChart1〜2で共通で用いられるNoteCommandはNoteCommand2, Chart3〜6で用いられるNoteCommandはNoteCommand6にするようになっていたが、これだとChart7を書くときにChart3〜6を修正する必要があった
  * 今後は最も古いChartバージョンのファイルにいっしょに置く (NoteCommand1をChart1,2で使い、NoteCommand3をChart3〜6で使い、NoteCommand7を現行NoteCommandとしてエイリアス)
  * lua周りで`Chart3|Level5|Level`を受け取る関数をジェネリクスにした
  * /api/chartFile はvalidateChart()をせずデータベースに保存されている譜面データ(ver5,6,7)をそのまま返すようにした
* seqのバージョン管理
  * loadChart,displayNoteはver6と7両方の関数を残し、playページは両対応、editページは最新バージョンのみ対応
  * /api/seqFile はChartSeqData6または7を返す
* dev環境でのテスト用に /play に直接cid指定で飛べるようにした

#236 のあとにマージ！