### PR TITLE
fetchエラーの処理を修正

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,9 @@
+## ver. 11.15 - 2025/04/19 [#507](https://github.com/na-trium-144/falling-nikochan/pull/507)
+
+* /api/latest や popular へのリクエストがエラーになったときstatusとmessageを表示する
+* serviceWorkerがAPIへのfetchに失敗した場合502を返す
+* /share が/api/briefへのアクセス中に発生したエラーステータスをそのまま返す
+
 ## ver. 11.13 - 2025/04/19 [#505](https://github.com/na-trium-144/falling-nikochan/pull/505)
 
 * プレイ中の時間の計算にDateではなくperformance.now()を使う

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "11.14.0",
+  "version": "11.15.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -275,7 +275,7 @@ export default function EditAuth(props: {
           console.error(e);
           setChart(undefined);
           setErrorStatus(undefined);
-          setErrorMsg(te("fetchError"));
+          setErrorMsg(te("api.fetchError"));
         }
         setLoading(false);
       }

--- a/frontend/app/[locale]/edit/metaTab.tsx
+++ b/frontend/app/[locale]/edit/metaTab.tsx
@@ -245,7 +245,7 @@ export function MetaTab(props: Props2) {
         }
       } catch (e) {
         console.error(e);
-        setErrorMsg(te("fetchError"));
+        setErrorMsg(te("api.fetchError"));
       }
     } else {
       const q = new URLSearchParams();
@@ -287,7 +287,7 @@ export function MetaTab(props: Props2) {
         }
       } catch (e) {
         console.error(e);
-        setErrorMsg(te("fetchError"));
+        setErrorMsg(te("api.fetchError"));
       }
     }
     props.chart!.changePasswd = null;

--- a/frontend/app/[locale]/main/edit/clientPage.tsx
+++ b/frontend/app/[locale]/main/edit/clientPage.tsx
@@ -56,7 +56,7 @@ export default function EditTab({ locale }: { locale: string }) {
     } catch (e) {
       console.error(e);
       setCidFetching(false);
-      setCIdErrorMsg(te("fetchError"));
+      setCIdErrorMsg(te("api.fetchError"));
       setInputCId("");
     }
   };

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -171,7 +171,7 @@ export function InitPlay({ locale }: { locale: string }) {
           setChartSeq(undefined);
           setErrorStatus(undefined);
           console.error(e);
-          setErrorMsg(te("fetchError"));
+          setErrorMsg(te("api.fetchError"));
         }
       })();
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "11.14.0",
+  "version": "11.15.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -26,9 +26,10 @@ export default {
       // 500
       imageGenerationFailed: "Failed to generate the image",
       unsupportedChartVersion: "Unsupported chart data version",
+      // 502
+      fetchError: "Failed to connect to the server",
     },
     unknownApiError: "An error occurred on the server",
-    fetchError: "Failed to connect to the server",
     noSession: "Failed to load session data",
     chartVersion: "The version of the chart data (ver. {ver}) is abnormal",
     badResponse: "Failed to interpret the response from the server",

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -26,9 +26,10 @@ export default {
       // 500
       imageGenerationFailed: "画像生成に失敗しました",
       unsupportedChartVersion: "サポートされていない譜面バージョンです",
+      // 502
+      fetchError: "サーバーへの接続に失敗しました",
     },
     unknownApiError: "サーバーで何らかのエラーが発生しました",
-    fetchError: "サーバーへの接続に失敗しました",
     noSession: "セッションデータを読み込めません",
     chartVersion: "譜面データのバージョン (ver. {ver}) が異常です",
     badResponse: "サーバーからの応答を解釈できません",

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "11.14.0",
+  "version": "11.15.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "11.14.0",
+      "version": "11.15.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "11.14.0",
+      "version": "11.15.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -95,7 +95,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "11.14.0",
+      "version": "11.15.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -9820,7 +9820,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "11.14.0",
+      "version": "11.15.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@vercel/og": "^0.6.8",
@@ -9832,7 +9832,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "11.14.0",
+      "version": "11.15.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.98.0",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "11.14.0",
+  "version": "11.15.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/route/serve-bun.ts
+++ b/route/serve-bun.ts
@@ -11,8 +11,8 @@ import {
   fetchStatic,
 } from "./src/index.js";
 import { Hono } from "hono";
