### PR TITLE
apiのtestを書く

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,8 +17,7 @@ jobs:
     - name: Abort if lockfile changed
       run: '[ -z "$(git status -s)" ]'
 
-  test: # uses node
-    needs: [check-lockfile]
+  lint: # uses node
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,10 +30,21 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
-    # - run: npm run test
+
+  test: # uses bun
+    runs-on: ubuntu-latest
+    env:
+      MONGODB_URI: mongodb://localhost:27017
+      API_ENV: development
+      # API_NO_RATELIMIT: "1"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: oven-sh/setup-bun@v2
+    - run: bun i --frozen-lock
+    - run: bun mongo-docker
+    - run: bun route:test
 
   vercel-build: # uses bun
-    needs: [check-lockfile]
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -54,7 +64,7 @@ jobs:
         include-hidden-files: true
 
   vercel-deploy:
-    needs: [vercel-build]
+    needs: [check-lockfile, lint, test, vercel-build]
     runs-on: ubuntu-latest
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,4 +1,12 @@
-## ver. 8.16 - 2025/03/06 [#356]
+## ver. 8.18 - 2025/03/08 [#364](https://github.com/na-trium-144/falling-nikochan/pull/364)
+
+* apiのテストを書いた `bun route:test`
+* messagepackを返すAPIでContent-Typeを設定するようにした
+* cidを受け取るAPIでcidが不正な場合400を返すようにした
+* API_ENV とは別に /api/newChartFile のratelimitの有無を切り替える API_NO_RATELIMIT 環境変数を追加
+* ciにテストの実行を追加、さらにjob間の依存関係を少し変更し効率化
+
+## ver. 8.16 - 2025/03/06 [#356](https://github.com/na-trium-144/falling-nikochan/pull/356)
 
 * play画面のloading表示の遷移、エラー表示処理を改善
 * resultがすべて表示されるまでresetもexitもできないようにした
@@ -10,7 +18,7 @@
     * 今はcloudflareのキャッシュを通しているので問題ない
     * 一応環境変数でオフのままにもできるようにもした
 
