### PR TITLE
エラーレスポンスのmessageの厳密化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ AIエージェントは以下の特殊な構成に注意してください。
 - 入力のバリデーションやOpenAPIドキュメントの入出力型定義には Valibot を使用しています。
 - バックエンドのエントリーポイントは、Node.js用の route/serve-local.ts 、Bun用の route/serve-bun-prod.ts 、Cloudflare Worker用の route/serve-cf.js 、Vercel用の api/index.js 、Service Workerで実行される worker/entry.ts (リダイレクトなど一部のロジックのみ) の5箇所あります。変更する際はこれらすべてを更新してください。
 - バックエンドが処理するパスを追加した場合には vercel.json のrewritesの更新も必要な場合があります。
+- 異常時のレスポンスはjsonで `{message: "事前に定義されたメッセージ"}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているものでなければなりません。
+    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ"})` とすることでグローバルなエラーハンドラー(src/error.ts)がそれをJSONに整形して返します。
+    - `ValiError` をthrowするとグローバルなエラーハンドラーが400として返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchする必要はありません。
+    - `ValiError` を400以外のレスポンスで返したい場合は、 `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: e.issues });` としてください。
 
 ### 3. Frontend Code
 - すべてのフロントエンドのソースコードは frontend/app/[locale]/ ディレクトリ内にあります。 ja, en ディレクトリではなく文字通り [locale] という名前のディレクトリです(dynamic route)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,11 @@ AIエージェントは以下の特殊な構成に注意してください。
 - 入力のバリデーションやOpenAPIドキュメントの入出力型定義には Valibot を使用しています。
 - バックエンドのエントリーポイントは、Node.js用の route/serve-local.ts 、Bun用の route/serve-bun-prod.ts 、Cloudflare Worker用の route/serve-cf.js 、Vercel用の api/index.js 、Service Workerで実行される worker/entry.ts (リダイレクトなど一部のロジックのみ) の5箇所あります。変更する際はこれらすべてを更新してください。
 - バックエンドが処理するパスを追加した場合には vercel.json のrewritesの更新も必要な場合があります。
-- 異常時のレスポンスはjsonで `{message?: "事前に定義されたメッセージ", cause?: additionalData}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているもの、または空でなければなりません。
-    - hono-openapiのvalidatorは独自の400レスポンスを生成するためその場合この形式に当てはまりません。
-    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: optional_data})` とすることでグローバルなエラーハンドラー(src/error.ts)がそれをJSONに整形して返します。
-    - `ValiError` をthrowするとグローバルなエラーハンドラーがmessageが空でcauseにvalibotのissueを含む400のレスポンスを返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchする必要はありません。
-    - `ValiError` を400以外のレスポンスで返したい場合は、 `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: e.issues });` としてください。
+- 異常時のレスポンスはjsonで `{message: "事前に定義されたメッセージ"}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているもの、または空でなければなりません。
+    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: optional_data})` とすることでグローバルなエラーハンドラー(`src/error.ts`)がそれをJSONに整形して返します。
+    - `ValiError` をthrowするか、HTTPExceptionの`cause`に渡すと、グローバルなエラーハンドラーが`message`に加えてvalibotのissueを含んだレスポンスを返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchしたり手動でjsonにして返す必要はありません。
+    - `hono-openapi` のvalidatorを使用する場合は第3引数に `sValidatorHook()` を渡すことでバリデーションエラーが上記のValiErrorの処理と同じロジックに流れます。
+- /api 以下のAPIには既存のAPIと同様にOpenAPIのドキュメントを記述してください。異常時のレスポンスのスキーマは `await errorLiteral("メッセージ")` (またはvalibotのissueを含む場合 `await validationErrorSchema("メッセージ")`) で記述してください。
 
 ### 3. Frontend Code
 - すべてのフロントエンドのソースコードは frontend/app/[locale]/ ディレクトリ内にあります。 ja, en ディレクトリではなく文字通り [locale] という名前のディレクトリです(dynamic route)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,10 @@ AIエージェントは以下の特殊な構成に注意してください。
 - 入力のバリデーションやOpenAPIドキュメントの入出力型定義には Valibot を使用しています。
 - バックエンドのエントリーポイントは、Node.js用の route/serve-local.ts 、Bun用の route/serve-bun-prod.ts 、Cloudflare Worker用の route/serve-cf.js 、Vercel用の api/index.js 、Service Workerで実行される worker/entry.ts (リダイレクトなど一部のロジックのみ) の5箇所あります。変更する際はこれらすべてを更新してください。
 - バックエンドが処理するパスを追加した場合には vercel.json のrewritesの更新も必要な場合があります。
-- 異常時のレスポンスはjsonで `{message: "事前に定義されたメッセージ"}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているものでなければなりません。
-    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ"})` とすることでグローバルなエラーハンドラー(src/error.ts)がそれをJSONに整形して返します。
-    - `ValiError` をthrowするとグローバルなエラーハンドラーが400として返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchする必要はありません。
+- 異常時のレスポンスはjsonで `{message?: "事前に定義されたメッセージ", cause?: additionalData}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているもの、または空でなければなりません。
+    - hono-openapiのvalidatorは独自の400レスポンスを生成するためその場合この形式に当てはまりません。
+    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: optional_data})` とすることでグローバルなエラーハンドラー(src/error.ts)がそれをJSONに整形して返します。
+    - `ValiError` をthrowするとグローバルなエラーハンドラーがmessageが空でcauseにvalibotのissueを含む400のレスポンスを返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchする必要はありません。
     - `ValiError` を400以外のレスポンスで返したい場合は、 `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: e.issues });` としてください。
 
 ### 3. Frontend Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,10 @@ pnpm run ldev
 **Conventions**
 
 - When code branches depending on the deployment target, the Hono App creation is made into a function. (`const fooApp = async (config: ...) => new Hono(...)`)