-import { logger } from 'hono/logger'
-import briefApp from "./src/api/brief.js";
+import { logger } from "hono/logger";
+import { briefAppWithHandler } from "./src/api/brief.js";
 
 const port = 8787;
 
@@ -23,7 +23,8 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route(
     "/share",
     shareApp({
-      fetchBrief: (cid) => briefApp.request(`/${cid}`),
+      fetchBrief: (cid) =>
+        briefAppWithHandler({ fetchStatic }).request(`/api/${cid}`),
       fetchStatic,
     }),
   )

--- a/route/serve-local.ts
+++ b/route/serve-local.ts
@@ -13,7 +13,7 @@ import {
 } from "./src/index.js";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
-import briefApp from "./src/api/brief.js";
+import { briefAppWithHandler } from "./src/api/brief.js";
 
 const port = 8787;
 console.log(`Server is running on http://localhost:${port}`);
@@ -25,7 +25,8 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route(
     "/share",
     shareApp({
-      fetchBrief: (cid) => briefApp.request(`/${cid}`),
+      fetchBrief: (cid) =>
+        briefAppWithHandler({ fetchStatic }).request(`/api/${cid}`),
       fetchStatic,
     }),
   )

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -5,6 +5,7 @@ import { Bindings, cacheControl } from "../env.js";
 import { env } from "hono/adapter";
 import { CidSchema } from "@falling-nikochan/chart";
 import * as v from "valibot";
+import { onError } from "../error.js";
 
 const briefApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   "/:cid",
@@ -23,5 +24,12 @@ const briefApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
     }
   },
 );
+
+export const briefAppWithHandler = (config: {
+  fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
+}) =>
+  new Hono<{ Bindings: Bindings }>({ strict: false })
+    .route("/api", briefApp)
+    .onError(onError({ fetchStatic: config.fetchStatic }));
 
 export default briefApp;

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -15,8 +15,10 @@ export const onError =
   async (err: any, c: Context) => {
     console.error(`Error: ${err} in ${c.req.path}`);
     try {
-      const lang = c.get("language");
-      if (err instanceof ValiError) {
+      const lang = c.get("language") || "en";
+      if (err instanceof TypeError) {
+        err = new HTTPException(502, { message: "fetchError" });
+      } else if (err instanceof ValiError) {
         err = new HTTPException(400, { message: err.message });
       } else if (!(err instanceof HTTPException)) {
         err = new HTTPException(500);

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { Bindings, cacheControl, fetchStatic } from "../env.js";
 import { ImageResponse } from "@vercel/og";
-import briefApp from "../api/brief.js";
+import { briefAppWithHandler } from "../api/brief.js";
 import { HTTPException } from "hono/http-exception";
 import {
   ChartBrief,
@@ -29,7 +29,9 @@ const ogApp = new Hono<{ Bindings: Bindings }>({ strict: false })
     // /og/share/cid?brief=表示する全情報 で生成した画像を永久にキャッシュ
     // (vパラメータは /share でも追加されるけど)
     if (!c.req.query("brief")) {
-      const briefRes = await briefApp.request(`/${cid}`);
+      const briefRes = await briefAppWithHandler({ fetchStatic }).request(
+        `/api/${cid}`,
+      );
       if (!briefRes.ok) {
         let message = "";
         try {

--- a/route/tests/api/init.ts
+++ b/route/tests/api/init.ts
@@ -31,7 +31,7 @@ import {
   languageDetector,
   fetchStatic,
 } from "@falling-nikochan/route";
-import briefApp from "@falling-nikochan/route/src/api/brief";
+import { briefAppWithHandler } from "@falling-nikochan/route/src/api/brief";
 
 export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route("/api", apiApp)
@@ -39,7 +39,8 @@ export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route(
     "/share",
     shareApp({
-      fetchBrief: (cid) => briefApp.request(`/${cid}`),
+      fetchBrief: (cid) =>
+        briefAppWithHandler({ fetchStatic }).request(`/api/${cid}`),
       fetchStatic,
     }),
   )

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "11.14.0",
+  "version": "11.15.0",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
close #500
close #432
﻿
* /api/latest や popular へのリクエストがエラーになったときstatusとmessageを表示する
* serviceWorkerがAPIへのfetchに失敗した場合502を返す
* /share が/api/briefへのアクセス中に発生したエラーステータスをそのまま返す