-## ver. 8.15 - 2025/03/04 [#352]
+## ver. 8.15 - 2025/03/04 [#352](https://github.com/na-trium-144/falling-nikochan/pull/352)
 
 * /main/playから/shareページへの遷移をmodal表示に変更
     * ブラウザのhistory遷移にも反応してmodalを開閉するようにした

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ YouTube: [@nikochan144](http://www.youtube.com/@nikochan144)
     MONGODB_URI="mongodb://localhost:27017"
     BACKEND_PREFIX="http://localhost:8787"
     API_ENV="development"
+    API_NO_RATELIMIT="1"
     ```
 * Install dependencies
     ```sh
@@ -77,6 +78,7 @@ See also [chart/src/chart.ts](chart/src/chart.ts) for relations among the chart 
     * Response
         * [ChartBrief](chart/src/chart.ts) as JSON with status code 200
         * `{message?: string}` as JSON with status code
+            * 400 (invalid cid),
             * 404 (cid not found),
             * or 500 (other error)
 * `GET /api/latest` - Get the list of 25 latest updated charts.
@@ -89,6 +91,7 @@ See also [chart/src/chart.ts](chart/src/chart.ts) for relations among the chart 
     * Response
         * [Level6Play](chart/src/legacy/chart6.ts) or [Level8Play](chart/src/legacy/chart8.ts) serialized with MessagePack with status code 200
         * `{message?: string}` as JSON with status code
+            * 400 (invalid cid),
             * 404 (cid or level not found),
             * or 500 (other error)
 * `GET /api/hashPasswd/:cid` - Get the hash of the password for the chart.
@@ -110,6 +113,7 @@ See also [chart/src/chart.ts](chart/src/chart.ts) for relations among the chart 
     * Response
         * [Chart4](chart/src/legacy/chart4.ts), [Chart5](chart/src/legacy/chart5.ts), [Chart6](chart/src/legacy/chart6.ts), [Chart7](chart/src/legacy/chart7.ts) or [Chart8Edit](chart/src/legacy/chart8.ts) serialized with MessagePack with status code 200
         * `{message?: string}` as JSON with status code
+            * 400 (invalid cid),
             * 401 (wrong passwd),
             * 404 (cid not found),
             * or 500 (other error)
@@ -120,6 +124,7 @@ See also [chart/src/chart.ts](chart/src/chart.ts) for relations among the chart 
     * Response
         * empty response with status code 204
         * `{message?: string}` as JSON with status code
+            * 400 (invalid cid),
             * 401 (wrong passwd),
             * 404 (cid not found),
             * 409 (chart data is Chart7 or older),
@@ -132,6 +137,7 @@ See also [chart/src/chart.ts](chart/src/chart.ts) for relations among the chart 
     * Response
         * empty response with status code 204
         * `{message?: string}` as JSON with status code
+            * 400 (invalid cid),
             * 401 (wrong passwd),
             * 404 (cid not found),
             * or 500 (other error)

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "8.17.0",
+  "version": "8.18.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "8.17.0",
+  "version": "8.18.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -2,6 +2,7 @@ export default {
   error: {
     api: {
       // 400
+      invalidChartId: "Chart ID is invalid",
       invalidResultParam: "Result parameter is invalid",
       missingResultParam: "Result parameter is missing",
       // 401

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -2,6 +2,7 @@ export default {
   error: {
     api: {
       // 400
+      invalidChartId: "譜面 ID が不正です",
       invalidResultParam: "result パラメータが不正です",
       missingResultParam: "result パラメータが指定されていません",
       // 401

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "8.17.0",
+  "version": "8.18.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "8.17.0",
+      "version": "8.18.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "wasmoon": "^1.16.0"
@@ -42,7 +42,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "8.17.0",
+      "version": "8.18.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "^5.2.5",
@@ -72,7 +72,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "8.17.0",
+      "version": "8.18.0",
       "dependencies": {
         "next-intl": "^3.26.5"
       }
@@ -8487,7 +8487,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "8.17.0",
+      "version": "8.18.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@vercel/og": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "route:lint": "cd route && eslint src/",
     "frontend:lint": "cd frontend && tsc --noEmit && eslint app/",
     "lint": "npm run chart:lint && npm run i18n:lint && npm run route:lint && npm run frontend:lint",
+    "route:test": "cd route && bun test",
     "chart:t": "cd chart && tsc",
     "route:t": "cd route && tsc",
     "i18n:t": "cd i18n && node verifyKeys.js",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "8.17.0",
+  "version": "8.18.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/route/src/api/chart.ts
+++ b/route/src/api/chart.ts
@@ -15,6 +15,7 @@ import {
   isSample,
   getSample,
   Chart8Edit,
+  validCId,
 } from "@falling-nikochan/chart";
 import { gzip, gunzip } from "node:zlib";
 import { promisify } from "node:util";
@@ -49,6 +50,9 @@ export async function getChartEntry(
   entry: ChartEntry;
   chart: Chart4 | Chart5 | Chart6 | Chart7 | Chart8Edit;
 }> {
+  if (!validCId(cid)) {
+    throw new HTTPException(400, { message: "invalidChartId" });
+  }
   const entryCompressed = (await db
     .collection("chart")
     .findOne({ cid })) as ChartEntryCompressed | null;

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -53,7 +53,9 @@ const chartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
         v7PasswdHash,
         v7HashKey,
       });
-      return c.body(new Blob([msgpack.serialize(chart)]).stream());
+      return c.body(new Blob([msgpack.serialize(chart)]).stream(), 200, {
+        "Content-Type": "application/vnd.msgpack",
+      });
     } finally {
       await client.close();
     }

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -34,7 +34,7 @@ const newChartFileApp = new Hono<{ Bindings: Bindings }>({ strict: false })
       const db = client.db("nikochan");
 
       if (
-        env(c).API_ENV !== "development" &&
+        !(env(c).API_ENV === "development" && env(c).API_NO_RATELIMIT) &&
         !(await updateIpLastCreate(db, ip))
       ) {
         return c.json(

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -60,7 +60,9 @@ const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         .updateOne({ cid }, { $inc: { playCount: 1 } });
       // revalidateBrief(cid);
 
-      return c.body(new Blob([msgpack.serialize(level)]).stream());
+      return c.body(new Blob([msgpack.serialize(level)]).stream(), 200, {
+        "Content-Type": "application/vnd.msgpack",
+      });
     } finally {
       await client.close();
     }

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -1,4 +1,5 @@
 export interface Bindings {
   MONGODB_URI: string;
   API_ENV: "development" | undefined;
+  API_NO_RATELIMIT: "1" | undefined;
 }

--- a/route/tests/api/brief.spec.ts
+++ b/route/tests/api/brief.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test, describe } from "bun:test";
+import { dummyChart, dummyDate, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import { ChartBrief, hashLevel } from "@falling-nikochan/chart";
+
+describe("GET /api/brief/:cid", () => {
+  test("should return a brief entry", async () => {
+    await initDb();
+    const res = await app.request("/api/brief/100000");
+    expect(res.status).toBe(200);
+    const entry: ChartBrief = await res.json();
+    expect(entry).toStrictEqual({
+      ytId: dummyChart().ytId,
+      title: dummyChart().title,
+      composer: dummyChart().composer,
+      chartCreator: dummyChart().chartCreator,
+      updatedAt: dummyDate.getTime(),
+      playCount: 0,
+      published: false,
+      locale: dummyChart().locale,
+      levels: [
+        {
+          name: "e",
+          hash: await hashLevel(dummyChart().levels[0]),
+          type: "Single",
+          difficulty: 1,
+          noteCount: 1,
+          bpmMin: 120,
+          bpmMax: 180,
+          length: 0,
+          unlisted: false,
+        },
+      ],
+    });
+  });
+  test("should return 404 for nonexistent cid", async () => {
+    await initDb();
+    const res = await app.request("/api/brief/100001");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "chartIdNotFound" });
+  });
+  test("should return 400 for invalid cid", async () => {
+    await initDb();
+    const res = await app.request("/api/brief/invalid");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChartId" });
+  });
+});

--- a/route/tests/api/chartFile.get.spec.ts
+++ b/route/tests/api/chartFile.get.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, describe } from "bun:test";
+import { dummyChart, dummyChart6, dummyChart7, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import {
+  Chart4,
+  Chart5,
+  Chart6,
+  Chart7,
+  ChartEdit,
+  hash,
+} from "@falling-nikochan/chart";
+import msgpack from "@ygoe/msgpack";
+
+describe("GET /api/chartFile/:cid", () => {
+  test("should return ChartEdit if raw password matches", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p");
+    expect(res.status).toBe(200);
+    const chart: ChartEdit = msgpack.deserialize(await res.arrayBuffer());
+    expect(chart).toStrictEqual(dummyChart());
+  });
+  test("should return ChartEdit if password hash matches", async () => {
+    await initDb();
+    const res = await app.request(
+      "/api/chartFile/100000?ph=" + (await hash("100000pdef")),
+      {
+        headers: { Cookie: "hashKey=def" },
+      }
+    );
+    expect(res.status).toBe(200);
+    const chart: ChartEdit = msgpack.deserialize(await res.arrayBuffer());
+    expect(chart).toStrictEqual(dummyChart());
+  });
+  test("should return Chart7 if chart version is 7", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100007?pw=p");
+    expect(res.status).toBe(200);
+    const chart: Chart7 = msgpack.deserialize(await res.arrayBuffer());
+    expect(chart).toStrictEqual(dummyChart7());
+  });
+  test("should return Chart6 if chart version is 6", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100006?pw=p");
+    expect(res.status).toBe(200);
+    const chart: Chart6 = msgpack.deserialize(await res.arrayBuffer());
+    expect(chart).toStrictEqual(dummyChart6());
+  });
+  test("should return Chart5 if chart version is 5", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100005?pw=p");
+    expect(res.status).toBe(200);
+    const chart: Chart5 = msgpack.deserialize(await res.arrayBuffer());
+    // expect(chart).toStrictEqual(dummyChart5());
+    expect(chart.ver).toBe(5);
+  });
+  test("should return Chart4 if chart version is 4", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100004?pw=p");
+    expect(res.status).toBe(200);
+    const chart: Chart4 = msgpack.deserialize(await res.arrayBuffer());
+    // expect(chart).toStrictEqual(dummyChart4());
+    expect(chart.ver).toBe(4);
+  });
+  test("should return 400 for invalid cid", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000a?pw=p");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChartId" });
+  });
+  test("should return 401 for wrong password", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=wrong&ph=wrong");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "badPassword" });
+  });
+  test("should return 404 for nonexistent cid", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100001?pw=p");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "chartIdNotFound" });
+  });
+});

