### PR TITLE
音符数表示とmusicAreaのcssの変更

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,8 @@
+## ver. 11.27 - 2025/05/02 [#530](https://github.com/na-trium-144/falling-nikochan/pull/530)
+
+* 音符数表示をpcでは1の桁中央揃え、モバイルでは中央揃えに変更
+* iPadサイズの画面で使用するもう1段階大きいタイトル表示を実装
+
 ## ver. 11.25 - 2025/05/02 [#529](https://github.com/na-trium-144/falling-nikochan/pull/529)
 
 * pixi.js で描画するとsvgの画質が悪くなっていたため、ver11.23〜24をrevert
@@ -8,7 +13,7 @@
 
 ## ver. 11.21 - 2025/04/28 [#522](https://github.com/na-trium-144/falling-nikochan/pull/522)
 
- cssのgradientが使えない環境で代わりの背景色を設定
+* cssのgradientが使えない環境で代わりの背景色を設定
 * ipadのuserAgent認識を修正
 * iosではYouTubeの音量を変更できないので、YouTube音量変更のinputを無効化
 

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "11.26.0",
+  "version": "11.27.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "11.25.0",
+  "version": "11.26.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/common/version.ts
+++ b/frontend/app/[locale]/common/version.ts
@@ -1,6 +1,6 @@
 const versionKey = "lastVisited";
 const latestChangelogMajor = 11;
