### PR TITLE
手動でworkflowを動かしてもPRのマージ条件には入らないらしい

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,6 @@ name: Node.js CI
 on:
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch:
     
 jobs:
   test:


### PR DESCRIPTION
#234 でlockfileを更新してpushするciを作ったが、github actionがpushしたコミットに対してはCIが自動で走らないので、手動でdispatchすればいいと思ったが、意味なかった
