### PR TITLE
play中の画像アセットを音符1個ごとにfetchしないようbase64のdataURLに変更

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 11.35 - 2025/05/06 [#555](https://github.com/na-trium-144/falling-nikochan/pull/555)
+
+* play中の画像アセットを音符1個ごとにfetchしないようbase64のdataURLに変更
+
 ## ver. 11.34 - 2025/05/05 [#553](https://github.com/na-trium-144/falling-nikochan/pull/553)
 
 * sitemapの生成

--- a/chart/package.json
+++ b/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/chart",
-  "version": "11.34.0",
+  "version": "11.35.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/frontend/app/[locale]/common/version.ts
+++ b/frontend/app/[locale]/common/version.ts
@@ -1,6 +1,6 @@
 const versionKey = "lastVisited";
 const latestChangelogMajor = 11;
-const latestChangelogMinor = 30;
+const latestChangelogMinor = 35;
 export function lastVisitedOld(): boolean {
   try {
     const lastVisited = localStorage.getItem(versionKey);

--- a/frontend/app/[locale]/play/fallingWindow.tsx
+++ b/frontend/app/[locale]/play/fallingWindow.tsx
@@ -102,8 +102,8 @@ export default function FallingWindow(props: Props) {
     Promise.all(
       [0, 1, 2, 3].map((i) =>
         fetch(process.env.ASSET_PREFIX + `/assets/nikochan${i}.svg`)
-          .then((res) => res.blob())
-          .then((blob) => URL.createObjectURL(blob)),
+          .then((res) => res.text())
+          .then((text) => `data:image/svg+xml;base64,${btoa(text)}`),
       ),
     ).then((urls) => {
       nikochanAssets.current = urls;
@@ -112,17 +112,13 @@ export default function FallingWindow(props: Props) {
       Array.from(new Array(13)).map((_, i) =>
         [4, 6, 8, 10, 12].includes(i)
           ? fetch(process.env.ASSET_PREFIX + `/assets/particle${i}.svg`)
-              .then((res) => res.blob())
-              .then((blob) => URL.createObjectURL(blob))
+              .then((res) => res.text())
+              .then((text) => `data:image/svg+xml;base64,${btoa(text)}`)
           : "",
       ),
     ).then((urls) => {
       particleAssets.current = urls;
     });
-    return () => {
-      nikochanAssets.current.forEach((url) => URL.revokeObjectURL(url));
-      particleAssets.current.forEach((url) => URL.revokeObjectURL(url));
-    }
   }, []);
 
   return (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "11.34.0",
+  "version": "11.35.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/i18n/en/changelog.mdx
+++ b/i18n/en/changelog.mdx
@@ -2,6 +2,10 @@ import { Key } from "@/common/key.js";
 import { SlimeSVG } from "@/common/slime.js";
 import { TranslateIcon } from "@/common/mdxIcons.js";
 
+## ver. 11.35 - 05/06/2025
+
+- Fixed an issue where the processing speed slowed down each time a note was hit on Android Chrome.
+
 ## ver. 11.30 - 05/03/2025
 
 - Changed the icon and color settings when adding to the home screen as an app.

--- a/i18n/ja/changelog.mdx
+++ b/i18n/ja/changelog.mdx
@@ -4,6 +4,10 @@ import { Key } from "@/common/key.js";
 import { SlimeSVG } from "@/common/slime.js";
 import { TranslateIcon, SunIcon, HelpIcon } from "@/common/mdxIcons.js";
 
+## ver. 11.35 - 2025/05/06
+
+- AndroidのChromeで音符を叩くたびに処理速度が遅くなるのを改善しました
+
 ## ver. 11.30 - 2025/05/03
 
 - アプリとしてホーム画面に追加する際のアイコンや色設定などを変更しました

--- a/i18n/package.json
+++ b/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/i18n",
-  "version": "11.34.0",
+  "version": "11.35.0",
   "private": true,
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
     },
     "chart": {
       "name": "@falling-nikochan/chart",
-      "version": "11.34.0",
+      "version": "11.35.0",
       "dependencies": {
         "@ygoe/msgpack": "^1.0.3",
         "valibot": "^1.0.0",
@@ -44,7 +44,7 @@
     },
     "frontend": {
       "name": "@falling-nikochan/frontend",
-      "version": "11.34.0",
+      "version": "11.35.0",
       "dependencies": {
         "@fontsource/kaisei-opti": "^5.2.5",
         "@fontsource/merriweather": "=5.2.5",
@@ -724,7 +724,7 @@
     },
     "i18n": {
       "name": "@falling-nikochan/i18n",
-      "version": "11.34.0",
+      "version": "11.35.0",
       "dependencies": {
         "next-intl": "^4.0.2"
       }
@@ -10551,7 +10551,7 @@
     },
     "route": {
       "name": "@falling-nikochan/route",
-      "version": "11.34.0",
+      "version": "11.35.0",
       "dependencies": {
         "@hono/node-server": "^1.14.1",
         "@vercel/og": "^0.6.8",
@@ -10565,7 +10565,7 @@
     },
     "worker": {
       "name": "@falling-nikochan/worker",
-      "version": "11.34.0",
+      "version": "11.35.0",
       "devDependencies": {
         "ts-loader": "^9.5.2",
         "webpack": "^5.99.7",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "11.34.0",
+  "version": "11.35.0",
   "private": true,
   "type": "module",
   "main": "dist/src/index.js",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/worker",
-  "version": "11.34.0",
+  "version": "11.35.0",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
objectURLよりbase64のほうが若干速そうな気がした

Androidでの動作がちょっと軽くなった (けど、完全に解決したわけではない)