### PR TITLE
負の速度に関する計算を修正

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,9 @@
+## ver. 8.3 - 2025/02/23 [#296](https://github.com/na-trium-144/falling-nikochan/pull/296)
+
+* 負の速度を編集できないバグの修正
+* vyまたはspeedが負のときの音符出現位置の計算を修正
+* noteタブでもvyに負の値を指定可能に
+
 ## ver. 8.1 - 2025/02/22 [#293](https://github.com/na-trium-144/falling-nikochan/pull/293)
 
 * bpmを変更してspeedも同時に変更される際にluaExecが2回連続で実行されてバグっていたのを修正

--- a/app/[locale]/edit/noteTab.tsx
+++ b/app/[locale]/edit/noteTab.tsx
@@ -222,9 +222,7 @@ function NoteEdit(props: Props) {
                   updateValue={(v) =>
                     props.updateNote({ ...n, hitVY: Number(v) })
                   }
-                  isValid={(v) =>
-                    v !== "" && !isNaN(Number(v)) && Number(v) >= 0
-                  }
+                  isValid={(v) => v !== "" && !isNaN(Number(v))}
                   disabled={!noteEditable}
                 />
               </td>

--- a/chartFormat/legacy/seq7.ts
+++ b/chartFormat/legacy/seq7.ts
@@ -1,7 +1,6 @@
-import { getTimeSec, Pos } from "../seq.js";
+import { Pos } from "../seq.js";
 import { BPMChange1 } from "./chart1.js";
 import { Signature5 } from "./chart5.js";
-import { Chart7 } from "./chart7.js";
 
 export interface ChartSeqData7 {
   ver: 7;
@@ -62,112 +61,6 @@ export interface DisplayNote7 {
   chain?: number;
 }
 
-/**
- * chartを読み込む
- */
-export function loadChart7(chart: Chart7, levelIndex: number): ChartSeqData7 {
-  const notes: Note7[] = [];
-  const level = chart.levels.at(levelIndex);
-  if (!level) {
-    return {
-      ver: 7,
-      notes: [],
-      bpmChanges: [],
-      signature: [],
-      offset: chart.offset,
-    };
-  }
-  for (let id = 0; id < level.notes.length; id++) {
-    const c = level.notes[id];
-
-    // hitの時刻
-    const hitTimeSec: number = getTimeSec(level.bpmChanges, c.step);
-
-    const display: DisplayParam7[] = [];
-    let tBegin = hitTimeSec;
-    // noteCommandの座標系 (-5<=x<=5) から
-    //  displayの座標系に変換するのもここでやる
-    const targetX = (c.hitX + 5) / 10;
-    const targetY = 0;
-    const vx = c.hitVX / 4;
-    const vy = c.hitVY / 4;
-    const ay = 1 / 4;
-    let u = 0;
-    // u(t) = ∫t→tBegin, dt * speed / 120
-    // x(t) = targetX + vx * u(t)
-    // y(t) = targetY + vy * u(t) - (ay * u(t)^2) / 2
-
-    let uAppear: number;
-    if (c.fall) {
-      // dy/du = 0 or y(t) = 1.5 or x(t) = 2 or x(t) = -0.5
-      const uTop = vy / ay;
-      const uAppearY =
-        (vy - Math.sqrt(vy * vy + 2 * ay * (targetY - 1.5))) / ay;
-      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
-      uAppear = Math.min(uAppearX, isNaN(uAppearY) ? uTop : uAppearY);
-    } else {
-      // y(t) = -0.5 or x(t) = 2 or x(t) = -0.5
-      const uAppearY =
-        (vy + Math.sqrt(vy * vy + 2 * ay * (targetY - -0.5))) / ay;
-      const uAppearX = Math.max((2 - targetX) / vx, (-0.5 - targetX) / vx);
-      uAppear = Math.max(uAppearX, uAppearY);
-    }
-
-    let appearTimeSec: number | null = null;
-    for (let ti = level.speedChanges.length - 1; ti >= 0; ti--) {
-      const ts = level.speedChanges[ti];
-      if (ts.timeSec >= hitTimeSec && ti >= 1) {
-        continue;
-      }
-      const tEnd = ts.timeSec;
-      const du = ts.bpm / 120;
-      // tEnd <= 時刻 <= tBegin の間、
-      //  t = tBegin - 時刻  > 0
-      //  u = u(tBegin) + du * t
-      display.push({
-        timeSecBefore: hitTimeSec - tBegin,
-        u0: u,
-        du: du,
-      });
-
-      const uEnd = u + du * (tBegin - tEnd);
-
-      if ((u <= uAppear && uAppear <= uEnd) || (u <= uAppear && ti === 0)) {
-        const tAppear = (uAppear - u) / du;
-        appearTimeSec = tBegin - tAppear;
-      }
-      tBegin = tEnd;
-      u = uEnd;
-    }
-    if (appearTimeSec === null) {
-      console.error("speedChanges:", level.speedChanges);
-      console.error("hitTimeSec:", hitTimeSec);
-      console.error("uAppear:", uAppear);
-      throw new Error("Failed to calculate appearTimeSec");
-    }
-    notes.push({
-      ver: 7,
-      id,
-      big: c.big,
-      hitTimeSec,
-      appearTimeSec,
-      done: 0,
-      bigDone: false,
-      display,
-      targetX,
-      vx,
-      vy,
-      ay,
-    });
-  }
-  return {
-    ver: 7,
-    offset: chart.offset,
-    signature: level.signature,
-    bpmChanges: level.bpmChanges,
-    notes,
-  };
-}
 export function displayNote7(
   note: Note7,
   timeSec: number

--- a/chartFormat/lua/exec.ts
+++ b/chartFormat/lua/exec.ts
@@ -75,7 +75,7 @@ export async function luaExec(
           `$1BeatStatic(${ln},$2)$3`
         )
         .replace(/^( *)BPM\(( *[\d.]+ *)\)( *)$/, `$1BPMStatic(${ln},$2)$3`)
-        .replace(/^( *)Accel\(( *[\d.]+ *)\)( *)$/, `$1AccelStatic(${ln},$2)$3`)
+        .replace(/^( *)Accel\(( *-?[\d.]+ *)\)( *)$/, `$1AccelStatic(${ln},$2)$3`)
     );
     console.log(codeStatic);
     await lua.doString(codeStatic.join("\n"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falling-nikochan",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falling-nikochan",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@icon-park/react": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falling-nikochan",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- 負の速度を編集できないバグの修正 (fix #295)
- vyまたはspeedが負のときの音符出現位置の計算を修正
- noteタブでもvyに負の値を指定可能に
- LoadChart7削除(もう使っていないので)