--- a/route/tests/api/chartFile.post.spec.ts
+++ b/route/tests/api/chartFile.post.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test, describe } from "bun:test";
+import { dummyChart, dummyChart7, dummyCid, dummyDate, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import { chartMaxEvent, fileMaxSize, hash } from "@falling-nikochan/chart";
+import msgpack from "@ygoe/msgpack";
+import { MongoClient } from "mongodb";
+import { ChartEntryCompressed } from "@falling-nikochan/route/src/api/chart";
+
+describe("POST /api/chartFile/:cid", () => {
+  test("should update chart if raw password matches", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+    });
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.title).toBe("updated");
+    } finally {
+      await client.close();
+    }
+  });
+  test("should update chart if password hash matches", async () => {
+    await initDb();
+    const res = await app.request(
+      "/api/chartFile/100000?ph=" + (await hash("100000pdef")),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/vnd.msgpack",
+          Cookie: "hashKey=def",
+        },
+        body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+      }
+    );
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.title).toBe("updated");
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 400 for invalid cid", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000a?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChartId" });
+  });
+  test("should return 401 for wrong password", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=wrong&ph=wrong", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "badPassword" });
+  });
+  test("should return 404 for nonexistent cid", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100001?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "chartIdNotFound" });
+  });
+  test("should return 413 for large file", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: new ArrayBuffer(fileMaxSize + 1),
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "tooLargeFile" });
+  });
+  test("should return 413 for chart containing too many events", async () => {
+    await initDb();
+    const chart = dummyChart();
+    chart.levels[0].rest = new Array(chartMaxEvent + 1).fill(
+      chart.levels[0].rest[0]
+    );
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(chart),
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "tooManyEvent" });
+  });
+  test("should return 409 for old chart version", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart7() }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "oldChartVersion" });
+  });
+  test("should return 415 for invalid chart", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      body: "invalid",
+    });
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChart" });
+  });
+  test("should not update the date of chart with uploading same chart", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(dummyChart()),
+    });
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.updatedAt).toBe(dummyDate.getTime());
+    } finally {
+      await client.close();
+    }
+  });
+  test("should not update the date of chart with metadata change", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), title: "updated" }),
+    });
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.updatedAt).toBe(dummyDate.getTime());
+    } finally {
+      await client.close();
+    }
+  });
+  test("should update the date of chart with level change", async () => {
+    await initDb();
+    const chart = dummyChart();
+    chart.levels[0].notes = new Array(10).fill(chart.levels[0].notes[0]);
+    const dateBefore = new Date();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(chart),
+    });
+    const dateAfter = new Date();
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.updatedAt).toBeGreaterThanOrEqual(dateBefore.getTime());
+      expect(e!.updatedAt).toBeLessThanOrEqual(dateAfter.getTime());
+    } finally {
+      await client.close();
+    }
+  });
+  test("should update the date of chart with publish", async () => {
+    await initDb();
+    const dateBefore = new Date();
+    const res = await app.request("/api/chartFile/100000?pw=p", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart(), published: true }),
+    });
+    const dateAfter = new Date();
+    expect(res.status).toBe(204);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: dummyCid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.updatedAt).toBeGreaterThanOrEqual(dateBefore.getTime());
+      expect(e!.updatedAt).toBeLessThanOrEqual(dateAfter.getTime());
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/route/tests/api/hashPasswd.spec.ts
+++ b/route/tests/api/hashPasswd.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test, describe } from "bun:test";
+import app from "@falling-nikochan/route";
+import { hash } from "@falling-nikochan/chart";
+
+describe("GET /api/hashPasswd/:cid", () => {
+  test("should return hashed password and random hashKey", async () => {
+    const res = await app.request("/api/hashPasswd/100000?pw=abc");
+    expect(res.status).toBe(200);
+    const resHash = await res.text();
+    const hashKey = res.headers.get("Set-Cookie")?.split(";")[0].split("=")[1];
+    console.log(hashKey);
+    expect(hashKey).toBeString();
+    expect(hashKey).not.toBeEmpty();
+    expect(resHash).toBe(await hash("100000abc" + hashKey));
+  });
+  test("should use same hashKey if it is set in the cookie", async () => {
+    const res = await app.request("/api/hashPasswd/100000?pw=abc", {
+      headers: { Cookie: "hashKey=def" },
+    });
+    expect(res.status).toBe(200);
+    const resHash = await res.text();
+    const hashKey = res.headers.get("Set-Cookie")?.split(";")[0].split("=")[1];
+    expect(hashKey).toBe("def");
+    expect(resHash).toBe(await hash("100000abcdef"));
+  });
+});

