### PR TITLE
fetchのエラーをuncaughtのまま放置しない

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,8 @@
+## ver. 16.2 - 2026/05/16
+
+* APIErrorクラスをErrorのサブクラスにしてSentry送信も統一して処理する
+* catchのないfetch呼び出しに空のcatchを追加
+
 ## ver. 16.1 - 2026/05/16
 
 * service workerがレスポンスを返す際にcloudflareのbeaconを手動挿入

--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -1,21 +1,48 @@
+import * as Sentry from "@sentry/nextjs";
+
 const fetchErrorStatus = 499;
 
-export class APIError {
+/**
+ * fetch()におけるネットワークエラーと5xxのサーバーエラーを統一して扱うクラス。
+ * サーバーエラーの場合は自動的にSentryへの送信も行う。
+ */
+export class APIError extends Error {
   status: number | null;
-  message: string;
-  constructor(status: number | null, message: string) {
+  original?: unknown; // 一応sentryから確認するため
+  // message: string;
+  constructor(status: number | null, message: string, original?: unknown) {
+    super(message);
+    this.name = status ? `APIError-${status}` : "APIError";
     this.status = status;
-    this.message = message;
     if (this.status === fetchErrorStatus) {
       // 499はユーザーに表示しない
       this.status = null;
     }
+    this.original = original;
+    if (this.original instanceof Error) {
+      this.stack = this.original.stack;
+      this.original.stack = undefined;
+    } else if ("captureStackTrace" in Error) {
+      Error.captureStackTrace(this, APIError);
+    }
+    if (this.isServerSide()) {
+      Sentry.captureException(this);
+    }
   }
-  static fetchError() {
-    return new APIError(fetchErrorStatus, "fetchError");
+  static fetchError(original: unknown) {
+    if (
+      original instanceof TypeError ||
+      (original instanceof DOMException &&
+        ["AbortError", "NotAllowedError"].includes(original.name))
+    ) {
+      return new APIError(fetchErrorStatus, "fetchError", original);
+    } else {
+      Sentry.captureException(`Object is not fetch error: ${original}`);
+      throw original;
+    }
   }
-  static badResponse() {
-    return new APIError(null, "badResponse");
+  static badResponse(original: unknown) {
+    return new APIError(null, "badResponse", original);
   }
   static async fromRes(res: Response) {
     try {

--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -45,11 +45,14 @@ export class APIError extends Error {
     return new APIError(null, "badResponse", original);
   }
   static async fromRes(res: Response) {
+    let e: APIError;
     try {
-      return new APIError(res.status, (await res.json()).message || "");
+      e = new APIError(res.status, (await res.json()).message || "");
     } catch {
-      return new APIError(res.status, "");
+      e = new APIError(res.status, "");
     }
+    Error.captureStackTrace(e, APIError);
+    return e;
   }
 
   formatMsg(t: {

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -270,25 +270,21 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
               clearTimeout(updateFetching.current);
             }
             const checkUpdate = () =>
-              fetch("/worker/checkUpdate")
-                .then((res) => {
+              fetch("/worker/checkUpdate").then(
+                (res) => {
                   // okの場合、messageイベントで受け取るのでここでは何もしない
                   if (!res.ok) {
                     if (isStandalone()) {
                       setWorkerUpdate({ state: "failed" });
                     }
                   }
-                })
-                .catch((e) => {
+                },
+                () => {
                   if (isStandalone()) {
                     setWorkerUpdate({ state: "failed" });
                   }
-                  Sentry.withScope((scope) => {
-                    // ページURLごとに別issueに分けられるのを防ぐ
-                    scope.setTransactionName("common/pwaInstall");
-                    Sentry.captureException(e);
-                  });
-                });
+                }
+              );
             updateFetching.current = setTimeout(checkUpdate, 1000);
             reg.addEventListener("updatefound", () => {
               if (isStandalone()) {

--- a/frontend/app/[locale]/common/se.ts
+++ b/frontend/app/[locale]/common/se.ts
@@ -139,12 +139,14 @@ export function useSE(
           ["beat1", audioBeat1],
         ] as const
       ).forEach(([name, audioBuffer]) =>
-        fetch(process.env.ASSET_PREFIX + `/assets/${name}.wav`)
-          .then((res) => res.arrayBuffer())
-          .then((aryBuf) => audioContext.current!.decodeAudioData(aryBuf))
-          .then((audio) => {
+        fetch(process.env.ASSET_PREFIX + `/assets/${name}.wav`).then(
+          async (res) => {
+            const aryBuf = await res.arrayBuffer();
+            const audio = await audioContext.current!.decodeAudioData(aryBuf);
             audioBuffer.current = audio;
-          })
+          },
+          () => undefined
+        )
       );
       return () => {
         gainNodeHit.current?.disconnect();

--- a/frontend/app/[locale]/common/shareLinkAndImage.tsx
+++ b/frontend/app/[locale]/common/shareLinkAndImage.tsx
@@ -74,7 +74,7 @@ export function useShareLink(
       // og画像の生成は時間がかかるので、
       // 共有される前にogを1回fetchしておくことにより、
       // cloudflareにキャッシュさせる
-      void fetch(process.env.BACKEND_PREFIX + ogPath);
+      void fetch(process.env.BACKEND_PREFIX + ogPath).catch(() => undefined);
       if (withTitle) {
         navigator.clipboard.writeText(
           newTitle +
@@ -92,7 +92,7 @@ export function useShareLink(
   );
   const [shareData, setShareData] = useState<object | null>(null);
   const toAPI = useCallback(() => {
-    void fetch(process.env.BACKEND_PREFIX + ogPath);
+    void fetch(process.env.BACKEND_PREFIX + ogPath).catch(() => undefined);
     navigator.share(shareData!);
   }, [shareData, ogPath]);
   useEffect(() => {
@@ -221,8 +221,9 @@ export function ShareImageModalProvider(props: { children: React.ReactNode }) {
   const [imageBlob, setImageBlob] = useState<Blob>();
   useEffect(() => {
     if (modalOpened) {
-      fetch(process.env.BACKEND_PREFIX + ogPath).then((r) =>
-        r.blob().then((b) => setImageBlob(b))
+      fetch(process.env.BACKEND_PREFIX + ogPath).then(
+        (r) => r.blob().then((b) => setImageBlob(b)),
+        () => undefined
       );
     }
   }, [ogPath, modalOpened]);

--- a/frontend/app/[locale]/common/sharePageModal.tsx
+++ b/frontend/app/[locale]/common/sharePageModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import clsx from "clsx/lite";
 import { titleShare, titleWithSiteName } from "@/common/title";
 import { ChartBrief, RecordGetSummary } from "@falling-nikochan/chart";
@@ -79,14 +78,13 @@ export function SharePageModalProvider(props: {
               setModalRecord(await res.json());
             } catch (e) {
               console.error(e);
-              Sentry.captureException(e);
-              setModalRecord(APIError.badResponse());
+              setModalRecord(APIError.badResponse(e));
             }
           } else {
             setModalRecord(await APIError.fromRes(res));
           }
-        } catch {
-          setModalRecord(APIError.fetchError());
+        } catch (e) {
+          setModalRecord(APIError.fetchError(e));
         }
       })();
       setModalOpened(true);

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -225,26 +225,25 @@ export function useChartState(props: Props) {
         }
         if (savePasswd) {
           if (currentPasswd.p) {
-            try {
-              fetch(
-                process.env.BACKEND_PREFIX +
-                  `/api/hashPasswd/${cid}?p=${currentPasswd.p}`,
-                {
-                  credentials:
-                    process.env.NODE_ENV === "development"
-                      ? "include"
-                      : "same-origin",
-                }
-              ).then(async (res) => {
+            fetch(
+              process.env.BACKEND_PREFIX +
+                `/api/hashPasswd/${cid}?p=${currentPasswd.p}`,
+              {
+                credentials:
+                  process.env.NODE_ENV === "development"
+                    ? "include"
+                    : "same-origin",
+              }
+            ).then(
+              async (res) => {
                 if (res.ok) {
                   const ph = await res.text();
                   setPasswd(cid, ph);
                   currentPasswd.ph = ph;
                 }
-              });
-            } catch {
-              //ignore
-            }
+              },
+              () => undefined
+            );
           }
         } else {
           unsetPasswd(cid);

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -36,7 +36,6 @@ import * as v from "valibot";
 import fnCommandsLib from "fn-commands?raw";
 import fnCommandsPackageJson from "fn-commands/package.json";
 import { isInsideFrame } from "@/scale";
-import * as v from "valibot";
 
 interface Props {
   onLoad: (cid: string) => void;

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -36,6 +36,7 @@ import * as v from "valibot";
 import fnCommandsLib from "fn-commands?raw";
 import fnCommandsPackageJson from "fn-commands/package.json";
 import { isInsideFrame } from "@/scale";
+import * as v from "valibot";
 
 interface Props {
   onLoad: (cid: string) => void;
@@ -180,8 +181,7 @@ export function useChartState(props: Props) {
               onLoadRef.current(cid);
             } catch (e) {
               console.error(e);
-              Sentry.captureException(e);
-              setChartState({ state: APIError.badResponse() });
+              setChartState({ state: APIError.badResponse(e) });
             }
           } else {
             if (res.status === 401 || res.status === 400) {
@@ -209,8 +209,7 @@ export function useChartState(props: Props) {
         }
       } catch (e) {
         console.error(e);
-        Sentry.captureException(e);
-        setChartState({ state: APIError.fetchError() });
+        setChartState({ state: APIError.fetchError(e) });
       }
     },
     [locale]
@@ -270,20 +269,17 @@ export function useChartState(props: Props) {
           );
           if (res.ok) {
             try {
-              const resBody = (await res.json()) as {
-                message?: string;
-                cid?: string;
-              };
-              if (typeof resBody.cid === "string") {
-                onLoadRef.current(resBody.cid);
-                onSave(resBody.cid);
-                setSaveState("ok");
-                return;
-              }
-            } catch {
-              // pass through
+              const resBody = v.parse(
+                v.object({ cid: v.string() }),
+                await res.json()
+              );
+              onLoadRef.current(resBody.cid);
+              onSave(resBody.cid);
+              setSaveState("ok");
+              return;
+            } catch (e) {
+              setSaveState(APIError.badResponse(e));
             }
-            setSaveState(APIError.badResponse());
             return;
           } else {
             setSaveState(await APIError.fromRes(res));
@@ -291,8 +287,7 @@ export function useChartState(props: Props) {
           }
         } catch (e) {
           console.error(e);
-          Sentry.captureException(e);
-          setSaveState(APIError.fetchError());
+          setSaveState(APIError.fetchError(e));
           return;
         }
       } else {
@@ -336,8 +331,7 @@ export function useChartState(props: Props) {
           }
         } catch (e) {
           console.error(e);
-          Sentry.captureException(e);
-          setSaveState(APIError.fetchError());
+          setSaveState(APIError.fetchError(e));
           return;
         }
       }

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -1,5 +1,4 @@
 "use client";
-import * as Sentry from "@sentry/nextjs";
 import { ChartBrief, levelTypes } from "@falling-nikochan/chart";
 import clsx from "clsx/lite";
 import ArrowRight from "@icon-park/react/lib/icons/ArrowRight";
@@ -153,8 +152,7 @@ export function ChartList(props: Props) {
             }
           } catch (e) {
             console.error(e);
-            Sentry.captureException(e);
-            setBriefs(APIError.fetchError());
+            setBriefs(APIError.fetchError(e));
           }
         })();
     }

--- a/frontend/app/[locale]/main/edit/clientPage.tsx
+++ b/frontend/app/[locale]/main/edit/clientPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import clsx from "clsx/lite";
 import { useState } from "react";
 import { IndexMain } from "../main.js";
@@ -53,9 +52,8 @@ export default function EditTab({ locale }: { locale: string }) {
       }
     } catch (e) {
       console.error(e);
-      Sentry.captureException(e);
       setCidFetching(false);
-      setCIdErrorMsg(APIError.fetchError());
+      setCIdErrorMsg(APIError.fetchError(e));
       setInputCId("");
     }
   };

--- a/frontend/app/[locale]/main/play/clientPage.tsx
+++ b/frontend/app/[locale]/main/play/clientPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import clsx from "clsx/lite";
 import { IndexMain } from "../main.js";
 import { ChartList } from "../chartList.js";
@@ -167,8 +166,7 @@ function PlayTabInternal(
       })
       .catch((e) => {
         console.error(e);
-        Sentry.captureException(e);
-        setSearchResult(APIError.fetchError());
+        setSearchResult(APIError.fetchError(e));
       });
   }, [t, params.search, params.sort, params.maxLv, params.minLv]);
 

--- a/frontend/app/[locale]/main/shareInternal/clientPage.tsx
+++ b/frontend/app/[locale]/main/shareInternal/clientPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Sentry from "@sentry/nextjs";
 import { IndexMain } from "../main.js";
 import { ChartBrief, RecordGetSummary } from "@falling-nikochan/chart";
 import { useTranslations } from "next-intl";
@@ -45,14 +44,13 @@ export default function ShareInternal({ locale }: { locale: string }) {
               setRecord(await res.json());
             } catch (e) {
               console.error(e);
-              Sentry.captureException(e);
-              setRecord(APIError.badResponse());
+              setRecord(APIError.badResponse(e));
             }
           } else {
             setRecord(await APIError.fromRes(res));
           }
-        } catch {
-          setRecord(APIError.fetchError());
+        } catch (e) {
+          setRecord(APIError.fetchError(e));
         }
       })();
     } else {

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -691,30 +691,26 @@ function Play(props: Props) {
             playbackRate === 1 &&
             chartBrief?.levels.at(lvIndex)
           ) {
-            try {
-              void fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  lvHash: chartBrief.levels[lvIndex].hash,
-                  auto,
-                  score,
-                  baseScore,
-                  chainScore,
-                  bigScore,
-                  fc: chainScore === chainScoreRate,
-                  fb: bigScore === bigScoreRate,
-                  editing,
-                  factor: updateRecordFactor(
-                    cid,
-                    chartBrief.levels[lvIndex].hash,
-                    auto
-                  ),
-                } satisfies RecordPost),
-              });
-            } catch {
-              //ignore
-            }
+            fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                lvHash: chartBrief.levels[lvIndex].hash,
+                auto,
+                score,
+                baseScore,
+                chainScore,
+                bigScore,
+                fc: chainScore === chainScoreRate,
+                fb: bigScore === bigScoreRate,
+                editing,
+                factor: updateRecordFactor(
+                  cid,
+                  chartBrief.levels[lvIndex].hash,
+                  auto
+                ),
+              } satisfies RecordPost),
+            }).catch(() => undefined);
           }
           setResultDate(newResultDate);
           setExitable((ex) =>

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -691,26 +691,31 @@ function Play(props: Props) {
             playbackRate === 1 &&
             chartBrief?.levels.at(lvIndex)
           ) {
-            fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                lvHash: chartBrief.levels[lvIndex].hash,
-                auto,
-                score,
-                baseScore,
-                chainScore,
-                bigScore,
-                fc: chainScore === chainScoreRate,
-                fb: bigScore === bigScoreRate,
-                editing,
-                factor: updateRecordFactor(
-                  cid,
-                  chartBrief.levels[lvIndex].hash,
-                  auto
-                ),
-              } satisfies RecordPost),
-            }).catch(() => undefined);
+            try {
+              const factor = updateRecordFactor(
+                cid,
+                chartBrief.levels[lvIndex].hash,
+                auto
+              );
+              fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  lvHash: chartBrief.levels[lvIndex].hash,
+                  auto,
+                  score,
+                  baseScore,
+                  chainScore,
+                  bigScore,
+                  fc: chainScore === chainScoreRate,
+                  fb: bigScore === bigScoreRate,
+                  editing,
+                  factor,
+                } satisfies RecordPost),
+              }).catch(() => undefined);
+            } catch {
+              // ignore errors from updateRecordFactor
+            }
           }
           setResultDate(newResultDate);
           setExitable((ex) =>

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -13,7 +13,6 @@ const exampleResult = {
   bigCount: 55,
 } as const;
 
-import * as Sentry from "@sentry/nextjs";
 import clsx from "clsx/lite";
 import { useCallback, useEffect, useRef, useState } from "react";
 import FallingWindow from "./fallingWindow.js";
@@ -147,8 +146,7 @@ export function InitPlay({ locale }: { locale: string }) {
             } catch (e) {
               setChartSeq(undefined);
               console.error(e);
-              Sentry.captureException(e);
-              setErrorMsg(APIError.badResponse());
+              setErrorMsg(APIError.badResponse(e));
             }
           } else {
             setChartSeq(undefined);
@@ -157,8 +155,7 @@ export function InitPlay({ locale }: { locale: string }) {
         } catch (e) {
           setChartSeq(undefined);
           console.error(e);
-          Sentry.captureException(e);
-          setErrorMsg(APIError.fetchError());
+          setErrorMsg(APIError.fetchError(e));
         }
       })();
     }
