### PR TITLE
譜面を新規作成したときのパスワード周りの処理を修正

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 7.2 - 2025/02/11 [#245](https://github.com/na-trium-144/falling-nikochan/pull/245)
+
+* 譜面を新規作成したときのパスワード周りの処理を修正
+
 ## ver. 7.1 - 2025/02/11 [#244](https://github.com/na-trium-144/falling-nikochan/pull/244)
 
 * /api にmiddlewareが適用されないようにした

--- a/app/[locale]/edit/clientPage.tsx
+++ b/app/[locale]/edit/clientPage.tsx
@@ -251,6 +251,8 @@ export default function EditAuth({ locale }: { locale: string }) {
         convertedFrom={convertedFrom}
         setConvertedFrom={setConvertedFrom}
         locale={locale}
+        editPasswdInitial={editPasswd}
+        savePasswdInitial={savePasswd}
       />
     );
   }
@@ -266,6 +268,8 @@ interface Props {
   convertedFrom: number;
   setConvertedFrom: (v: number) => void;
   locale: string;
+  editPasswdInitial?: string;
+  savePasswdInitial: boolean;
 }
 function Page(props: Props) {
   const {
@@ -288,6 +292,14 @@ function Page(props: Props) {
   const [sessionId, setSessionId] = useState<number>();
   const [sessionData, setSessionData] = useState<SessionData>();
   const [fileSize, setFileSize] = useState<number>(0);
+  const [savePasswd, setSavePasswd] = useState<boolean>(
+    props.savePasswdInitial
+  );
+  // パスワードの変更前の値を保存
+  // post後に chart.editPasswd で上書き
+  const [editPasswdPrev, setEditPasswdPrev] = useState<string>(
+    props.editPasswdInitial || ""
+  );
 
   const changeChart = (chart: Chart) => {
     setHasChange(true);
@@ -1034,7 +1046,9 @@ function Page(props: Props) {
                   String(Math.floor(Number(v) / 4) * 4) === v
                 }
               />
-              <HelpIcon className="self-center">{t.rich("stepUnitHelp", {br: () => <br/>})}</HelpIcon>
+              <HelpIcon className="self-center">
+                {t.rich("stepUnitHelp", { br: () => <br /> })}
+              </HelpIcon>
               <div className="flex-1" />
               <span className="mr-1">{t("zoom")}</span>
               <Button
@@ -1088,6 +1102,10 @@ function Page(props: Props) {
                   setHasChange={setHasChange}
                   currentLevelIndex={currentLevelIndex}
                   locale={locale}
+                  editPasswdPrev={editPasswdPrev}
+                  setEditPasswdPrev={setEditPasswdPrev}
+                  savePasswd={savePasswd}
+                  setSavePasswd={setSavePasswd}
                 />
               ) : tab === 1 ? (
                 <TimingTab

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falling-nikochan",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falling-nikochan",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@icon-park/react": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falling-nikochan",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
* metaタブの「パスワードを保存」のチェックが勝手に外れるバグを修正
* 「パスワードを保存」のチェックがないとき<del>アプリが本当に今のパスワードを忘れて</del>上書き保存ができなくなるバグを修正
* /ja/edit?cid=new から /edit?cid=123456 へリダイレクトしてしまう(localeがない)のを修正