--- a/route/tests/api/init.ts
+++ b/route/tests/api/init.ts
@@ -1,0 +1,257 @@
+import { MongoClient } from "mongodb";
+import { chartToEntry, zipEntry } from "@falling-nikochan/route/src/api/chart";
+import {
+  Chart4,
+  Chart5,
+  Chart6,
+  Chart7,
+  ChartEdit,
+  currentChartVer,
+  Level6Play,
+  Level8Play,
+  stepZero,
+} from "@falling-nikochan/chart";
+
+export const dummyCid = "100000";
+export const dummyDate = new Date(2025, 0, 1);
+export function dummyChart(): ChartEdit {
+  return {
+    falling: "nikochan",
+    ver: currentChartVer,
+    offset: 1.23,
+    ytId: "123456789ab",
+    title: "a",
+    composer: "b",
+    chartCreator: "c",
+    locale: "d",
+    editPasswd: "p",
+    published: false,
+    levels: [
+      {
+        name: "e",
+        type: "Single",
+        unlisted: false,
+        lua: ["g"],
+        notes: [
+          {
+            step: stepZero(),
+            big: false,
+            hitX: 0,
+            hitVX: 0,
+            hitVY: 0,
+            fall: true,
+            luaLine: null,
+          },
+        ],
+        rest: [{ begin: stepZero(), duration: stepZero(), luaLine: null }],
+        bpmChanges: [
+          { step: stepZero(), timeSec: 0, bpm: 180, luaLine: null },
+          {
+            step: { fourth: 1, numerator: 0, denominator: 1 },
+            timeSec: 60 / 180,
+            bpm: 120,
+            luaLine: null,
+          },
+        ],
+        speedChanges: [
+          { step: stepZero(), timeSec: 0, bpm: 240, luaLine: null },
+        ],
+        signature: [
+          {
+            step: stepZero(),
+            offset: stepZero(),
+            barNum: 0,
+            bars: [[4]],
+            luaLine: null,
+          },
+        ],
+      },
+    ],
+  };
+}
+export function dummyChart7(): Chart7 {
+  return { ...dummyChart(), ver: 7 };
+}
+export function dummyChart6(): Chart6 {
+  const c: Chart6 = { ...dummyChart(), ver: 6 };
+  // @ts-expect-error converting Chart8 to 6
+  delete c.locale;
+  return c;
+}
+export function dummyChart5(): Chart5 {
+  const c: Chart5 = {
+    ...dummyChart6(),
+    ver: 5,
+    updatedAt: dummyDate.getTime(),
+    levels: dummyChart().levels.map((l) => ({ ...l, hash: "" })),
+  };
+  return c;
+}
+export function dummyChart4(): Chart4 {
+  return {
+    ...dummyChart5(),
+    ver: 4,
+  };
+}
+
+export function dummyLevel8(): Level8Play {
+  return {
+    ver: 8,
+    offset: 1.23,
+    notes: [
+      {
+        step: stepZero(),
+        big: false,
+        hitX: 0,
+        hitVX: 0,
+        hitVY: 0,
+        fall: true,
+      },
+    ],
+    bpmChanges: [
+      { step: stepZero(), timeSec: 0, bpm: 180 },
+      {
+        step: { fourth: 1, numerator: 0, denominator: 1 },
+        timeSec: 60 / 180,
+        bpm: 120,
+      },
+    ],
+    speedChanges: [{ step: stepZero(), timeSec: 0, bpm: 240 }],
+    signature: [
+      {
+        step: stepZero(),
+        offset: stepZero(),
+        barNum: 0,
+        bars: [[4]],
+      },
+    ],
+  };
+}
+
+export function dummyLevel6(): Level6Play {
+  return {
+    ver: 6,
+    name: "e",
+    type: "Single",
+    offset: 1.23,
+    notes: [
+      {
+        step: stepZero(),
+        big: false,
+        hitX: 0,
+        hitVX: 0,
+        hitVY: 0,
+        luaLine: null,
+      },
+    ],
+    rest: [{ begin: stepZero(), duration: stepZero(), luaLine: null }],
+    bpmChanges: [
+      { step: stepZero(), timeSec: 0, bpm: 180, luaLine: null },
+      {
+        step: { fourth: 1, numerator: 0, denominator: 1 },
+        timeSec: 60 / 180,
+        bpm: 120,
+        luaLine: null,
+      },
+    ],
+    speedChanges: [{ step: stepZero(), timeSec: 0, bpm: 240, luaLine: null }],
+    signature: [
+      {
+        step: stepZero(),
+        offset: stepZero(),
+        barNum: 0,
+        bars: [[4]],
+        luaLine: null,
+      },
+    ],
+    lua: ["g"],
+    unlisted: false,
+  };
+}
+
+/*
+cid100000に最新バージョンのchart(dummyChart()参照)を、
+100004〜100007にそれぞれver4〜7のchartを保存する
+*/
+export async function initDb() {
+  if (typeof process.env.MONGODB_URI !== "string") {
+    throw new Error("MONGODB_URI is not set");
+  }
+  const client = new MongoClient(process.env.MONGODB_URI);
+  try {
+    await client.connect();
+    const db = client.db("nikochan");
+    await db.collection("rateLimit").deleteMany({});
+    await db.collection("chart").updateOne(
+      { cid: dummyCid },
+      {
+        $set: await zipEntry(
+          await chartToEntry(dummyChart(), dummyCid, dummyDate.getTime())
+        ),
+      },
+      { upsert: true }
+    );
+    await db.collection("chart").updateOne(
+      { cid: String(Number(dummyCid) + 4) },
+      {
+        $set: await zipEntry({
+          ...(await chartToEntry(
+            dummyChart(),
+            String(Number(dummyCid) + 4),
+            dummyDate.getTime()
+          )),
+          ver: 4,
+          levels: dummyChart4().levels,
+        }),
+      },
+      { upsert: true }
+    );
+    await db.collection("chart").updateOne(
+      { cid: String(Number(dummyCid) + 5) },
+      {
+        $set: await zipEntry({
+          ...(await chartToEntry(
+            dummyChart(),
+            String(Number(dummyCid) + 5),
+            dummyDate.getTime()
+          )),
+          ver: 5,
+          levels: dummyChart5().levels,
+        }),
+      },
+      { upsert: true }
+    );
+    await db.collection("chart").updateOne(
+      { cid: String(Number(dummyCid) + 6) },
+      {
+        $set: await zipEntry({
+          ...(await chartToEntry(
+            dummyChart(),
+            String(Number(dummyCid) + 6),
+            dummyDate.getTime()
+          )),
+          ver: 6,
+          levels: dummyChart6().levels,
+        }),
+      },
+      { upsert: true }
+    );
+    await db.collection("chart").updateOne(
+      { cid: String(Number(dummyCid) + 7) },
+      {
+        $set: await zipEntry({
+          ...(await chartToEntry(
+            dummyChart(),
+            String(Number(dummyCid) + 7),
+            dummyDate.getTime()
+          )),
+          ver: 7,
+          levels: dummyChart7().levels,
+        }),
+      },
+      { upsert: true }
+    );
+  } finally {
+    await client.close();
+  }
+}