-- Error messages use only those included in `i18n/[locale]/error.js`, except for validation errors, and are returned using `throw new HTTPException` or `return c.json()`.
+- The error response must be in JSON format and be in the form of `{message: "predefined message"}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js`.
+  - Throwing an HTTPException will cause the global error handler (src/error.ts) to format it into JSON and return it.
+  - Throwing a `ValiError` will cause the global error handler to return a 400 status code. Therefore, handlers for each API should always use `v.parse()` and do not need to catch it.
+  - If you want to return a `ValiError` with a response other than 400, use `throw new HTTPException(4xx, {message: "predefined message", cause: e.issues });`.
 
 ### Frontend
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,12 +144,11 @@ pnpm run ldev
 **Conventions**
 
 - When code branches depending on the deployment target, the Hono App creation is made into a function. (`const fooApp = async (config: ...) => new Hono(...)`)
-- The error response must be in JSON format and be in the form of `{message?: "predefined message", cause?: additionalData}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js` or empty.
-  - The validator in hono-openapi generates its own 400 response, so this format does not apply in that case.
-  - By using `throw new HTTPException(4xx, {message: "predefined message", cause: optional_data})`, the global error handler (src/error.ts) will format it into JSON and return it.
-  - Throwing an HTTPException will cause the global error handler (src/error.ts) to format it into JSON and return it.
-  - Throwing a `ValiError` will cause the global error handler to return a 400 status code. Therefore, handlers for each API should always use `v.parse()` and do not need to catch it.
-  - If you want to return a `ValiError` with a response other than 400, use `throw new HTTPException(4xx, {message: "predefined message", cause: e.issues });`.
+- The error response must be in JSON format and be in the form of `{message: "predefined message"}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js` or empty.
+  - By using `throw new HTTPException(4xx, {message: "predefined message", cause: optional_data})`, the global error handler (`src/error.ts`) will format it into JSON and return it.
+  - Throwing a `ValiError` or passing it as the `cause` of an HTTPException will cause the global error handler to return a response that includes the valibot issues in addition to the `message`. Therefore, you should always use `v.parse()` in each API handler and do not need to catch it or manually format it into JSON and return it.
+  - When using the `hono-openapi` validator, passing `sValidatorHook()` as the third argument will cause validation errors to flow to the same logic as the ValiError processing described above.
+- For APIs under /api, please write OpenAPI documentation like existing APIs.
 
 ### Frontend
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,9 @@ pnpm run ldev
 **Conventions**
 
 - When code branches depending on the deployment target, the Hono App creation is made into a function. (`const fooApp = async (config: ...) => new Hono(...)`)
-- The error response must be in JSON format and be in the form of `{message: "predefined message"}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js`.
+- The error response must be in JSON format and be in the form of `{message?: "predefined message", cause?: additionalData}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js` or empty.
+  - The validator in hono-openapi generates its own 400 response, so this format does not apply in that case.
+  - By using `throw new HTTPException(4xx, {message: "predefined message", cause: optional_data})`, the global error handler (src/error.ts) will format it into JSON and return it.
   - Throwing an HTTPException will cause the global error handler (src/error.ts) to format it into JSON and return it.
   - Throwing a `ValiError` will cause the global error handler to return a 400 status code. Therefore, handlers for each API should always use `v.parse()` and do not need to catch it.
   - If you want to return a `ValiError` with a response other than 400, use `throw new HTTPException(4xx, {message: "predefined message", cause: e.issues });`.

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -2,7 +2,7 @@ export default {
   error: {
     api: {
       // 400
-      generic400: "The parameter is invalid",
+      badRequest: "The parameter is invalid",
       noPasswd: "Password is not specified",
       invalidChartId: "Chart ID is invalid",
       invalidResultParam: "Result parameter is invalid",
@@ -25,6 +25,7 @@ export default {
       // 429
       tooManyRequest: "Please wait a while and try again",
       // 500
+      unknownApiError: "An error occurred on the server",
       imageGenerationFailed: "Failed to generate the image",
       unsupportedChartVersion: "Unsupported chart data version",
       // 499

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -2,7 +2,7 @@ export default {
   error: {
     api: {
       // 400
-      generic400: "パラメータが正しくありません",
+      badRequest: "パラメータが正しくありません",
       noPasswd: "パスワードが指定されていません",
       invalidChartId: "譜面 ID が正しくありません",
       invalidResultParam: "result パラメータが正しくありません",
@@ -25,6 +25,7 @@ export default {
       // 429
       tooManyRequest: "しばらく待ってからやり直してください",
       // 500
+      unknownApiError: "サーバーで何らかのエラーが発生しました",
       imageGenerationFailed: "画像生成に失敗しました",
       unsupportedChartVersion: "サポートされていない譜面バージョンです",
       // 499

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -7,7 +7,11 @@ import { env } from "hono/adapter";
 import { CidSchema, docRefs } from "@falling-nikochan/chart";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 600;
@@ -28,12 +32,18 @@ const briefApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
             schema: docRefs("ChartBrief"),
           },
         },
+        headers: {
+          "Cache-Control": {
+            description: `max-age=${CACHE_MAX_AGE}`,
+            schema: { type: "string" },
+          },
+        },
       },
       400: {
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({})),
+            schema: resolver(await validationErrorSchema()),
           },
         },
       },
@@ -47,7 +57,7 @@ const briefApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       },
     },
   }),
-  validator("param", v.object({ cid: CidSchema() })),
+  validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
   async (c) => {
     const { cid } = c.req.valid("param");
     const client = new MongoClient(env(c).MONGODB_URI);

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -33,7 +33,7 @@ const briefApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(v.object({})),
           },
         },
       },

