### PR TITLE
shareページをmetaタグ使って再度SSRに戻した

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 10.4 - 2025/03/31 [#431](https://github.com/na-trium-144/falling-nikochan/pull/431)
+
+* #369 (ver9.0) でshareページのbodyをSSRせずクライアント側でfetchする仕様に変更していたが、遅いのでmetaタグを利用してbriefデータを渡すようにした
+
 ## ver. 10.0 - 2025/03/30 [#403](https://github.com/na-trium-144/falling-nikochan/pull/403), [#424](https://github.com/na-trium-144/falling-nikochan/pull/424), [#426](https://github.com/na-trium-144/falling-nikochan/pull/426)
 
 * 音符を叩いたときのSEを追加

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/metadata.ts
+++ b/frontend/app/[locale]/metadata.ts
@@ -14,6 +14,7 @@ export async function initMetadata(
     image?: string;
     noAlternate?: boolean;
     description?: string;
+    custom?: { [key: string]: string };
   },
 ): Promise<Metadata> {
   const locale = (await params).locale || "en";
@@ -85,5 +86,6 @@ export async function initMetadata(
       follow: path ? true : false,
       nocache: true,
     },
+    other: options?.custom,
   };
 }

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -13,7 +13,6 @@ import { useTranslations } from "next-intl";
 import { titleShare } from "@/common/title.js";
 import { ShareBox } from "./shareBox.js";
 import { Box } from "@/common/box.js";