--- a/route/tests/api/latest.spec.ts
+++ b/route/tests/api/latest.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, describe } from "bun:test";
+import { dummyCid, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import { validCId } from "@falling-nikochan/chart";
+import { MongoClient } from "mongodb";
+
+describe("GET /api/latest", () => {
+  test("should return latest entries", async () => {
+    await initDb();
+    const res = await app.request("/api/latest");
+    expect(res.status).toBe(200);
+    const entries: { cid: string }[] = await res.json();
+    expect(entries.length).toBeLessThanOrEqual(25);
+    for (const entry of entries) {
+      expect(entry).toStrictEqual({
+        cid: expect.any(String),
+      });
+      expect(validCId(entry.cid)).toBe(true);
+    }
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      await db.collection("chart").updateOne(
+        { cid: dummyCid },
+        {
+          $set: {
+            updatedAt: new Date().getTime(),
+            published: true,
+          },
+        }
+      );
+    } finally {
+      await client.close();
+    }
+
+    const res2 = await app.request("/api/latest");
+    expect(res2.status).toBe(200);
+    const entries2: { cid: string }[] = await res2.json();
+    expect(entries2.length).toBeLessThanOrEqual(25);
+    expect(entries2[0]).toStrictEqual({
+      cid: dummyCid,
+    });
+  });
+});

