### PR TITLE
Revert "Bump @fontsource/merriweather from 5.2.5 to 5.2.6"

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 9.3 - 2025/03/11 [#378](https://github.com/na-trium-144/falling-nikochan/pull/378)
+
+* @fontsource/merriweather のバージョンを5.2.5にダウングレード、固定
+
 ## ver. 9.1 - 2025/03/11 [#377](https://github.com/na-trium-144/falling-nikochan/pull/377)
 
 * URLにクエリパラメータでredirected=1がついているとき、リダイレクトに関するメッセージを表示する

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "9.1.0",
+      "version": "9.3.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0-rc.3",
@@ -34,10 +34,10 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "9.1.0",
+      "version": "9.3.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
-        "@fontsource/merriweather": "^5.2.5",
+        "@fontsource/merriweather": "=5.2.5",
         "@fontsource/noto-sans": "^5.2.5",
         "@fontsource/noto-sans-jp": "^5.2.5",
         "@icon-park/react": "^1.4.2",
@@ -64,14 +64,14 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "9.1.0",
+      "version": "9.3.0",
       "dependencies": {
         "next-intl": "^3.26.5",
       },
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "9.1.0",
+      "version": "9.3.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@vercel/og": "^0.6.5",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
       "version": "9.1.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
-        "@fontsource/merriweather": "^5.2.6",
+        "@fontsource/merriweather": "^5.2.5",
         "@fontsource/noto-sans": "^5.2.5",
         "@fontsource/noto-sans-jp": "^5.2.5",
         "@icon-park/react": "^1.4.2",
@@ -169,7 +169,7 @@
 
     "@fontsource/kaisei-opti": ["@fontsource/kaisei-opti@5.2.5", "", {}, "sha512-Ttd/KTtKEB1M+CAD52R5dQs/qlP4csMtJVwhydlza175rd+WBwT+EQiI6IrBPjFPVZjIruVG2bTMa8gluYkXNQ=="],
 
-    "@fontsource/merriweather": ["@fontsource/merriweather@5.2.6", "", {}, "sha512-lPFH6+Kz3V7MK9SRDI/Y9hxMc+2Sjb/FjyNHlotRjL7eFRhJ8/LnnWsDTGAccTuoGEmfdaaia7SHw6LoNtoIyg=="],
+    "@fontsource/merriweather": ["@fontsource/merriweather@5.2.5", "", {}, "sha512-5LHr2QYcpovXZc3iLsD2BLqpuwDUNxOSH6hDLDatferd++7xTEHPLHRPheyBECUU+KiXv/CBFs+amz9eh8U+Bw=="],
 
     "@fontsource/noto-sans": ["@fontsource/noto-sans@5.2.5", "", {}, "sha512-g3hWgsQayHQGVXgQKjbHKpS7YQFQY8azwXFCi3ZkhgCK5fZXe3udeQYrZJJ4PMswGkNhoDPRR9OJZBlMjzZAEQ=="],
 

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@fontsource/kaisei-opti": "^5.2.5",
-    "@fontsource/merriweather": "^5.2.5",
+    "@fontsource/merriweather": "=5.2.5",
     "@fontsource/noto-sans": "^5.2.5",
     "@fontsource/noto-sans-jp": "^5.2.5",
     "@icon-park/react": "^1.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@fontsource/kaisei-opti": "^5.2.5",
-    "@fontsource/merriweather": "^5.2.6",
+    "@fontsource/merriweather": "^5.2.5",
     "@fontsource/noto-sans": "^5.2.5",
     "@fontsource/noto-sans-jp": "^5.2.5",
     "@icon-park/react": "^1.4.2",

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0-rc.3",
@@ -43,10 +43,10 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
-        "@fontsource/merriweather": "^5.2.5",
+        "@fontsource/merriweather": "=5.2.5",
         "@fontsource/noto-sans": "^5.2.5",
         "@fontsource/noto-sans-jp": "^5.2.5",
         "@icon-park/react": "^1.4.2",
@@ -73,7 +73,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "dependencies": {
         "next-intl": "^3.26.5"
       }
@@ -8490,7 +8490,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@vercel/og": "^0.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "version": "9.2.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
-        "@fontsource/merriweather": "^5.2.6",
+        "@fontsource/merriweather": "^5.2.5",
         "@fontsource/noto-sans": "^5.2.5",
         "@fontsource/noto-sans-jp": "^5.2.5",
         "@icon-park/react": "^1.4.2",
@@ -703,9 +703,9 @@
       }
     },
     "node_modules/@fontsource/merriweather": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.2.6.tgz",
-      "integrity": "sha512-lPFH6+Kz3V7MK9SRDI/Y9hxMc+2Sjb/FjyNHlotRjL7eFRhJ8/LnnWsDTGAccTuoGEmfdaaia7SHw6LoNtoIyg==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.2.5.tgz",
+      "integrity": "sha512-5LHr2QYcpovXZc3iLsD2BLqpuwDUNxOSH6hDLDatferd++7xTEHPLHRPheyBECUU+KiXv/CBFs+amz9eh8U+Bw==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
Reverts na-trium-144/falling-nikochan#371

@fontsource/merriweatherパッケージを5.2.5→5.2.6にアップデートすると明らかに見た目が変わってるんだけどどういうこと??

5.2.5
![image](https://github.com/user-attachments/assets/b9d9cae8-8425-4aff-8832-54de9a91255d)

5.2.6
![image](https://github.com/user-attachments/assets/99864bc7-105d-4831-b5d3-c2eaee5637b6)
