### PR TITLE
iframeの中で動くようにする

### DIFF
--- a/frontend/app/[locale]/common/extLink.tsx
+++ b/frontend/app/[locale]/common/extLink.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx/lite";
 import { useStandaloneDetector } from "./pwaInstall";
 import Link from "next/link";
 import EfferentThree from "@icon-park/react/lib/icons/EfferentThree";
+import { useInsideFrameDetector } from "@/scale";
 
 interface Props {
   className?: string;
@@ -23,6 +24,7 @@ function LinkChildren(props: Props) {
 }
 export function ExternalLink(props: Props) {
   const isStandalone = useStandaloneDetector();
+  const isInsideFrame = useInsideFrameDetector();
   if (props.onClick) {
     return (
       <button
@@ -32,7 +34,7 @@ export function ExternalLink(props: Props) {
         <LinkChildren {...props} />
       </button>
     );
-  } else if (props.href?.startsWith("/") && isStandalone) {
+  } else if (props.href?.startsWith("/") && (isStandalone || isInsideFrame)) {
     return (
       <Link className={clsx("fn-link-1", props.className)} href={props.href}>
         <LinkChildren {...props} />

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -34,6 +34,7 @@ import { isStandalone } from "@/common/pwaInstall";
 import * as v from "valibot";
 import fnCommandsLib from "fn-commands?raw";
 import fnCommandsPackageJson from "fn-commands/package.json";
+import { isInsideFrame } from "@/scale";
 
 interface Props {
   onLoad: (cid: string) => void;
@@ -374,7 +375,7 @@ export function useChartState(props: Props) {
             }
           );
           if (res.ok) {
-            if (isStandalone()) {
+            if (isStandalone() || isInsideFrame()) {
               history.back();
             } else {
               window.close();

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -24,7 +24,7 @@ import { LuaTabPlaceholder, LuaTabProvider, useLuaExecutor } from "./luaTab.js";
 import Select from "@/common/select.js";
 import LevelTab from "./levelTab.js";
 import { initSession, SessionData } from "@/play/session.js";
-import { useDisplayMode } from "@/scale.js";
+import { useDisplayMode, useInsideFrameDetector } from "@/scale.js";
 import Forbid from "@icon-park/react/lib/icons/Forbid";
 import Move from "@icon-park/react/lib/icons/Move";
 import { GuideMain } from "./guideMain.js";
@@ -53,6 +53,7 @@ export default function Edit(props: {
   const t = useTranslations("edit");
   const { isTouch } = useDisplayMode();
   const standalone = useStandaloneDetector();
+  const insideFrame = useInsideFrameDetector();
 
   const luaExecutor = useLuaExecutor();
 
@@ -524,7 +525,10 @@ export default function Edit(props: {
           "fn-mh-blur"
         )}
       >
-        <MobileHeader className="flex-1 " noBackButton={!standalone}>
+        <MobileHeader
+          className="flex-1 "
+          noBackButton={!standalone && !insideFrame}
+        >
           {t("titleShort")} ID: {chart?.cid}
         </MobileHeader>
         <Button text={t("help")} onClick={openGuide} />
@@ -608,7 +612,7 @@ export default function Edit(props: {
             )}
           >
             <div className="hidden edit-wide:flex flex-row items-baseline mb-3 space-x-2">
-              {standalone && (
+              {(standalone || insideFrame) && (
                 <button
                   className={clsx("fn-link-1")}
                   onClick={() => {

--- a/frontend/app/[locale]/edit/metaTab.tsx
+++ b/frontend/app/[locale]/edit/metaTab.tsx
@@ -14,7 +14,7 @@ import { chartMaxEvent } from "@falling-nikochan/chart";
 import { useShareLink } from "@/common/shareLinkAndImage";
 import { isStandalone } from "@/common/pwaInstall";
 import { useRouter } from "next/navigation";
-import { useDisplayMode } from "@/scale.js";
+import { isInsideFrame, useDisplayMode } from "@/scale.js";
 import { LocalLoadError, LocalLoadState, SaveState } from "./chartState";
 import { APIError } from "@/common/apiError";
 
@@ -156,7 +156,7 @@ export function MetaTab(props: Props2) {
           onClick={() => {
             if (props.sessionData) {
               initSession(props.sessionData, props.sessionId);
-              if (isStandalone()) {
+              if (isStandalone() || isInsideFrame()) {
                 props.saveEditSession();
                 router.push(`/${props.locale}/play?sid=${props.sessionId}`);
               } else {

--- a/frontend/app/[locale]/edit/passwdPrompt.tsx
+++ b/frontend/app/[locale]/edit/passwdPrompt.tsx
@@ -13,6 +13,7 @@ import {
   historyBackWithReview,
   useStandaloneDetector,
 } from "@/common/pwaInstall";
+import { useInsideFrameDetector } from "@/scale";
 
 interface PasswdProps {
   loadStatus: LoadState;
@@ -32,6 +33,7 @@ export function PasswdPrompt(props: PasswdProps) {
   const [editPasswd, setEditPasswd] = useState<string>("");
   const te = useTranslations("error");
   const standalone = useStandaloneDetector();
+  const insideFrame = useInsideFrameDetector();
 
   const [cid, setCId] = useState<string>("");
   useEffect(() => {
@@ -56,7 +58,7 @@ export function PasswdPrompt(props: PasswdProps) {
         )}
         <p className="mb-3">{props.loadStatus.formatMsg(te)}</p>
         {props.loadStatus.isServerSide() && <LinksOnError />}
-        {standalone && (
+        {(standalone || insideFrame) && (
           <p>
             <Button text={t("back")} onClick={historyBackWithReview} />
           </p>
@@ -130,7 +132,7 @@ export function PasswdPrompt(props: PasswdProps) {
             </button>
           </div>
         )}
-        {standalone && (
+        {(standalone || insideFrame) && (
           <p>
             <Button text={t("back")} onClick={historyBackWithReview} />
           </p>

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -15,7 +15,7 @@ import { getBestScore } from "@/common/bestScore.js";
 import { useSharePageModal } from "@/common/sharePageModal.jsx";
 import { fetchBrief } from "@/common/briefCache.js";
 import { useResizeDetector } from "react-resize-detector";
-import { useDisplayMode } from "@/scale.jsx";
+import { useDisplayMode, useInsideFrameDetector } from "@/scale.jsx";
 import { ButtonHighlight } from "@/common/button.jsx";
 import { APIError } from "@/common/apiError.js";
 
@@ -399,10 +399,11 @@ interface CProps {
 }
 export function ChartListItem(props: CProps) {
   const isStandalone = useStandaloneDetector();
+  const isInsideFrame = useInsideFrameDetector();
 
   return (
     <li className="fn-cl-item">
-      {props.onClick || (props.newTab && !isStandalone) ? (
+      {props.onClick || (props.newTab && !isStandalone && !isInsideFrame) ? (
         <>
           <a
             href={props.href}

--- a/frontend/app/[locale]/main/edit/clientPage.tsx
+++ b/frontend/app/[locale]/main/edit/clientPage.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import Youtube from "@icon-park/react/lib/icons/Youtube.js";
 import Caution from "@icon-park/react/lib/icons/Caution.js";
 import { APIError } from "@/common/apiError.js";
+import { isInsideFrame } from "@/scale.jsx";
 
 export default function EditTab({ locale }: { locale: string }) {
   const t = useTranslations("main.edit");
@@ -41,7 +42,7 @@ export default function EditTab({ locale }: { locale: string }) {
       );
       setCidFetching(false);
       if (res.ok) {
-        if (isStandalone()) {
+        if (isStandalone() || isInsideFrame()) {
           router.push(`/${locale}/edit?cid=${cid}`);
         } else {
           window.open(`/${locale}/edit?cid=${cid}`, "_blank")?.focus(); // これで新しいタブが開かない場合がある

--- a/frontend/app/[locale]/metadata.ts
+++ b/frontend/app/[locale]/metadata.ts
@@ -35,6 +35,7 @@ export async function initMetadata(
     image?: string;
     noAlternate?: boolean;
     custom?: { [key: string]: string };
+    alternateTypes?: { [key: string]: string };
   }
 ): Promise<Metadata> {
   const locale = (await params).locale || "en";
@@ -59,6 +60,7 @@ export async function initMetadata(
                 },
                 {} as { [key: string]: string }
               ),
+          types: options?.alternateTypes || {},
         }
       : undefined,
     description,

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -39,7 +39,7 @@ import { useResizeDetector } from "react-resize-detector";
 import { ChartBrief } from "@falling-nikochan/chart";
 import * as msgpack from "@msgpack/msgpack";
 import { CenterBox } from "@/common/box.js";
-import { useDisplayMode } from "@/scale.js";
+import { isInsideFrame, useDisplayMode } from "@/scale.js";
 import { addRecent } from "@/common/recent.js";
 import Result, { resultAnimDelays } from "./result.js";
 import { getBestScore, setBestScore } from "@/common/bestScore.js";
@@ -536,7 +536,7 @@ function Play(props: Props) {
   }, [chartPlaying, ytVolume]);
   const exit = useCallback(() => {
     // router.replace(`/share/${cid}`);
-    if (isStandalone()) {
+    if (isStandalone() || isInsideFrame()) {
       historyBackWithReview();
     } else {
       window.close();

--- a/frontend/app/[locale]/scale.tsx
+++ b/frontend/app/[locale]/scale.tsx
@@ -75,3 +75,12 @@ export function hasTouch() {
     return "ontouchstart" in window;
   }
 }
+
+export function isInsideFrame() {
+  return window.self !== window.top;
+}
+export function useInsideFrameDetector() {
+  const [state, setState] = useState<boolean | null>(null);
+  useEffect(() => setState(isInsideFrame()), []);
+  return state;
+}

--- a/frontend/app/[locale]/scale.tsx
+++ b/frontend/app/[locale]/scale.tsx
@@ -64,13 +64,10 @@ export function useDisplayMode(): DisplayMode {
 }
 
 export function hasTouch() {
-  // Bug in FireFox+Windows 10, navigator.maxTouchPoints is incorrect when script is running inside frame.
-  // TBD: report to bugzilla.
-  const navigator = (window.top || window).navigator;
-  const maxTouchPoints = Number.isFinite(navigator.maxTouchPoints)
-    ? navigator.maxTouchPoints
+  const maxTouchPoints = Number.isFinite(window.navigator.maxTouchPoints)
+    ? window.navigator.maxTouchPoints
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (navigator as any).msMaxTouchPoints;
+      (window.navigator as any).msMaxTouchPoints;
   if (Number.isFinite(maxTouchPoints)) {
     // Windows 10 system reports that it supports touch, even though it acutally doesn't (ignore msMaxTouchPoints === 256).
     return maxTouchPoints > 0 && maxTouchPoints !== 256;

--- a/frontend/app/[locale]/share/placeholder/page.tsx
+++ b/frontend/app/[locale]/share/placeholder/page.tsx
@@ -10,6 +10,10 @@ export async function generateMetadata({ params }: MetadataProps) {
     {
       image: "https://placeholder_og_image/",
       noAlternate: true,
+      alternateTypes: {
+        "application/json+oembed": "https://placeholder_oembed/json",
+        "text/xml+oembed": "https://placeholder_oembed/xml",
+      },
       custom: { nikochanSharingBrief: "PLACEHOLDER_BRIEF" },
     }
   );

--- a/frontend/app/[locale]/share/placeholder/playOption.tsx
+++ b/frontend/app/[locale]/share/placeholder/playOption.tsx
@@ -29,6 +29,7 @@ import { SlimeSVG } from "@/common/slime";
 import ArrowRight from "@icon-park/react/lib/icons/ArrowRight";
 import { useShareLink } from "@/common/shareLinkAndImage";
 import { APIError } from "@/common/apiError";
+import { isInsideFrame } from "@/scale";
 
 interface Props {
   locale: string;
@@ -157,7 +158,7 @@ export function PlayOption(props: Props) {
                 lvIndex: selectedLevel,
                 brief: props.brief,
               });
-              if (isStandalone()) {
+              if (isStandalone() || isInsideFrame()) {
                 router.push(`/${props.locale}/play?sid=${sessionId}`);
               } else {
                 window

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       valibot:
         specifier: ^1.0.0
         version: 1.2.0(typescript@5.9.3)
+      xmlbuilder2:
+        specifier: ^4.0.3
+        version: 4.0.3
     devDependencies:
       '@falling-nikochan/route':
         specifier: workspace:*
@@ -1480,6 +1483,22 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@oozcitak/dom@2.0.2':
+    resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/infra@2.0.2':
+    resolution: {integrity: sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/url@3.0.0':
+    resolution: {integrity: sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/util@10.0.0':
+    resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
+    engines: {node: '>=20.0'}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -4771,6 +4790,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xmlbuilder2@4.0.3:
+    resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
+    engines: {node: '>=20.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5967,6 +5990,23 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@oozcitak/dom@2.0.2':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/url': 3.0.0
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/infra@2.0.2':
+    dependencies:
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/url@3.0.0':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/util@10.0.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -9724,6 +9764,13 @@ snapshots:
       strip-ansi: 7.1.2
 
   ws@8.19.0: {}
+
+  xmlbuilder2@4.0.3:
+    dependencies:
+      '@oozcitak/dom': 2.0.2
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+      js-yaml: 4.1.1
 
   yallist@3.1.1: {}
 

--- a/route/package.json
+++ b/route/package.json
@@ -36,7 +36,8 @@
     "react": "^19.2.4",
     "sitemap": "^9.0.0",
     "twitter-text": "^3.1.0",
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0",
+    "xmlbuilder2": "^4.0.3"
   },
   "devDependencies": {
     "@falling-nikochan/route": "workspace:*",

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -1,7 +1,7 @@
 import { Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import briefApp from "./brief.js";
-import { Bindings } from "../env.js";
+import { Bindings, fetchBrief, fetchStatic } from "../env.js";
 import chartFileApp from "./chartFile.js";
 import latestApp from "./latest.js";
 import newChartFileApp from "./newChartFile.js";
@@ -22,6 +22,7 @@ import { Scalar } from "@scalar/hono-api-reference";
 import { ConnInfo } from "hono/conninfo";
 import ytMetaApp from "./ytMeta.js";
 import { forwardCheckApp } from "./dbRateLimit.js";
+import oembedApp from "./oembed.js";
 dotenv.config({ path: join(dirname(process.cwd()), ".env") });
 
 const apiApp = async (config: {
@@ -64,7 +65,11 @@ const apiApp = async (config: {
     .route("/search", searchApp)
     .route("/hashPasswd", hashPasswdApp)
     .route("/record", await recordApp({ getConnInfo: config.getConnInfo }))
-    .route("/ip", forwardCheckApp({ getConnInfo: config.getConnInfo }));
+    .route("/ip", forwardCheckApp({ getConnInfo: config.getConnInfo }))
+    .route(
+      "/oembed",
+      await oembedApp({ fetchBrief: fetchBrief({ fetchStatic }) })
+    );
   apiApp.get(
     "/openapi.json",
     openAPIRouteHandler(apiApp, {

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -1,0 +1,160 @@
+import { ExecutionContext, Hono } from "hono";
+import { cache } from "hono/cache";
+import { Bindings, cacheControl } from "../env.js";
+import { env } from "hono/adapter";
+import { ChartBrief } from "@falling-nikochan/chart";
+import * as v from "valibot";
+import { describeRoute, resolver, validator } from "hono-openapi";
+import { errorLiteral } from "../error.js";
+import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
+import xmlbuilder2 from "xmlbuilder2";
+
+// Cache duration for this API endpoint (in seconds)
+const CACHE_MAX_AGE = 600;
+
+const OEmbedSchema = () =>
+  v.object({
+    type: v.string(),
+    version: v.literal("1.0"),
+    title: v.string(),
+    author_name: v.optional(v.string()),
+    author_url: v.optional(v.string()),
+    provider_name: v.optional(v.string()),
+    provider_url: v.optional(v.string()),
+    cache_age: v.optional(v.number()),
+    thumbnail_url: v.optional(v.string()),
+    thumbnail_width: v.optional(v.number()),
+    thumbnail_height: v.optional(v.number()),
+    // rich type
+    html: v.optional(v.string()),
+    width: v.optional(v.number()),
+    height: v.optional(v.number()),
+  });
+const OEmbedParamSchema = () =>
+  v.object({
+    url: v.string(),
+    maxwidth: v.optional(v.pipe(v.string(), v.toNumber())),
+    maxheight: v.optional(v.pipe(v.string(), v.toNumber())),
+    format: v.optional(v.union([v.literal("json"), v.literal("xml")])),
+  });
+
+const oembedApp = async (config: {
+  fetchBrief: (
+    e: Bindings,
+    cid: string,
+    ctx: ExecutionContext | undefined
+  ) => Response | Promise<Response>;
+}) =>
+  new Hono<{ Bindings: Bindings }>({ strict: false }).get(
+    "/",
+    cache({
+      cacheName: "api-oembed",
+      cacheControl: `max-age=${CACHE_MAX_AGE}`,
+    }),
+    describeRoute({
+      description:
+        "Get oEmbed information about the chart according to oEmbed spec: https://oembed.com/",
+      responses: {
+        200: {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: resolver(OEmbedSchema()),
+            },
+            "text/xml": {
+              schema: resolver(OEmbedSchema()),
+            },
+          },
+        },
+        404: {
+          description: "Chart not found or invalid url",
+          content: {
+            "application/json": {
+              schema: resolver(
+                await errorLiteral("notFound", "chartIdNotFound")
+              ),
+            },
+          },
+        },
+      },
+    }),
+    validator("query", OEmbedParamSchema()),
+    async (c) => {
+      const {
+        url: embedUrl,
+        // maxwidth,
+        // maxheight,
+        format: resFormat,
+      } = c.req.valid("query");
+      const match = new URL(embedUrl).pathname.match(
+        /^\/(?:embed|share)\/([0-9]+)$/
+      );
+      const cid = match ? match[1] : null;
+      if (!cid) {
+        return c.json({ message: "notFound" }, 404);
+      }
+
+      const t = await getTranslations("en", "share");
+
+      let executionCtx: ExecutionContext | undefined = undefined;
+      try {
+        executionCtx = c.executionCtx;
+      } catch {
+        //ignore
+      }
+      const briefRes = await config.fetchBrief(env(c), cid, executionCtx);
+      if (!briefRes.ok) {
+        return briefRes;
+      }
+      const brief = (await briefRes.json()) as ChartBrief;
+
+      const iframeURL = new URL(
+        `/share/${cid}`,
+        new URL(env(c).BACKEND_PREFIX || c.req.url).origin
+      );
+      const oembed: v.InferOutput<ReturnType<typeof OEmbedSchema>> = {
+        type: "rich",
+        version: "1.0",
+        title: brief.composer
+          ? t("titleWithComposer", {
+              title: brief.title,
+              composer: brief.composer,
+              cid: cid,
+            })
+          : t("title", {
+              title: brief.title,
+              cid: cid,
+            }),
+        author_name: brief.chartCreator,
+        provider_name: "Falling Nikochan",
+        provider_url: new URL(env(c).BACKEND_PREFIX || c.req.url).origin,
+        cache_age: CACHE_MAX_AGE,
+        // TODO: maxwidth, maxheight
+        html: `<iframe width="640" height="480" src="${iframeURL}" sandbox="allow-scripts allow-same-origin"></iframe>`,
+        width: 640,
+        height: 480,
+      };
+
+      switch (resFormat) {
+        case "json":
+        case undefined:
+          return c.json(oembed, 200, {
+            "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+          });
+        case "xml":
+          return c.body(
+            xmlbuilder2.create({ oembed }).end({ prettyPrint: true }),
+            200,
+            {
+              "Content-Type": "text/xml",
+              "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+            }
+          );
+        default:
+          resFormat satisfies never;
+          return c.body(null, 400);
+      }
+    }
+  );
+
+export default oembedApp;

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -82,8 +82,8 @@ const oembedApp = async (config: {
     async (c) => {
       const {
         url: embedUrl,
-        // maxwidth,
-        // maxheight,
+        maxwidth,
+        maxheight,
         format: resFormat,
       } = c.req.valid("query");
       const match = new URL(embedUrl).pathname.match(
@@ -112,6 +112,12 @@ const oembedApp = async (config: {
         `/share/${cid}`,
         new URL(env(c).BACKEND_PREFIX || c.req.url).origin
       );
+      const width = Math.round(maxwidth || 640);
+      const height = Math.round(
+        maxheight
+          ? Math.min(maxheight, ((maxwidth || Infinity) / 4) * 3)
+          : (width / 4) * 3
+      );
       const oembed: v.InferOutput<ReturnType<typeof OEmbedSchema>> = {
         type: "rich",
         version: "1.0",
@@ -129,10 +135,9 @@ const oembedApp = async (config: {
         provider_name: "Falling Nikochan",
         provider_url: new URL(env(c).BACKEND_PREFIX || c.req.url).origin,
         cache_age: CACHE_MAX_AGE,
-        // TODO: maxwidth, maxheight
-        html: `<iframe width="640" height="480" src="${iframeURL}" sandbox="allow-scripts allow-same-origin"></iframe>`,
-        width: 640,
-        height: 480,
+        html: `<iframe width="${width}" height="${height}" src="${iframeURL}" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"></iframe>`,
+        width,
+        height,
       };
 
       switch (resFormat) {

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -162,9 +162,26 @@ const shareApp = (config: {
             `location.replace("${newPath}");` +
             "</script></body></html>";
         }
+
+        const thisURL = new URL(
+          `/share/${cid}`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
+        const oembedJsonURL = new URL(
+          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=json`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
+        const oembedXmlURL = new URL(
+          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=xml`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
         return c.text(replacedBody, 200, {
           "Content-Type": res.headers.get("Content-Type") || "text/plain",
           "Cache-Control": cacheControl(env(c), null),
+          "Link": [
+            `<${oembedJsonURL.toString()}>; rel="alternate"; type="application/json+oembed"; title="${escapeHtml(newTitle)}"`,
+            `<${oembedXmlURL.toString()}>; rel="alternate"; type="text/xml+oembed"; title="${escapeHtml(newTitle)}"`,
+          ],
         });
       } else {
         let message = "";

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -126,6 +126,18 @@ const shareApp = (config: {
               title: brief.title,
             });
         const briefStr = JSON.stringify(brief);
+        const thisURL = new URL(
+          `/share/${cid}`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
+        const oembedJsonURL = new URL(
+          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=json`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
+        const oembedXmlURL = new URL(
+          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=xml`,
+          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+        );
         // キャッシュが正しく動作するように、クエリパラメータの順番が常に一定である必要がある
         const ogQuery = new URLSearchParams();
         ogQuery.set("lang", qLang);
@@ -151,7 +163,15 @@ const shareApp = (config: {
           )
           .replaceAll("PLACEHOLDER_DESCRIPTION", escapeHtml(newDescription))
           .replaceAll('\\"PLACEHOLDER_BRIEF', '\\"' + escapeJs(briefStr))
-          .replaceAll("PLACEHOLDER_BRIEF", escapeHtml(briefStr));
+          .replaceAll("PLACEHOLDER_BRIEF", escapeHtml(briefStr))
+          .replaceAll(
+            "https://placeholder_oembed/json",
+            oembedJsonURL.toString()
+          )
+          .replaceAll(
+            "https://placeholder_oembed/xml",
+            oembedXmlURL.toString()
+          );
         if (c.req.path.startsWith("/share") && lang !== qLang) {
           const q = new URLSearchParams(c.req.query());
           q.delete("lang");
@@ -163,25 +183,17 @@ const shareApp = (config: {
             "</script></body></html>";
         }
 
-        const thisURL = new URL(
-          `/share/${cid}`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
-        const oembedJsonURL = new URL(
-          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=json`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
-        const oembedXmlURL = new URL(
-          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=xml`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
         return c.text(replacedBody, 200, {
           "Content-Type": res.headers.get("Content-Type") || "text/plain",
           "Cache-Control": cacheControl(env(c), null),
+          /*
+          Linkヘッダーかmetaタグのどちらかがあればいいはずだが、
+          Linkタグは例えばdiscordで動作しないらしい?: https://github.com/discord/discord-api-docs/issues/7370
           "Link": [
             `<${oembedJsonURL.toString()}>; rel="alternate"; type="application/json+oembed"; title="${escapeHtml(newTitle)}"`,
             `<${oembedXmlURL.toString()}>; rel="alternate"; type="text/xml+oembed"; title="${escapeHtml(newTitle)}"`,
           ],
+          */
         });
       } else {
         let message = "";


### PR DESCRIPTION
需要があるかはわからないが、間違えてNotionに貼った時にApplicationErrorとだけ表示されるのは不親切なので、エラーを直したらiframeで動かせるのか試してみる

* [x] window.topのSecurityError対応
* [x] iframe内でプレイ画面を開く
  * やっぱり別タブのほうが良いか...? 
  * sandboxのオプションによっては別タブが開けないかもしれない
* [ ] localStorageのエラーを解消 https://qiita.com/torotake/items/fbe93a3845242b82b041
  * localStorage/sessionStorageが利用できない環境の場合、どのみちプレイ画面に遷移できないのでは...? 
* <del>shareページに限り、iframe時はフッター・navbarを消す (mainのページがiframeに入れられた場合は今まで通り表示し、そこから遷移するshareInternalも今まで通り)</del>
* [ ] ↑ embedページを新しく作るほうが良さそう
* [ ] iframe時はタイトルをクリックでトップページに遷移しないようにする・新しいタブでトップページを開く
* [ ] iframe用ソースをコピーできる機能を用意する
* [x] oembed
* [ ] そもそもApplicationErrorのページを改善する？
* [ ] テーマをクエリパラメータで指定できるようにする?