--- a/route/src/api/chart.ts
+++ b/route/src/api/chart.ts
@@ -58,7 +58,7 @@ export async function getChartEntryCompressed(
   p: Passwd | null
 ): Promise<ChartEntryCompressed> {
   v.parse(CidSchema(), cid);
-  
+
   const entryCompressed = await db
     .collection<ChartEntryCompressed>("chart")
     .findOne({ cid, deleted: false });

--- a/route/src/api/chart.ts
+++ b/route/src/api/chart.ts
@@ -57,9 +57,8 @@ export async function getChartEntryCompressed(
   cid: string,
   p: Passwd | null
 ): Promise<ChartEntryCompressed> {
-  if (!v.parse(CidSchema(), cid)) {
-    throw new HTTPException(400, { message: "invalidChartId" });
-  }
+  v.parse(CidSchema(), cid);
+  
   const entryCompressed = await db
     .collection<ChartEntryCompressed>("chart")
     .findOne({ cid, deleted: false });

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -354,7 +354,12 @@ const chartFileApp = async (config: {
             description: "Invalid chart format",
             content: {
               "application/json": {
-                schema: resolver(await validationErrorSchema("invalidChart")),
+                schema: resolver(
+                  v.union([
+                    await validationErrorSchema("invalidChart"),
+                    await errorLiteral("invalidChart"),
+                  ])
+                ),
               },
             },
           },

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -324,7 +324,7 @@ const chartFileApp = async (config: {
             description: "Invalid chart format",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(await errorLiteral("invalidChart")),
               },
             },
           },
@@ -365,7 +365,10 @@ const chartFileApp = async (config: {
             | Chart15;
         } catch (e) {
           console.error(e);
-          throw new HTTPException(415, { message: (e as Error).toString() });
+          throw new HTTPException(415, {
+            message: "invalidChart",
+            cause: v.isValiError(e) ? e.issues : undefined,
+          });
         }
 
         if (numEvents(newChart as Chart14Edit | Chart15) > chartMaxEvent) {

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -161,7 +161,7 @@ const chartFileApp = async (config: {
             description: "invalid chart id or password not specified",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(v.object({})),
               },
             },
           },
@@ -213,7 +213,7 @@ const chartFileApp = async (config: {
             description: "invalid chart id or password not specified",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(v.object({})),
               },
             },
           },
@@ -282,7 +282,7 @@ const chartFileApp = async (config: {
             description: "invalid chart id or password not specified",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(v.object({})),
               },
             },
           },

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -31,7 +31,11 @@ import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { getYTDataEntry } from "./ytData.js";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 import { join, dirname } from "node:path";
 import dotenv from "dotenv";
 import { getIp, updateIp } from "./dbRateLimit.js";
@@ -71,7 +75,7 @@ const chartFileApp = async (config: {
     .on(
       ["GET", "POST", "DELETE"],
       "/:cid",
-      validator("param", v.object({ cid: CidSchema() })),
+      validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
       validator(
         "query",
         v.object({
@@ -87,13 +91,15 @@ const chartFileApp = async (config: {
             )
           ),
           pbypass: v.optional(v.string()),
-        })
+        }),
+        sValidatorHook()
       ),
       validator(
         "cookie",
         v.object({
           pUserSalt: v.optional(v.string()),
-        })
+        }),
+        sValidatorHook()
       ),
       async (c, next) => {
         const { cid } = c.req.valid("param");
@@ -156,12 +162,18 @@ const chartFileApp = async (config: {
                 schema: docRefs("Chart15"),
               },
             },
+            headers: {
+              "Content-Disposition": {
+                description: "Filename with extension of .fn{ver}.mpk",
+                schema: { type: "string" },
+              },
+            },
           },
           400: {
-            description: "invalid chart id or password not specified",
+            description: "invalid chart id or parameter",
             content: {
               "application/json": {
-                schema: resolver(v.object({})),
+                schema: resolver(await validationErrorSchema()),
               },
             },
           },
