### PR TITLE
別ドメインのworkerを読み込めずエラーになっていたのを修正

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "9.13.0",
+      "version": "9.19.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -34,7 +34,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "9.13.0",
+      "version": "9.19.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -50,6 +50,7 @@
         "next": "^15.2.4",
         "react-ace": "^14.0.1",
         "react-resize-detector": "^12.0.2",
+        "remote-web-worker": "^0.0.9",
         "yaml": "^2.7.0",
       },
       "devDependencies": {
@@ -64,14 +65,14 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "9.13.0",
+      "version": "9.19.0",
       "dependencies": {
         "next-intl": "^4.0.2",
       },
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "9.13.0",
+      "version": "9.19.0",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
         "@vercel/og": "^0.6.5",
@@ -1016,6 +1017,8 @@
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-rehype": ["remark-rehype@11.1.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ=="],
+
+    "remote-web-worker": ["remote-web-worker@0.0.9", "", {}, "sha512-TguJhQVWeeL2zWqLQpTfq/uIOpXRHHq7SI6fw6xTIJfSN/ojiKUqV16oAhPD8zH71MFy3FHqSoQEx2cks5gcAA=="],
 
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "9.18.0",
+  "version": "9.19.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -23,6 +23,8 @@ import { ThemeContext } from "@/common/theme.js";
 import { LevelEdit } from "@falling-nikochan/chart";
 import { useResizeDetector } from "react-resize-detector";
 import { useTranslations } from "next-intl";
+// https://github.com/vercel/next.js/discussions/29415
+import "remote-web-worker";
 
 export function useLuaExecutor() {
   const [stdout, setStdout] = useState<string[]>([]);
@@ -57,12 +59,7 @@ export function useLuaExecutor() {
       const p = new Promise<LevelFreeze | null>((resolve) => {
         workerResolver.current = resolve;
       });
-      // https://github.com/vercel/next.js/discussions/29415
-      // @ts-expect-error webpack5 global variable
-      __webpack_public_path__ = "/_next/";
       worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
-      // @ts-expect-error webpack5 global variable
-      __webpack_public_path__ = process.env.ASSET_PREFIX + "/_next/";
       worker.current.postMessage({ code, catchError: true });
       worker.current.addEventListener(
         "message",

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -57,7 +57,12 @@ export function useLuaExecutor() {
       const p = new Promise<LevelFreeze | null>((resolve) => {
         workerResolver.current = resolve;
       });
+      // https://github.com/vercel/next.js/discussions/29415
+      // @ts-expect-error webpack5 global variable
+      __webpack_public_path__ = "/_next/";
       worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
+      // @ts-expect-error webpack5 global variable
+      __webpack_public_path__ = process.env.ASSET_PREFIX + "/_next/";
       worker.current.postMessage({ code, catchError: true });
       worker.current.addEventListener(
         "message",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "next": "^15.2.4",
     "react-ace": "^14.0.1",
     "react-resize-detector": "^12.0.2",
+    "remote-web-worker": "^0.0.9",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "9.18.0",
+  "version": "9.19.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "9.18.0",
+  "version": "9.19.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "9.18.0",
+      "version": "9.19.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "9.18.0",
+      "version": "9.19.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -94,7 +94,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "9.18.0",
+      "version": "9.19.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -8490,7 +8490,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "9.18.0",
+      "version": "9.19.0",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
         "@vercel/og": "^0.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "next": "^15.2.4",
         "react-ace": "^14.0.1",
         "react-resize-detector": "^12.0.2",
+        "remote-web-worker": "^0.0.9",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
@@ -7189,6 +7190,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remote-web-worker": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/remote-web-worker/-/remote-web-worker-0.0.9.tgz",
+      "integrity": "sha512-TguJhQVWeeL2zWqLQpTfq/uIOpXRHHq7SI6fw6xTIJfSN/ojiKUqV16oAhPD8zH71MFy3FHqSoQEx2cks5gcAA==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "9.18.0",
+  "version": "9.19.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
#421 の続きで、
グローバル変数をいじらずにremote-web-workerパッケージのパッチを使うようにすることでCDNを利用できるようになったが、auto-mergeを解除するのが間に合わなかった