-import { fetchBrief } from "@/common/briefCache.js";
 import { RedirectedWarning } from "@/common/redirectedWarning.js";
 
 const dummyBrief = {
@@ -52,19 +51,18 @@ export default function ShareChart({ locale }: { locale: string }) {
     const cid = window.location.pathname.split("/").pop()!;
     setCId(cid);
     const searchParams = new URLSearchParams(window.location.search);
-    void (async () => {
-      let brief: ChartBrief | undefined;
-      if (process.env.NODE_ENV === "development") {
-        brief = dummyBrief;
-      } else {
-        brief = (await fetchBrief(cid, true)).brief;
-      }
-      if (!brief) {
-        throw new Error("Failed to fetch brief");
-      }
-      setBrief(brief);
-      document.title = titleShare(t, cid, brief);
-    })();
+    let brief: ChartBrief;
+    if (process.env.NODE_ENV === "development") {
+      brief = dummyBrief;
+    } else {
+      brief = JSON.parse(
+        document
+          .querySelector('meta[name="nikochanSharingBrief"]')!
+          .getAttribute("content")!,
+      );
+    }
+    setBrief(brief);
+    document.title = titleShare(t, cid, brief);
     fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`)
       .then((res) => {
         if (res.ok) {

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -41,7 +41,7 @@ const dummyBrief = {
 export default function ShareChart({ locale }: { locale: string }) {
   const t = useTranslations("share");
 
-  const [cid, setCId] = useState<string>("");
+  const [cid, setCId] = useState<string>();
   // const { res, brief } = await getBrief(cid, true);
   const [brief, setBrief] = useState<ChartBrief | null>(null);
   const [record, setRecord] = useState<RecordGetSummary[]>([]);

--- a/frontend/app/[locale]/share/placeholder/page.tsx
+++ b/frontend/app/[locale]/share/placeholder/page.tsx
@@ -6,6 +6,7 @@ export async function generateMetadata({ params }: MetadataProps) {
     image: "https://placeholder_og_image/",
     noAlternate: true,
     description: "PLACEHOLDER_DESCRIPTION",
+    custom: { nikochanSharingBrief: "PLACEHOLDER_BRIEF" },
   });
 }
 // pageTitle(cid, brief) or `Not Found (ID: ${cid})`

--- a/frontend/app/[locale]/share/placeholder/shareBox.tsx
+++ b/frontend/app/[locale]/share/placeholder/shareBox.tsx
@@ -18,7 +18,7 @@ import { useShareLink } from "@/common/share.js";
 import { SharedResultBox } from "./sharedResult.js";
 
 interface Props {
-  cid: string;
+  cid: string | undefined;
   brief: ChartBrief | null;
   record: RecordGetSummary[];
   sharedResult?: ResultParams | null;
@@ -48,7 +48,7 @@ export function ShareBox(props: Props) {
           backButton={props.backButton}
           locale={locale}
         >
-          ID: {cid}
+          {cid && "ID: " + cid}
         </Header>
       )}
       <div className="main-wide:flex main-wide:flex-row-reverse main-wide:items-center">
@@ -73,15 +73,19 @@ export function ShareBox(props: Props) {
           <p className="font-title text-lg">{brief?.composer}</p>
           <p className="mt-1">
             <span className="inline-block">
-              <span className="text-sm">{t("chartCreator")}:</span>
+              <span className="text-sm">
+                {brief && `${t("chartCreator")}:`}
+              </span>
               <span className="ml-2 font-title text-lg">
                 {brief?.chartCreator}
               </span>
             </span>
             <span className="inline-block ml-3 text-slate-500 dark:text-stone-400 ">
-              <span className="inline-block">({updatedAt})</span>
+              <span className="inline-block">
+                {updatedAt && `(${updatedAt})`}
+              </span>
               <span>
-                {isSample(cid) ? (
+                {cid && isSample(cid) ? (
                   <span className="ml-2">
                     <International className="inline-block w-5 translate-y-0.5" />
                     <span>{t("isSample")}</span>
@@ -112,28 +116,34 @@ export function ShareBox(props: Props) {
         </div>
       </div>
       {sharedResult && <SharedResultBox result={sharedResult} />}
-      <p className="mt-2">
-        <span className="hidden main-wide:inline-block mr-2">
-          {t("shareLink")}:
-        </span>
-        <a
-          className={"inline-block py-2 " + linkStyle1}
-          href={shareLink.path}
-          onClick={(e) => e.preventDefault()}
-        >
-          <span className="main-wide:hidden">{t("shareLink")}</span>
-          <span className="hidden main-wide:inline-block">{shareLink.url}</span>
-        </a>
-        <span className="inline-block ml-2 space-x-1">
-          {shareLink.toClipboard && (
-            <Button text={t("copy")} onClick={shareLink.toClipboard} />
-          )}
-          {shareLink.toAPI && (
-            <Button text={t("share")} onClick={shareLink.toAPI} />
-          )}
-        </span>
-      </p>
-      {brief && <PlayOption cid={cid} brief={brief} record={props.record} />}
+      {brief && (
+        <p className="mt-2">
+          <span className="hidden main-wide:inline-block mr-2">
+            {t("shareLink")}:
+          </span>
+          <a
+            className={"inline-block py-2 " + linkStyle1}
+            href={shareLink.path}
+            onClick={(e) => e.preventDefault()}
+          >
+            <span className="main-wide:hidden">{t("shareLink")}</span>
+            <span className="hidden main-wide:inline-block">
+              {shareLink.url}
+            </span>
+          </a>
+          <span className="inline-block ml-2 space-x-1">
+            {shareLink.toClipboard && (
+              <Button text={t("copy")} onClick={shareLink.toClipboard} />
+            )}
+            {shareLink.toAPI && (
+              <Button text={t("share")} onClick={shareLink.toAPI} />
+            )}
+          </span>
+        </p>
+      )}
+      {cid && brief && (
+        <PlayOption cid={cid} brief={brief} record={props.record} />
+      )}
     </div>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -95,7 +95,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -9719,7 +9719,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "@hono/node-server": "^1.14.0",
         "@vercel/og": "^0.6.5",
@@ -9731,7 +9731,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.98.0",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -79,10 +79,15 @@ const shareApp = (config: {
         }
         let titleEscapedJsStr = ""; // "{...\"TITLE\"}" inside script tag
         let titleEscapedHtml = ""; // <title>TITLE</title>, "TITLE" inside meta tag
+        const briefStr = JSON.stringify(brief);
+        let briefEscapedHtml = "";
         for (let i = 0; i < newTitle.length; i++) {
           titleEscapedJsStr +=
             "\\\\u" + newTitle.charCodeAt(i).toString(16).padStart(4, "0");
           titleEscapedHtml += "&#" + newTitle.charCodeAt(i) + ";";
+        }
+        for (let i = 0; i < briefStr.length; i++) {
+          briefEscapedHtml += "&#" + briefStr.charCodeAt(i) + ";";
         }
         const newDescription = resultParams
           ? t("descriptionWithResult", {
@@ -128,12 +133,8 @@ const shareApp = (config: {
               new URL(c.req.url).origin,
             ).toString(),
           )
-          .replaceAll("PLACEHOLDER_DESCRIPTION", newDescription);
-        // .replaceAll(
-        //   // これはjsファイルの中にしか現れないのでエスケープの必要はない
-        //   '"PLACEHOLDER_BRIEF"',
-        //   JSON.stringify(JSON.stringify(brief))
-        // );
+          .replaceAll("PLACEHOLDER_DESCRIPTION", newDescription)
+          .replaceAll("PLACEHOLDER_BRIEF", briefEscapedHtml);
         if (c.req.path.startsWith("/share") && lang !== qLang) {
           const q = new URLSearchParams(c.req.query());
           q.delete("lang");

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
#369 でassetsのURLの都合?でshareページのbodyをSSRせずクライアント側でfetchする仕様に変更していたが、遅いのでやっぱりSSRにする
jsコードを書き換えずにbriefデータを渡すため、metaタグを利用