@@ -186,6 +198,12 @@ const chartFileApp = async (config: {
             content: {
               "application/json": {
                 schema: resolver(await errorLiteral("tooManyRequest")),
+              },
+            },
+            headers: {
+              "Retry-After": {
+                description: "Number of seconds to wait before retrying",
+                schema: { type: "integer" },
               },
             },
           },
@@ -210,10 +228,10 @@ const chartFileApp = async (config: {
             description: "No content, chart deleted successfully",
           },
           400: {
-            description: "invalid chart id or password not specified",
+            description: "invalid chart id or parameter",
             content: {
               "application/json": {
-                schema: resolver(v.object({})),
+                schema: resolver(await validationErrorSchema()),
               },
             },
           },
@@ -238,6 +256,12 @@ const chartFileApp = async (config: {
             content: {
               "application/json": {
                 schema: resolver(await errorLiteral("tooManyRequest")),
+              },
+            },
+            headers: {
+              "Retry-After": {
+                description: "Number of seconds to wait before retrying",
+                schema: { type: "integer" },
               },
             },
           },
@@ -279,10 +303,16 @@ const chartFileApp = async (config: {
             description: "No content, chart updated successfully",
           },
           400: {
-            description: "invalid chart id or password not specified",
+            description:
+              "invalid chart id or parameter, or password not specified in the chart data",
             content: {
               "application/json": {
-                schema: resolver(v.object({})),
+                schema: resolver(
+                  v.union([
+                    await validationErrorSchema(),
+                    await errorLiteral("noPasswd"),
+                  ])
+                ),
               },
             },
           },
@@ -324,7 +354,7 @@ const chartFileApp = async (config: {
             description: "Invalid chart format",
             content: {
               "application/json": {
-                schema: resolver(await errorLiteral("invalidChart")),
+                schema: resolver(await validationErrorSchema("invalidChart")),
               },
             },
           },
@@ -333,6 +363,12 @@ const chartFileApp = async (config: {
             content: {
               "application/json": {
                 schema: resolver(await errorLiteral("tooManyRequest")),
+              },
+            },
+            headers: {
+              "Retry-After": {
+                description: "Number of seconds to wait before retrying",
+                schema: { type: "integer" },
               },
             },
           },
@@ -364,11 +400,7 @@ const chartFileApp = async (config: {
             | Chart14Edit
             | Chart15;
         } catch (e) {
-          console.error(e);
-          throw new HTTPException(415, {
-            message: "invalidChart",
-            cause: v.isValiError(e) ? e.issues : undefined,
-          });
+          throw new HTTPException(415, { message: "invalidChart", cause: e });
         }
 
         if (numEvents(newChart as Chart14Edit | Chart15) > chartMaxEvent) {

--- a/route/src/api/hashPasswd.ts
+++ b/route/src/api/hashPasswd.ts
@@ -9,7 +9,11 @@ import { CidSchema } from "@falling-nikochan/chart";
 import * as v from "valibot";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 
 /**
  * chartFile のコメントを参照
@@ -34,16 +38,21 @@ const hashPasswdApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
           "Set-Cookie": {
             description:
               "Sets the pUserSalt cookie if it was not present in the request.",
-            // @ts-expect-error type OpenAPIV3_1.SchemaObject is not assignable to type OpenAPIV3.SchemaObject... why?
-            schema: (await resolver(v.string()).toOpenAPISchema()).schema,
+            schema: { type: "string" },
           },
         },
       },
       400: {
-        description: "invalid chart id or password not specified",
+        description:
+          "invalid chart id or parameter, or password not specified in the chart data",
         content: {
           "application/json": {
-            schema: resolver(v.object({})),
+            schema: resolver(
+              v.union([
+                await validationErrorSchema(),
+                await errorLiteral("noPasswd"),
+              ])
+            ),
           },
         },
       },
@@ -65,14 +74,19 @@ const hashPasswdApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       },
     },
   }),
-  validator("param", v.object({ cid: CidSchema() })),
+  validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
   validator(
     "query",
     v.object({
       p: v.pipe(v.string(), v.minLength(1), v.description("plain password")),
-    })
+    }),
+    sValidatorHook()
   ),
-  validator("cookie", v.object({ pUserSalt: v.optional(v.string()) })),
+  validator(
+    "cookie",
+    v.object({ pUserSalt: v.optional(v.string()) }),
+    sValidatorHook()
+  ),
   async (c) => {
     const { cid } = c.req.valid("param");
     const { p } = c.req.valid("query");

--- a/route/src/api/hashPasswd.ts
+++ b/route/src/api/hashPasswd.ts
@@ -43,7 +43,7 @@ const hashPasswdApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         description: "invalid chart id or password not specified",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(v.object({})),
           },
         },
       },

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -20,7 +20,7 @@ import { env } from "hono/adapter";
 import { HTTPException } from "hono/http-exception";
 import { getYTDataEntry } from "./ytData.js";
 import { describeRoute, resolver } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import { errorLiteral, validationErrorSchema } from "../error.js";
 import * as v from "valibot";
 import { ConnInfo } from "hono/conninfo";
 
@@ -55,6 +55,14 @@ const newChartFileApp = async (config: {
             },
           },
         },
+        400: {
+          description: "password not specified in the chart data",
+          content: {
+            "application/json": {
+              schema: resolver(await errorLiteral("noPasswd")),
+            },
+          },
+        },
         409: {
           description: `chart version is older than ${currentChartVer - 1}`,
           content: {
@@ -77,7 +85,7 @@ const newChartFileApp = async (config: {
           description: "Invalid chart format",
           content: {
             "application/json": {
-              schema: resolver(await errorLiteral("invalidChart")),
+              schema: resolver(await validationErrorSchema("invalidChart")),
             },
           },
         },
@@ -88,12 +96,12 @@ const newChartFileApp = async (config: {
               schema: resolver(await errorLiteral("tooManyRequest")),
             },
           },
-          // headers: {
-          //   "retry-after": {
-          //     description: `Number of seconds to wait before retrying (approximately ${rateLimitMin} minutes)`,
-          //     schema: { type: "string", format: "int32" },
-          //   },
-          // },
+          headers: {
+            "Retry-After": {
+              description: "Number of seconds to wait before retrying",
+              schema: { type: "integer" },
+            },
+          },
         },
       },
     }),
@@ -134,11 +142,7 @@ const newChartFileApp = async (config: {
             | Chart14Edit
             | Chart15;
         } catch (e) {
-          console.error(e);
-          throw new HTTPException(415, {
-            message: "invalidChart",
-            cause: v.isValiError(e) ? e.issues : undefined,
-          });
+          throw new HTTPException(415, { message: "invalidChart", cause: e });
         }
 
         if (numEvents(newChart) > chartMaxEvent) {

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -77,7 +77,7 @@ const newChartFileApp = async (config: {
           description: "Invalid chart format",
           content: {
             "application/json": {
-              schema: resolver(v.object({ message: v.string() })),
+              schema: resolver(await errorLiteral("invalidChart")),
             },
           },
         },
@@ -135,7 +135,10 @@ const newChartFileApp = async (config: {
             | Chart15;
         } catch (e) {
           console.error(e);
-          throw new HTTPException(415, { message: (e as Error).toString() });
+          throw new HTTPException(415, {
+            message: "invalidChart",
+            cause: v.isValiError(e) ? e.issues : undefined,
+          });
         }
 
         if (numEvents(newChart) > chartMaxEvent) {

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -85,7 +85,12 @@ const newChartFileApp = async (config: {
           description: "Invalid chart format",
           content: {
             "application/json": {
-              schema: resolver(await validationErrorSchema("invalidChart")),
+              schema: resolver(
+                v.union([
+                  await validationErrorSchema("invalidChart"),
+                  await errorLiteral("invalidChart"),
+                ])
+              ),
             },
           },
         },

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -52,6 +52,7 @@ const oembedApp = async (config: {
       cacheControl: `max-age=${CACHE_MAX_AGE}`,
     }),
     describeRoute({
+      hide: true,
       description:
         "Get oEmbed information about the chart according to oEmbed spec: https://oembed.com/",
       responses: {

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -5,7 +5,11 @@ import { env } from "hono/adapter";
 import { ChartBrief } from "@falling-nikochan/chart";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import xmlbuilder2 from "xmlbuilder2";
 
@@ -66,6 +70,20 @@ const oembedApp = async (config: {
               schema: resolver(OEmbedSchema()),
             },
           },
+          headers: {
+            "Cache-Control": {
+              description: `max-age=${CACHE_MAX_AGE}`,
+              schema: { type: "string" },
+            },
+          },
+        },
+        400: {
+          description: "invalid parameter",
+          content: {
+            "application/json": {
+              schema: resolver(await validationErrorSchema()),
+            },
+          },
         },
         404: {
           description: "Chart not found or invalid url",
@@ -79,7 +97,7 @@ const oembedApp = async (config: {
         },
       },
     }),
-    validator("query", OEmbedParamSchema()),
+    validator("query", OEmbedParamSchema(), sValidatorHook()),
     async (c) => {
       const {
         url: embedUrl,

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -38,7 +38,7 @@ const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(v.object({})),
           },
         },
       },

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -16,7 +16,11 @@ import {
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 
 const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   "/:cid/:lvIndex",
@@ -33,12 +37,18 @@ const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
             schema: docRefs("LevelPlay15"),
           },
         },
+        headers: {
+          "Content-Disposition": {
+            description: "Filename with extension of .fn{ver}p.mpk",
+            schema: { type: "string" },
+          },
+        },
       },
       400: {
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({})),
+            schema: resolver(await validationErrorSchema()),
           },
         },
       },
@@ -59,7 +69,8 @@ const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
     v.object({
       cid: CidSchema(),
       lvIndex: v.pipe(v.string(), v.regex(/^[0-9]+$/), v.transform(Number)),
-    })
+    }),
+    sValidatorHook()
   ),
   async (c) => {
     const { cid, lvIndex } = c.req.valid("param");

--- a/route/src/api/record.ts
+++ b/route/src/api/record.ts
@@ -12,7 +12,11 @@ import * as v from "valibot";
 import { MongoClient } from "mongodb";
 import { env } from "hono/adapter";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 import { getIp, updateIp } from "./dbRateLimit.js";
 import { ConnInfo } from "hono/conninfo";
 
@@ -53,12 +57,18 @@ const recordApp = async (config: {
                 schema: resolver(v.array(RecordGetSummarySchema())),
               },
             },
+            headers: {
+              "Cache-Control": {
+                description: `max-age=${CACHE_MAX_AGE}`,
+                schema: { type: "string" },
+              },
+            },
           },
           400: {
             description: "invalid chart id",
             content: {
               "application/json": {
-                schema: resolver(v.object({})),
+                schema: resolver(await validationErrorSchema()),
               },
             },
           },
@@ -72,7 +82,7 @@ const recordApp = async (config: {
           },
         },
       }),
-      validator("param", v.object({ cid: CidSchema() })),
+      validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
       async (c) => {
         const { cid } = c.req.valid("param");
         const client = new MongoClient(env(c).MONGODB_URI);
@@ -142,7 +152,7 @@ const recordApp = async (config: {
             description: "invalid chart id or body",
             content: {
               "application/json": {
-                schema: resolver(v.object({})),
+                schema: resolver(await validationErrorSchema()),
               },
             },
           },
@@ -164,8 +174,8 @@ const recordApp = async (config: {
           },
         },
       }),
-      validator("param", v.object({ cid: CidSchema() })),
-      validator("json", RecordPostSchema()),
+      validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
+      validator("json", RecordPostSchema(), sValidatorHook()),
       async (c) => {
         const { cid } = c.req.valid("param");
         const {

--- a/route/src/api/record.ts
+++ b/route/src/api/record.ts
@@ -58,7 +58,7 @@ const recordApp = async (config: {
             description: "invalid chart id",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(v.object({})),
               },
             },
           },
@@ -142,7 +142,7 @@ const recordApp = async (config: {
             description: "invalid chart id or body",
             content: {
               "application/json": {
-                schema: resolver(v.object({ message: v.string() })),
+                schema: resolver(v.object({})),
               },
             },
           },

--- a/route/src/api/search.ts
+++ b/route/src/api/search.ts
@@ -14,6 +14,7 @@ import {
   popularDays,
 } from "@falling-nikochan/chart";
 import { PlayRecordEntry } from "./record.js";
+import { sValidatorHook, validationErrorSchema } from "../error.js";
 
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 600;
@@ -73,6 +74,20 @@ const searchApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
             schema: resolver(v.array(SearchResultSchema())),
           },
         },
+        headers: {
+          "Cache-Control": {
+            description: `max-age=${CACHE_MAX_AGE}`,
+            schema: { type: "string" },
+          },
+        },
+      },
+      400: {
+        description: "invalid parameter",
+        content: {
+          "application/json": {
+            schema: resolver(await validationErrorSchema()),
+          },
+        },
       },
     },
   }),
@@ -100,7 +115,8 @@ const searchApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         v.transform(Number),
         DifficultySchema()
       ),
-    })
+    }),
+    sValidatorHook()
   ),
   async (c) => {
     let { q, sort, difficultyMin, difficultyMax } = c.req.valid("query");

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -16,7 +16,11 @@ import {
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral, sValidatorHook, validationErrorSchema } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 
 const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   "/:cid/:lvIndex",

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -36,7 +36,7 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(v.object({})),
           },
         },
       },

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -16,7 +16,7 @@ import {
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import { errorLiteral, sValidatorHook, validationErrorSchema } from "../error.js";
 
 const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   "/:cid/:lvIndex",
@@ -31,12 +31,18 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
             schema: docRefs("ChartSeqData"),
           },
         },
+        headers: {
+          "Content-Disposition": {
+            description: "Filename with extension of .fnseq.mpk",
+            schema: { type: "string" },
+          },
+        },
       },
       400: {
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({})),
+            schema: resolver(await validationErrorSchema()),
           },
         },
       },
@@ -57,7 +63,8 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
     v.object({
       cid: CidSchema(),
       lvIndex: v.pipe(v.string(), v.regex(/^[0-9]+$/), v.transform(Number)),
-    })
+    }),
+    sValidatorHook()
   ),
   async (c) => {
     const { cid, lvIndex } = c.req.valid("param");

--- a/route/src/api/seqPreview.ts
+++ b/route/src/api/seqPreview.ts
@@ -12,7 +12,7 @@ import {
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 import { describeRoute, resolver } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import { errorLiteral, validationErrorSchema } from "../error.js";
 
 const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
   "/",
@@ -36,6 +36,12 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
             schema: docRefs("ChartSeqData"),
           },
         },
+        headers: {
+          "Content-Disposition": {
+            description: "Filename with extension of .fnseq.mpk",
+            schema: { type: "string" },
+          },
+        },
       },
       409: {
         description: "chart version is not 15",
@@ -49,7 +55,7 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
         description: "Invalid chart format",
         content: {
           "application/json": {
-            schema: resolver(await errorLiteral("invalidChart")),
+            schema: resolver(await validationErrorSchema("invalidChart")),
           },
         },
       },
@@ -73,11 +79,7 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
       }
       levelData = v.parse(LevelPlaySchema15(), decodedData);
     } catch (e) {
-      console.error(e);
-      throw new HTTPException(415, {
-        message: "invalidChart",
-        cause: v.isValiError(e) ? e.issues : undefined,
-      });
+      throw new HTTPException(415, { message: "invalidChart", cause: e });
     }
 
     // Load chart data

--- a/route/src/api/seqPreview.ts
+++ b/route/src/api/seqPreview.ts
@@ -7,6 +7,7 @@ import {
   LevelPlaySchema15,
   Level15Play,
   docRefs,
+  currentChartVer,
 } from "@falling-nikochan/chart";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
@@ -48,65 +49,46 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
         description: "Invalid chart format",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(await errorLiteral("invalidChart")),
           },
         },
       },
     },
   }),
   async (c) => {
+    const rawBody = await c.req.arrayBuffer();
+
+    let levelData: Level15Play;
     try {
-      // Get the raw body as ArrayBuffer
-      const rawBody = await c.req.arrayBuffer();
-
-      // Decode msgpack
-      let decodedData: unknown;
-      try {
-        decodedData = msgpack.decode(new Uint8Array(rawBody));
-      } catch {
-        throw new HTTPException(415, {
-          message: "Invalid msgpack format",
-        });
-      }
-
-      // Check version first
+      const decodedData = msgpack.decode(new Uint8Array(rawBody));
       if (
         typeof decodedData === "object" &&
         decodedData !== null &&
-        "ver" in decodedData
+        "ver" in decodedData &&
+        typeof decodedData.ver === "number"
       ) {
-        if (decodedData.ver !== 15 && decodedData.ver !== 16) {
-          throw new HTTPException(409, { message: "oldChartVersion" });
+        if (decodedData.ver < currentChartVer - 1) {
+          return c.json({ message: "oldChartVersion" }, 409);
         }
       }
-
-      // Validate with LevelPlaySchema15
-      const parseResult = v.safeParse(LevelPlaySchema15(), decodedData);
-      if (!parseResult.success) {
-        throw new HTTPException(415, {
-          message: `Validation error: ${parseResult.issues.map((i) => i.message).join(", ")}`,
-        });
-      }
-
-      const levelData = parseResult.output as Level15Play;
-
-      // Load chart data
-      const seqData: ChartSeqData = loadChart(levelData);
-
-      // Return msgpack-encoded response
-      const filename = "preview.fnseq.mpk";
-      return c.body(new Blob([msgpack.encode(seqData)]).stream(), 200, {
-        "Content-Type": "application/vnd.msgpack",
-        "Content-Disposition": `attachment; filename="${filename}"`,
-      });
-    } catch (error) {
-      if (error instanceof HTTPException) {
-        throw error;
-      }
-      throw new HTTPException(500, {
-        message: "Internal server error",
+      levelData = v.parse(LevelPlaySchema15(), decodedData);
+    } catch (e) {
+      console.error(e);
+      throw new HTTPException(415, {
+        message: "invalidChart",
+        cause: v.isValiError(e) ? e.issues : undefined,
       });
     }
+
+    // Load chart data
+    const seqData: ChartSeqData = loadChart(levelData);
+
+    // Return msgpack-encoded response
+    const filename = "preview.fnseq.mpk";
+    return c.body(new Blob([msgpack.encode(seqData)]).stream(), 200, {
+      "Content-Type": "application/vnd.msgpack",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    });
   }
 );
 

--- a/route/src/api/seqPreview.ts
+++ b/route/src/api/seqPreview.ts
@@ -44,7 +44,7 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
         },
       },
       409: {
-        description: "chart version is not 15",
+        description: `chart version is older than ${currentChartVer - 1}`,
         content: {
           "application/json": {
             schema: resolver(await errorLiteral("oldChartVersion")),

--- a/route/src/api/seqPreview.ts
+++ b/route/src/api/seqPreview.ts
@@ -55,7 +55,12 @@ const seqPreviewApp = new Hono<{ Bindings: Bindings }>({ strict: false }).post(
         description: "Invalid chart format",
         content: {
           "application/json": {
-            schema: resolver(await validationErrorSchema("invalidChart")),
+            schema: resolver(
+              v.union([
+                await validationErrorSchema("invalidChart"),
+                await errorLiteral("invalidChart"),
+              ])
+            ),
           },
         },
       },

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -39,7 +39,7 @@ const ytMetaApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({ message: v.string() })),
+            schema: resolver(v.object({})),
           },
         },
       },

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -7,8 +7,13 @@ import { env } from "hono/adapter";
 import { CidSchema } from "@falling-nikochan/chart";
 import * as v from "valibot";
 import { describeRoute, resolver, validator } from "hono-openapi";
-import { errorLiteral } from "../error.js";
+import {
+  errorLiteral,
+  sValidatorHook,
+  validationErrorSchema,
+} from "../error.js";
 import { getYTDataEntry } from "./ytData.js";
+import { HTTPException } from "hono/http-exception";
 
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 86400;
@@ -34,12 +39,18 @@ const ytMetaApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
             ),
           },
         },
+        headers: {
+          "Cache-Control": {
+            description: `max-age=${CACHE_MAX_AGE}`,
+            schema: { type: "string" },
+          },
+        },
       },
       400: {
         description: "invalid chart id",
         content: {
           "application/json": {
-            schema: resolver(v.object({})),
+            schema: resolver(await validationErrorSchema()),
           },
         },
       },
@@ -53,8 +64,8 @@ const ytMetaApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       },
     },
   }),
-  validator("param", v.object({ cid: CidSchema() })),
-  validator("query", v.object({ lang: v.string() })),
+  validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
+  validator("query", v.object({ lang: v.string() }), sValidatorHook()),
   async (c) => {
     const { cid } = c.req.valid("param");
     const { lang } = c.req.valid("query");
@@ -85,7 +96,7 @@ const ytMetaApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
         });
       } else {
         // todo: better error message
-        return c.json({}, 500);
+        throw new HTTPException(500);
       }
     } finally {
       await client.close();

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -59,20 +59,17 @@ export const onError =
     try {
       const lang = c.get("language") || "en";
       let status: ContentfulStatusCode;
-      let message: string;
+      let message: string = "";
       let others: object = {};
       if (v.isValiError(err)) {
         status = 400;
-        message = "badRequest";
         others = {
           flattened: v.flatten(err.issues),
           issues: err.issues,
         };
       } else if (err instanceof HTTPException) {
         status = err.status;
-        message =
-          err.message ||
-          (status === 400 ? "badRequest" : status === 404 ? "notFound" : "");
+        message = err.message;
         if (v.isValiError(err.cause)) {
           others = {
             flattened: v.flatten(err.cause.issues),
@@ -81,8 +78,15 @@ export const onError =
         }
       } else {
         status = 500;
-        message = "unknownApiError";
       }
+
+      const messageFallbacks: Record<number, string> = {
+        400: "badRequest",
+        404: "notFound",
+        500: "unknownApiError",
+      };
+      message = message || messageFallbacks[status] || "";
+
       if (c.req.path.startsWith("/api") || c.req.path.startsWith("/og")) {
         return c.json(
           {

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -137,7 +137,7 @@ async function errorResponse(
       t.has("api." + message)
         ? t("api." + message)
         : status === 400
-          ? t("api.badResponse")
+          ? t("api.badRequest")
           : status === 404
             ? t("api.notFound")
             : message || t("unknownApiError")

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -45,7 +45,7 @@ export const onError =
       const status = (err as HTTPException).status;
       const message =
         (err as HTTPException).message || (status === 404 ? "notFound" : "");
-      const cause = JSON.parse(JSON.stringify((err as HTTPException).cause));
+      const cause = (err as HTTPException).cause;
       if (c.req.path.startsWith("/api") || c.req.path.startsWith("/og")) {
         return c.json(
           {

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -4,6 +4,7 @@ import { HTTPException } from "hono/http-exception";
 import { env } from "hono/adapter";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import * as v from "valibot";
+import { ContentfulStatusCode } from "hono/utils/http-status";
 
 export function notFound(): Response {
   throw new HTTPException(404);
@@ -18,6 +19,26 @@ export function fetchError(e: Bindings) {
     }
   };
 }
+/**
+ * validation error時にValiErrorにしてthrowするだけのhook
+ */
+export function sValidatorHook() {
+  return (
+    e:
+      | { success: true }
+      | {
+          success: false;
+          error: readonly unknown[]; // readonly Issue[] だが正しいimport方法がわからない & 結局キャスト必要
+        }
+  ) => {
+    if (!e.success) {
+      throw new v.ValiError([...e.error] as [
+        v.BaseIssue<unknown>,
+        ...v.BaseIssue<unknown>[],
+      ]);
+    }
+  };
+}
 export const onError =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
@@ -29,7 +50,7 @@ export const onError =
         console.log(`Error handler triggered in ${c.req.path}: ${err.message}`);
       } else {
         console.error(
-          `Error handler triggered in ${c.req.path}: ${err.message}\n${err.stack}`
+          `Error handler triggered in ${c.req.path}: ${err.message}\n${err.cause}\n${err.stack}`
         );
       }
     } else {
@@ -37,20 +58,36 @@ export const onError =
     }
     try {
       const lang = c.get("language") || "en";
+      let status: ContentfulStatusCode;
+      let message: string;
+      let others: object = {};
       if (v.isValiError(err)) {
-        err = new HTTPException(400, { cause: err.issues });
-      } else if (!(err instanceof HTTPException)) {
-        err = new HTTPException(500);
+        status = 400;
+        message = "badRequest";
+        others = {
+          flattened: v.flatten(err.issues),
+          issues: err.issues,
+        };
+      } else if (err instanceof HTTPException) {
+        status = err.status;
+        message =
+          err.message ||
+          (status === 400 ? "badRequest" : status === 404 ? "notFound" : "");
+        if (v.isValiError(err.cause)) {
+          others = {
+            flattened: v.flatten(err.cause.issues),
+            issues: err.cause.issues,
+          };
+        }
+      } else {
+        status = 500;
+        message = "unknownApiError";
       }
-      const status = (err as HTTPException).status;
-      const message =
-        (err as HTTPException).message || (status === 404 ? "notFound" : "");
-      const cause = (err as HTTPException).cause;
       if (c.req.path.startsWith("/api") || c.req.path.startsWith("/og")) {
         return c.json(
           {
-            ...(message ? { message } : {}),
-            ...(cause ? { cause } : {}),
+            message,
+            ...others,
           },
           status
         );
@@ -100,7 +137,7 @@ async function errorResponse(
       t.has("api." + message)
         ? t("api." + message)
         : status === 400
-          ? t("api.generic400")
+          ? t("api.badResponse")
           : status === 404
             ? t("api.notFound")
             : message || t("unknownApiError")
@@ -116,5 +153,27 @@ export async function errorLiteral(...message: string[]) {
   }
   return v.object({
     message: v.union([...message.map((m) => v.literal(m))]),
+  });
+}
+
+export async function validationErrorSchema(m: string = "badRequest") {
+  const t = await getTranslations("en", "error");
+  if (!t.has("api." + m)) {
+    throw new Error("Unknown error message key in " + m);
+  }
+  return v.object({
+    message: v.literal(m),
+    flattened: v.pipe(
+      v.object({
+        root: v.optional(v.unknown()),
+        nested: v.optional(v.unknown()),
+        other: v.optional(v.unknown()),
+      }),
+      v.description("Flattened error messages of issues")
+    ),
+    issues: v.pipe(
+      v.array(v.unknown()),
+      v.description("raw issues from Valibot")
+    ),
   });
 }

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -1,6 +1,5 @@
 import { Context } from "hono";
 import { backendOrigin, Bindings } from "./env.js";
-import { ValiError } from "valibot";
 import { HTTPException } from "hono/http-exception";
 import { env } from "hono/adapter";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
@@ -38,17 +37,23 @@ export const onError =
     }
     try {
       const lang = c.get("language") || "en";
-      if (err instanceof ValiError) {
-        err = new HTTPException(400, { message: err.message });
+      if (v.isValiError(err)) {
+        err = new HTTPException(400, { cause: err.issues });
       } else if (!(err instanceof HTTPException)) {
         err = new HTTPException(500);
       }
       const status = (err as HTTPException).status;
       const message =
-        (await (err as HTTPException).getResponse().text()) ||
-        (status === 404 ? "notFound" : "");
+        (err as HTTPException).message || (status === 404 ? "notFound" : "");
+      const cause = JSON.parse(JSON.stringify((err as HTTPException).cause));
       if (c.req.path.startsWith("/api") || c.req.path.startsWith("/og")) {
-        return c.json({ message }, status);
+        return c.json(
+          {
+            ...(message ? { message } : {}),
+            ...(cause ? { cause } : {}),
+          },
+          status
+        );
       } else {
         if (c.req.path === `/${lang}/errorPlaceholder`) {
           // エラーハンドラーがfetchに失敗して無限ループになるのを防ぐ

--- a/route/tests/api/brief.spec.ts
+++ b/route/tests/api/brief.spec.ts
@@ -50,5 +50,8 @@ describe("GET /api/brief/:cid", () => {
     await initDb();
     const res = await app.request("/api/brief/invalid");
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
 });

--- a/route/tests/api/chartFile.delete.spec.ts
+++ b/route/tests/api/chartFile.delete.spec.ts
@@ -65,6 +65,9 @@ describe("DELETE /api/chartFile/:cid", () => {
       method: "delete",
     });
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
   test("should return 401 for wrong password", async () => {
     await initDb();

--- a/route/tests/api/chartFile.get.spec.ts
+++ b/route/tests/api/chartFile.get.spec.ts
@@ -173,6 +173,9 @@ describe("GET /api/chartFile/:cid", () => {
     await initDb();
     const res = await app.request("/api/chartFile/100000a?p=p");
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
   test("should return 401 for wrong password", async () => {
     await initDb();

--- a/route/tests/api/chartFile.post.spec.ts
+++ b/route/tests/api/chartFile.post.spec.ts
@@ -168,6 +168,9 @@ describe("POST /api/chartFile/:cid", () => {
       body: msgpack.encode({ ...dummyChart(), title: "updated" }),
     });
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
   test("should return 401 for wrong password", async () => {
     await initDb();
@@ -297,6 +300,8 @@ describe("POST /api/chartFile/:cid", () => {
       body: "invalid",
     });
     expect(res.status).to.equal(415);
+    const body = await res.json();
+    expect(body.message).to.equal("invalidChart");
   });
   describe("password of chart", () => {
     test("should not be changed if changePasswd is null", async () => {

--- a/route/tests/api/hashPasswd.spec.ts
+++ b/route/tests/api/hashPasswd.spec.ts
@@ -50,7 +50,7 @@ describe("GET /api/hashPasswd/:cid", () => {
       pServerHash = (await (await client.connect())
         .db("nikochan")
         .collection<ChartEntryCompressed>("chart")
-        .findOne({ cid: "100000" }))!.pServerHash;
+        .findOne({ cid: "100000" }))!.pServerHash!;
     } finally {
       client.close();
     }
@@ -59,6 +59,9 @@ describe("GET /api/hashPasswd/:cid", () => {
   test("should return 400 for invalid cid", async () => {
     const res = await app.request("/api/hashPasswd/invalid?p=p");
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
   test("should return 404 for nonexistent cid", async () => {
     const res = await app.request("/api/hashPasswd/100002?p=p");

--- a/route/tests/api/newChartFile.post.spec.ts
+++ b/route/tests/api/newChartFile.post.spec.ts
@@ -224,5 +224,7 @@ describe("POST /api/newChartFile", () => {
       body: "invalid",
     });
     expect(res.status).to.equal(415);
+    const body = await res.json();
+    expect(body.message).to.equal("invalidChart");
   });
 });

--- a/route/tests/api/playFile.spec.ts
+++ b/route/tests/api/playFile.spec.ts
@@ -128,5 +128,8 @@ describe("GET /api/playFile/:cid/:lvIndex", () => {
     await initDb();
     const res = await app.request("/api/playFile/invalid/0");
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
 });

--- a/route/tests/api/seqFile.spec.ts
+++ b/route/tests/api/seqFile.spec.ts
@@ -61,5 +61,8 @@ describe("GET /api/seqFile/:cid/:lvIndex", () => {
     await initDb();
     const res = await app.request("/api/seqFile/invalid/0");
     expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.cid[0]).to.be.a("string");
   });
 });

--- a/route/tests/api/seqPreview.spec.ts
+++ b/route/tests/api/seqPreview.spec.ts
@@ -40,7 +40,7 @@ describe("POST /api/seqPreview", () => {
 
     expect(res.status).to.equal(415);
     const body = await res.json();
-    expect(body.message).to.equal("Invalid msgpack format");
+    expect(body.message).to.equal("invalidChart");
   });
 
   test("should return 415 for invalid Level15Play data (missing required fields)", async () => {
@@ -60,7 +60,7 @@ describe("POST /api/seqPreview", () => {
 
     expect(res.status).to.equal(415);
     const body = await res.json();
-    expect(body.message).to.include("Validation error");
+    expect(body.message).to.include("invalidChart");
   });
 
   test("should return 409 for invalid ver field", async () => {
@@ -102,6 +102,6 @@ describe("POST /api/seqPreview", () => {
 
     expect(res.status).to.equal(415);
     const body = await res.json();
-    expect(body.message).to.include("Validation error");
+    expect(body.message).to.include("invalidChart");
   });
 });

--- a/route/tsconfig.json
+++ b/route/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2021",
-    "lib": ["es2021"],
+    "lib": ["es2021", "es2022.error"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,


### PR DESCRIPTION
#1135 の実装中に見つけたエラーメッセージの不統一を修正。

- エラーレスポンスのmessageの厳密化
  - 400, 500のメッセージなしエラーに対してエラーハンドラで汎用メッセージを付与
  - 400の`generic400`を`badResponse`に変更
- ValiErrorの場合にその詳細をmessageではなく flattened, issues として出力する
- レスポンスヘッダーのドキュメントを追加、resolverを使わず直接型を記述することでtypescriptのエラー回避
- hono-openapiのvalidatorにhookを設定し他のエラーレスポンスと同じ出力形式にする
- /api/oembedのドキュメントが不要なので隠す
- update agents.md and contributing.md