--- a/route/tests/api/newChartFile.post.spec.ts
+++ b/route/tests/api/newChartFile.post.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, describe } from "bun:test";
+import { dummyChart, dummyChart7, dummyCid, dummyDate, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import { chartMaxEvent, fileMaxSize, hash } from "@falling-nikochan/chart";
+import msgpack from "@ygoe/msgpack";
+import { MongoClient } from "mongodb";
+import { ChartEntryCompressed } from "@falling-nikochan/route/src/api/chart";
+
+describe("POST /api/newChartFile", () => {
+  test.skipIf(
+    process.env.API_ENV === "development" && !!process.env.API_NO_RATELIMIT
+  )("should return 429 for too many requests", async () => {
+    await initDb();
+    const res1 = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(dummyChart()),
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(dummyChart()),
+    });
+    expect(res2.status).toBe(429);
+    const body = await res2.json();
+    expect(body).toStrictEqual({ message: "tooManyRequest" });
+  });
+  test("should create chart and return cid", async () => {
+    await initDb();
+    const dateBefore = new Date();
+    const res = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(dummyChart()),
+    });
+    const dateAfter = new Date();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cid).toBeString();
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const e = (await db
+        .collection("chart")
+        .findOne({ cid: body.cid })) as ChartEntryCompressed | null;
+      expect(e).not.toBeNull();
+      expect(e!.title).toBe(dummyChart().title);
+      expect(e!.updatedAt).toBeGreaterThanOrEqual(dateBefore.getTime());
+      expect(e!.updatedAt).toBeLessThanOrEqual(dateAfter.getTime());
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 413 for large file", async () => {
+    await initDb();
+    const res = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: new ArrayBuffer(fileMaxSize + 1),
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "tooLargeFile" });
+  });
+  test("should return 413 for chart containing too many events", async () => {
+    await initDb();
+    const chart = dummyChart();
+    chart.levels[0].rest = new Array(chartMaxEvent + 1).fill(
+      chart.levels[0].rest[0]
+    );
+    const res = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize(chart),
+    });
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "tooManyEvent" });
+  });
+  test("should return 409 for old chart version", async () => {
+    await initDb();
+    const res = await app.request("/api/newChartFile", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.msgpack" },
+      body: msgpack.serialize({ ...dummyChart7() }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "oldChartVersion" });
+  });
+  test("should return 415 for invalid chart", async () => {
+    await initDb();
+    const res = await app.request("/api/newChartFile", {
+      method: "POST",
+      body: "invalid",
+    });
+    expect(res.status).toBe(415);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChart" });
+  });
+});

