### PR TITLE
shareページのタイトルをエスケープ

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 8.5 - 2025/02/24 [#301](https://github.com/na-trium-144/falling-nikochan/pull/301)
+
+* XSS対策のため /share ページで楽曲タイトルをエスケープする処理を追加
+
 ## ver. 8.4 - 2025/02/23 [#300](https://github.com/na-trium-144/falling-nikochan/pull/300)
 
 * フォントをCDNから読み込むのではなく、npmでインストールしてバンドルするようにした

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falling-nikochan",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falling-nikochan",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.1.1",
         "@fontsource/merriweather": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falling-nikochan",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
XSS対策のため。エスケープする必要のある文字を列挙するのは自信がなかったので、すべての文字をエスケープすることにした