### PR TITLE
フレームレートの安定化

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,10 +1,16 @@
+## ver. 11.10 - 2025/04/19 [#503](https://github.com/na-trium-144/falling-nikochan/pull/503)
+
+* play画面のフレームレートができるだけ一定になるように修正
+* displayNoteの計算をrequestAnimationFrameではなくrender時に行う
+* Revert #496
+
 ## ver. 11.9 - 2025/04/17 [#499](https://github.com/na-trium-144/falling-nikochan/pull/499)
 
 * 非表示のレベルの編集では日付を更新しないようにする
 
 ## ver. 11.7 - 2025/04/16 [#496](https://github.com/na-trium-144/falling-nikochan/pull/496)
 
-* プレイ中にoutputLatencyの値が揺れるのを対策するため、latencyの最大値を使用する
+* <del>プレイ中にoutputLatencyの値が揺れるのを対策するため、latencyの最大値を使用する</del>
 
 ## ver. 11.6 - 2025/04/16 [#476](https://github.com/na-trium-144/falling-nikochan/pull/476)
 

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -791,7 +791,8 @@ function Play(props: Props) {
         </div>
         <div className={"relative flex-1"} ref={mainWindowSpace.ref}>
           <FallingWindow
-            frameDrop={frameDrop || 1}
+            maxFPS={maxFPS}
+            frameDrop={frameDrop}
             className="absolute inset-0"
             notes={notesAll}
             getCurrentTimeSec={getCurrentTimeSec}

--- a/frontend/app/[locale]/play/se.ts
+++ b/frontend/app/[locale]/play/se.ts
@@ -93,14 +93,7 @@ export function useSE(cid: string | undefined, userOffset: number) {
           ? audioContext.current.baseLatency +
             audioContext.current.outputLatency
           : null;
-      if (
-        audioLatency === undefined ||
-        (audioLatency === null && latency !== null) ||
-        (audioLatency !== null && latency === null) ||
-        (typeof audioLatency === "number" &&
-          typeof latency === "number" &&
-          audioLatency < latency)
-      ) {
+      if (audioLatency !== latency) {
         setAudioLatency(latency);
       }
     }, 100);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -95,7 +95,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -9820,7 +9820,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@vercel/og": "^0.6.8",
@@ -9832,7 +9832,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "11.9.0",
+      "version": "11.10.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.98.0",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "11.9.0",
+  "version": "11.10.0",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
* play画面のフレームレートができるだけ一定になるように修正
* displayNoteの計算をrequestAnimationFrameではなくrender時に行う
* Revert "audioLatencyは最大値を使用する (#496)"

どうしてもAndroidで音符の表示が揺れる。#496 は関係なさそうだったのでrevert。シンプルに性能が足りていなくてフレームレートが落ちているだけな気もするが、なんでそんなに重くなっているのかがわからん