--- a/route/tests/api/playFile.spec.ts
+++ b/route/tests/api/playFile.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, describe } from "bun:test";
+import { dummyLevel6, dummyLevel8, initDb } from "./init";
+import app from "@falling-nikochan/route";
+import { Level6Play, Level8Play, LevelPlay } from "@falling-nikochan/chart";
+import msgpack from "@ygoe/msgpack";
+
+describe("GET /api/playFile/:cid/:lvIndex", () => {
+  test("should return LevelPlay", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100000/0");
+    expect(res.status).toBe(200);
+    const level: LevelPlay = msgpack.deserialize(await res.arrayBuffer());
+    expect(level).toStrictEqual(dummyLevel8());
+  });
+  test("should return Level8Play if chart version is 7", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100007/0");
+    expect(res.status).toBe(200);
+    const level: Level8Play = msgpack.deserialize(await res.arrayBuffer());
+    expect(level).toMatchObject(dummyLevel8());
+  });
+  test("should return Level6Play if chart version is 6", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100006/0");
+    expect(res.status).toBe(200);
+    const level: Level6Play = msgpack.deserialize(await res.arrayBuffer());
+    expect(level).toMatchObject(dummyLevel6());
+  });
+  test("should return Level6Play if chart version is 5", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100005/0");
+    expect(res.status).toBe(200);
+    const level: Level6Play = msgpack.deserialize(await res.arrayBuffer());
+    expect(level).toMatchObject(dummyLevel6());
+  });
+  test("should return Level6Play if chart version is 4", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100004/0");
+    expect(res.status).toBe(200);
+    const level: Level6Play = msgpack.deserialize(await res.arrayBuffer());
+    // ↓ 本来はChart4→6の変換でsignatureが[]になるはずはないのだが、
+    // テスト用のダミーデータを雑に作りすぎたためsignatureの追加に失敗している
+    expect(level).toMatchObject({ ...dummyLevel6(), signature: [] });
+  });
+  test("should return 404 for nonexistent cid", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100001/0");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "chartIdNotFound" });
+  });
+  test("should return 404 for nonexistent lvIndex", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100000/5");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "levelNotFound" });
+  });
+  test("should return 400 for invalid cid", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/invalid/0");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toStrictEqual({ message: "invalidChartId" });
+  });
+});

--- a/route/tsconfig.json
+++ b/route/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "jsx": "react",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
-  "include": ["src/*.ts", "src/*.tsx"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
* apiのテストを書いた `bun route:test`
* messagepackを返すAPIでContent-Typeを設定するようにした
* cidを受け取るAPIでcidが不正な場合400を返すようにした
* API_ENV とは別に /api/newChartFile のratelimitの有無を切り替える API_NO_RATELIMIT 環境変数を追加
* ciにテストの実行を追加、さらにjob間の依存関係を少し変更し効率化