### PR TITLE
wasmoonのwasmをassetsに入れてローカルでも使えるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 */public/assets/*.ttf
+*/public/assets/wasmoon_glue.wasm
 */dist/
 /node_modules/
 /.vercel/

--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 8.20 - 2025/03/09 [#367](https://github.com/na-trium-144/falling-nikochan/pull/367)
+
+* wasmoonのwasmをassetsに入れてローカルでも使えるようにする
+
 ## ver. 8.18 - 2025/03/08 [#364](https://github.com/na-trium-144/falling-nikochan/pull/364)
 
 * apiのテストを書いた `bun route:test`

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/chart/src/luaExec/exec.ts
+++ b/chart/src/luaExec/exec.ts
@@ -13,10 +13,11 @@ export interface Result {
   step: Step;
 }
 export async function luaExec(
+  wasmPath: string,
   code: string,
   catchError: boolean
 ): Promise<Result> {
-  const factory = new LuaFactory();
+  const factory = new LuaFactory(wasmPath);
   const lua = await factory.createEngine();
   const result: Result = {
     stdout: [],

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -21,7 +21,11 @@ export function useLuaExecutor() {
 
   const exec = async (code: string) => {
     setRunning(true);
-    const result = await luaExec(code, true);
+    const result = await luaExec(
+      process.env.ASSET_PREFIX + "/assets/wasmoon_glue.wasm",
+      code,
+      true
+    );
     setRunning(false);
     setStdout(result.stdout);
     setErr(result.err);

--- a/frontend/app/[locale]/edit/metaTab.tsx
+++ b/frontend/app/[locale]/edit/metaTab.tsx
@@ -322,7 +322,13 @@ export function MetaTab(props: Props2) {
           levels: await Promise.all(
             newChartMin.levels.map(async (l) => ({
               ...l,
-              ...(await luaExec(l.lua.join("\n"), false)).levelFreezed,
+              ...(
+                await luaExec(
+                  process.env.ASSET_PREFIX + "/assets/wasmoon_glue.wasm",
+                  l.lua.join("\n"),
+                  false
+                )
+              ).levelFreezed,
             }))
           ),
         };
@@ -341,7 +347,13 @@ export function MetaTab(props: Props2) {
             levels: await Promise.all(
               newChartMin.levels.map(async (l) => ({
                 ...l,
-                ...(await luaExec(l.lua.join("\n"), false)).levelFreezed,
+                ...(
+                  await luaExec(
+                    process.env.ASSET_PREFIX + "/assets/wasmoon_glue.wasm",
+                    l.lua.join("\n"),
+                    false
+                  )
+                ).levelFreezed,
               }))
             ),
           };

--- a/frontend/initAssets.js
+++ b/frontend/initAssets.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
 import { parse } from "node:path";
 import { toSfnt } from "woff2sfnt-sfnt2woff";
 for (const [name, file] of [
@@ -12,3 +12,8 @@ for (const [name, file] of [
   );
   writeFileSync(`public/assets/${parse(file).name}.ttf`, toSfnt(woff));
 }
+
+copyFileSync(
+  "../node_modules/wasmoon/dist/glue.wasm",
+  "public/assets/wasmoon_glue.wasm"
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "8.19.0",
+      "version": "8.20.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "wasmoon": "^1.16.0"
@@ -42,7 +42,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "8.19.0",
+      "version": "8.20.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "^5.2.5",
@@ -72,7 +72,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "8.19.0",
+      "version": "8.20.0",
       "dependencies": {
         "next-intl": "^3.26.5"
       }
@@ -8487,7 +8487,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "8.19.0",
+      "version": "8.20.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@vercel/og": "^0.6.5",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "t": "npm run chart:t && npm run route:t && npm run i18n:t",
     "prepare": "npm run t",
     "mongo-docker": "docker run --rm -p 27017:27017 -d mongodb/mongodb-community-server:latest",
-    "ndev": "cd frontend && next dev -H 0.0.0.0",
-    "nbuild": "cd frontend && node ./woff2sfnt.js && next build",
+    "ndev": "cd frontend && node ./initAssets.js && next dev -H 0.0.0.0",
+    "nbuild": "cd frontend && node ./initAssets.js && next build",
     "ldev": "cd route/ && tsx watch serve-local.ts",
     "bdev": "cd route/ && bun run --hot serve-bun.ts"
   },

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "8.19.0",
+  "version": "8.20.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
今まではwasmoonのLuaFactory()内でCDNからglue.wasmをfetchしていたらしいが、node_modulesからpublic/assets/にコピーしそれを使うようにする

(よく考えたらYouTubeEmbedにインターネットが要るのだからどのみちインターネットなしで動かないことに変わりはないのでは...)