@@ -677,14 +674,13 @@ function Play(props: Props) {
                   );
                 } catch (e) {
                   console.error(e);
-                  Sentry.captureException(e);
-                  setRecord(APIError.badResponse());
+                  setRecord(APIError.badResponse(e));
                 }
               } else {
                 setRecord(await APIError.fromRes(res));
               }
-            } catch {
-              setRecord(APIError.fetchError());
+            } catch (e) {
+              setRecord(APIError.fetchError(e));
             }
           })();
         }

--- a/frontend/app/[locale]/play/fallingWindow.tsx
+++ b/frontend/app/[locale]/play/fallingWindow.tsx
@@ -207,6 +207,7 @@ export default function FallingWindow(props: Props) {
   useEffect(() => {
     Promise.all(
       [0, 1, 2, 3].map(async (i) => {
+        // TODO: エラーハンドリング
         const res = await fetch(
           process.env.ASSET_PREFIX +
             `/assets/nikochan${i}.svg` +
@@ -372,7 +373,8 @@ export default function FallingWindow(props: Props) {
     Promise.all(
       Array.from(new Array(13)).map((_, i) =>
         [4, 6, 8, 10, 12].includes(i)
-          ? fetch(process.env.ASSET_PREFIX + `/assets/particle${i}.svg`)
+          ? // TODO: エラーハンドリング
+            fetch(process.env.ASSET_PREFIX + `/assets/particle${i}.svg`)
               .then((res) => res.text())
               .then((text) => `data:image/svg+xml;base64,${btoa(text)}`)
           : ""

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -90,14 +90,13 @@ export default function ShareChart(props: Props) {
             setRecord(await res.json());
           } catch (e) {
             console.error(e);
-            Sentry.captureException(e);
-            setRecord(APIError.badResponse());
+            setRecord(APIError.badResponse(e));
           }
         } else {
           setRecord(await APIError.fromRes(res));
         }
-      } catch {
-        setRecord(APIError.fetchError());
+      } catch (e) {
+        setRecord(APIError.fetchError(e));
       }
     })();
     if (searchParams.get("result")) {

--- a/frontend/app/[locale]/share/placeholder/shareBox.tsx
+++ b/frontend/app/[locale]/share/placeholder/shareBox.tsx
@@ -53,13 +53,16 @@ export function ShareBox(props: Props) {
     if (cid) {
       fetch(
         process.env.BACKEND_PREFIX + `/api/ytMeta/${cid}?lang=${locale}`
-      ).then(async (res) => {
-        if (res.ok) {
-          setYtMeta(await res.json());
-        } else {
-          setYtMeta(null);
-        }
-      });
+      ).then(
+        async (res) => {
+          if (res.ok) {
+            setYtMeta(await res.json());
+          } else {
+            setYtMeta(null);
+          }
+        },
+        () => setYtMeta(null)
+      );
     }
   }, [cid, locale]);
 

--- a/frontend/app/[locale]/topDemo.tsx
+++ b/frontend/app/[locale]/topDemo.tsx
@@ -77,22 +77,25 @@ export function TopDemo(
       fetch(
         process.env.BACKEND_PREFIX +
           `/api/seqFile/${props.cid}/${props.lvIndex}`
-      ).then((res) => {
-        if (res.ok) {
-          res.arrayBuffer().then((buf) => {
-            const seq = msgpack.decode(buf) as ChartSeqData;
-            resetNotesAll(
-              seq.notes.map((n) => ({
-                ...n,
-                done: 0,
-                bigDone: false,
-              })),
-              props.offset! - seq.offset
-            );
-            currentTimeSec.current = props.offset! - seq.offset;
-          });
-        }
-      });
+      ).then(
+        (res) => {
+          if (res.ok) {
+            res.arrayBuffer().then((buf) => {
+              const seq = msgpack.decode(buf) as ChartSeqData;
+              resetNotesAll(
+                seq.notes.map((n) => ({
+                  ...n,
+                  done: 0,
+                  bigDone: false,
+                })),
+                props.offset! - seq.offset
+              );
+              currentTimeSec.current = props.offset! - seq.offset;
+            });
+          }
+        },
+        () => undefined
+      );
     }
   }, [notesAll, resetNotesAll, props.cid, props.lvIndex, props.offset]);
 
@@ -138,7 +141,8 @@ export function DemoDetail(
           if (res.ok) {
             res.json().then((brief: ChartBrief) => setBrief(brief));
           }
-        }
+        },
+        () => undefined
       );
     }
   }, [brief, props.cid]);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "16.1.0",
+  "version": "16.2.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
- APIErrorクラスをErrorのサブクラスにしてSentry送信も統一して処理する
- catchのないfetch呼び出し(今までエラー処理を行っていなかった・無視していたもの)に空のcatchを追加し、unhandledrejectionとしてsentryに送られないようにする