-const latestChangelogMinor = 19;
+const latestChangelogMinor = 27;
 export function lastVisitedOld(): boolean {
   try {
     const lastVisited = localStorage.getItem(versionKey);

--- a/frontend/app/[locale]/play/musicArea.tsx
+++ b/frontend/app/[locale]/play/musicArea.tsx
@@ -38,7 +38,8 @@ export function MusicArea(props: Props) {
   const { width, height, ref } = useResizeDetector();
   const { rem } = useDisplayMode();
   const ytHalf = width && width / 2 < 200;
-  const largeTitle = props.isMobile ? height && height > 8 * rem : true;
+  const largeTitle = props.isMobile ? height && height > 7.5 * rem : true;
+  const veryLargeTitle = props.isMobile ? height && height > 11.5 * rem : true;
 
   const t = useTranslations("play.message");
 
@@ -137,12 +138,20 @@ export function MusicArea(props: Props) {
           }
         >
           <div className={props.isMobile ? "h-0 overflow-visible " : ""}>
-            <p className={largeTitle ? "leading-5 " : "leading-3.5 "}>
+            <p
+              className={
+                veryLargeTitle ? "" : largeTitle ? "leading-5 " : "leading-3.5 "
+              }
+            >
               {/* x-hiddenとy-visibleを組み合わせることはできないが、clipならok? */}
               <span
                 className={
                   "inline-block font-title align-bottom " +
-                  (largeTitle ? "text-2xl/6 " : "text-lg/5 ") +
+                  (veryLargeTitle
+                    ? "block! text-3xl "
+                    : largeTitle
+                      ? "text-2xl/6 "
+                      : "text-lg/5 ") +
                   "overflow-x-clip overflow-y-visible " +
                   "max-w-full text-ellipsis text-nowrap "
                 }
@@ -153,7 +162,11 @@ export function MusicArea(props: Props) {
                 <span
                   className={
                     "inline-block font-title align-bottom " +
-                    (largeTitle ? "text-lg/5 " : "text-sm/3.5 ") +
+                    (veryLargeTitle
+                      ? "block! text-2xl "
+                      : largeTitle
+                        ? "text-lg/5 "
+                        : "text-sm/3.5 ") +
                     "overflow-x-clip overflow-y-visible " +
                     "max-w-full text-ellipsis text-nowrap "
                   }
@@ -163,21 +176,38 @@ export function MusicArea(props: Props) {
                 </span>
               )}
             </p>
-            <p className={largeTitle ? "leading-4.5 " : "leading-4 "}>
+            <p
+              className={
+                veryLargeTitle
+                  ? "leading-6 "
+                  : largeTitle
+                    ? "leading-4.5 "
+                    : "leading-4 "
+              }
+            >
               {props.lvIndex !== undefined &&
                 props.chartBrief?.levels[props.lvIndex] && (
                   <span
                     className={
-                      "inline-block leading-0 align-bottom " +
+                      "inline-block align-bottom " +
                       "overflow-x-clip overflow-y-visible " +
-                      "max-w-full text-ellipsis text-nowrap "
+                      "max-w-full text-ellipsis text-nowrap " +
+                      (veryLargeTitle
+                        ? "leading-6 "
+                        : largeTitle
+                          ? "leading-4.5 "
+                          : "leading-4 ")
                     }
                   >
                     {props.chartBrief?.levels[props.lvIndex].name && (
                       <span
                         className={
                           "font-title mr-1 align-bottom " +
-                          (largeTitle ? "text-lg/4 " : "text-sm/3.5 ")
+                          (veryLargeTitle
+                            ? "text-2xl "
+                            : largeTitle
+                              ? "text-lg/4 "
+                              : "text-sm/3.5 ")
                         }
                       >
                         {props.chartBrief?.levels[props.lvIndex].name}
@@ -186,7 +216,11 @@ export function MusicArea(props: Props) {
                     <span
                       className={
                         "align-bottom " +
-                        (largeTitle ? "text-base/3 " : "text-xs/2.5 ")
+                        (veryLargeTitle
+                          ? "text-xl "
+                          : largeTitle
+                            ? "text-base/3 "
+                            : "text-xs/2.5 ")
                       }
                     >
                       {props.lvType}-
@@ -194,7 +228,11 @@ export function MusicArea(props: Props) {
                     <span
                       className={
                         "align-bottom " +
-                        (largeTitle ? "text-xl/4 " : "text-lg/3.5 ")
+                        (veryLargeTitle
+                          ? "text-3xl "
+                          : largeTitle
+                            ? "text-xl/4 "
+                            : "text-lg/3.5 ")
                       }
                     >
                       {props.chartBrief?.levels[props.lvIndex]?.difficulty}
@@ -205,13 +243,22 @@ export function MusicArea(props: Props) {
                 className={
                   "inline-block align-bottom " +
                   "overflow-x-clip overflow-y-visible " +
-                  "max-w-full text-ellipsis text-nowrap "
+                  "max-w-full text-ellipsis text-nowrap " +
+                  (veryLargeTitle
+                    ? "leading-6 "
+                    : largeTitle
+                      ? "leading-4.5 "
+                      : "leading-4 ")
                 }
               >
                 <span
                   className={
                     "ml-2 align-bottom " +
-                    (largeTitle ? "text-sm/3.5 " : "text-xs/2.5")
+                    (veryLargeTitle
+                      ? "text-lg "
+                      : largeTitle
+                        ? "text-sm/3.5 "
+                        : "text-xs/2.5")
                   }
                 >
                   by
@@ -219,7 +266,11 @@ export function MusicArea(props: Props) {
                 <span
                   className={
                     "ml-1.5 font-title align-bottom " +
-                    (largeTitle ? "text-lg/4 " : "text-sm/3.5 ")
+                    (veryLargeTitle
+                      ? "text-2xl "
+                      : largeTitle
+                        ? "text-lg/4 "
+                        : "text-sm/3.5 ")
                   }
                 >
                   {props.chartBrief?.chartCreator}

--- a/frontend/app/[locale]/play/musicArea.tsx
+++ b/frontend/app/[locale]/play/musicArea.tsx
@@ -133,7 +133,7 @@ export function MusicArea(props: Props) {
         <div
           className={
             "flex-1 min-w-0 mr-1 flex flex-col justify-between " +
-            (props.isMobile ? "ml-3 mt-2 " : "")
+            (props.isMobile ? (largeTitle ? "ml-3 mt-4 " : "ml-3 mt-2 ") : "")
           }
         >
           <div className={props.isMobile ? "h-0 overflow-visible " : ""}>

--- a/frontend/app/[locale]/play/statusBox.tsx
+++ b/frontend/app/[locale]/play/statusBox.tsx
@@ -65,7 +65,7 @@ export default function StatusBox(props: Props) {
         {props.isMobile && screenWidth >= 39 * rem && (
           <span
             className={
-              "flex-none w-12 pl-1 self-end translate-y-1 flex flex-row items-baseline mr-2 " +
+              "flex-none w-12 self-end translate-y-1 flex flex-row items-baseline mr-2 " +
               (props.bigTotal === 0
                 ? "text-slate-400 dark:text-stone-600 "
                 : "")
@@ -88,7 +88,7 @@ export default function StatusBox(props: Props) {
           )}
         </StatusItem>
         {props.isMobile && screenWidth >= 35 * rem && (
-          <span className="flex-none w-12 pl-1 self-end translate-y-1 flex flex-row items-baseline">
+          <span className="flex-none w-12 self-end translate-y-1 flex flex-row items-baseline">
             <span className="flex-1">/</span>
             <span>{props.notesTotal}</span>
           </span>
@@ -153,21 +153,42 @@ function StatusName(props: { children: ReactNode }) {
   const { screenWidth, screenHeight } = useDisplayMode();
   const isMobile = screenWidth < screenHeight;
   return (
-    <span className={isMobile ? "h-max w-max" : "flex-1"}>
+    <span className={isMobile ? "h-max w-full text-center " : "flex-1"}>
       {props.children}
     </span>
   );
 }
-function StatusValue(props: { children: ReactNode }) {
-  return (
-    <span
-      className="text-right mt-1"
-      style={{
-        fontSize: "2em",
-        lineHeight: 1,
-      }}
-    >
-      {props.children}
-    </span>
-  );
+function StatusValue(props: { children: number }) {
+  const { screenWidth, screenHeight } = useDisplayMode();
+  const isMobile = screenWidth < screenHeight;
+  if (isMobile) {
+    return (
+      <span
+        className="mt-1 w-full text-center "
+        style={{
+          fontSize: "2em",
+          lineHeight: 1,
+        }}
+      >
+        {props.children}
+      </span>
+    );
+  } else {
+    return (
+      <span
+        className="inline-flex mt-1 w-4 justify-center items-baseline "
+        style={{
+          fontSize: "2em",
+          lineHeight: 1,
+        }}
+      >
+        <span className="relative w-max ">
+          {props.children % 10}
+          <span className="absolute inset-y-0 right-full ">
+            {props.children >= 10 && Math.floor(props.children / 10)}
+          </span>
+        </span>
+      </span>
+    );
+  }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "11.25.0",
+  "version": "11.26.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "11.26.0",
+  "version": "11.27.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/en/changelog.mdx
+++ b/i18n/en/changelog.mdx
@@ -2,6 +2,14 @@ import { Key } from "@/common/key.js";
 import { SlimeSVG } from "@/common/slime.js";
 import { TranslateIcon } from "@/common/mdxIcons.js";
 
+## ver. 11.27 - 05/02/2025
+
+- Enlarged the display of song names, etc. when playing on a screen size like an iPad.
+
+## ver. 11.21 - 04/28/2025
+
+- Fixed an issue where the background appeared completely white on iOS 16 and earlier.
+
 ## ver. 11.19 - 04/24/2025
 
 - Updated the sample chart list.

--- a/i18n/ja/changelog.mdx
+++ b/i18n/ja/changelog.mdx
@@ -4,6 +4,14 @@ import { Key } from "@/common/key.js";
 import { SlimeSVG } from "@/common/slime.js";
 import { TranslateIcon, SunIcon, HelpIcon } from "@/common/mdxIcons.js";
 
+## ver. 11.27 - 2025/05/02
+
+- iPadのような画面サイズでプレイする際の曲名などの表示を大きくしました。
+
+## ver. 11.21 - 2025/04/28
+
+- iOS16以下で背景が真っ白に表示されるのを修正しました。
+
 ## ver. 11.19 - 2025/04/24
 
 - サンプル譜面リストを更新しました。

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "11.25.0",
+  "version": "11.26.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "11.26.0",
+  "version": "11.27.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "11.26.0",
+      "version": "11.27.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "11.26.0",
+      "version": "11.27.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -95,7 +95,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "11.26.0",
+      "version": "11.27.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -9820,7 +9820,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "11.26.0",
+      "version": "11.27.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@vercel/og": "^0.6.8",
@@ -9832,7 +9832,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "11.26.0",
+      "version": "11.27.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.98.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "11.25.0",
+      "version": "11.26.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -43,7 +43,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "11.25.0",
+      "version": "11.26.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -95,7 +95,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "11.25.0",
+      "version": "11.26.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -9820,7 +9820,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "11.25.0",
+      "version": "11.26.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@vercel/og": "^0.6.8",
@@ -9832,7 +9832,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "11.25.0",
+      "version": "11.26.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.98.0",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "11.26.0",
+  "version": "11.27.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "11.25.0",
+  "version": "11.26.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "11.25.0",
+  "version": "11.26.0",
   "private": true,
   "type": "module",
   "devDependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "11.26.0",
+  "version": "11.27.0",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
- 音符数表示をpcは1の桁中央揃え/モバイルは中央揃えに変更
- musicAreaにveryLargeTitleモードを追加 (iPad用)