### PR TITLE
Wretch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ AIエージェントは以下の特殊な構成に注意してください。
 - `@/...` のパスは `app/[locale]/` ディレクトリを基準としたパスに解決します。
 - アイコンは icon-park ライブラリを使用しています。 `import アイコン名 from "@icon-park/react/lib/icons/アイコン名";` でインポートしてください。
 - CSSはTailwindCSSを使用しています。app/[locale]/globals.cssで独自のテーマ変数を定義しており、特にbreakpointは一般的なmdやlgを使わず独自のmain-wide:などを使用します。またstyles/utilities.cssに独自のユーティリティクラスが定義されています。同じスタイルの記述を複数書く場合はtailwind componentに抽出し、styles/以下のcssファイルに書きます(その場合独自のコンポーネントの名前はfn-で始めます)。
+- フロントエンドがHTTPリクエストを行う際は生の fetch API の代わりに `wretch` ライブラリを使用しています。ただし、`wretch()` を直接使用せず `@/common/fetch.ts` で定義されているラッパーメソッド `fetchBackend()` `fetchAsset()` を使用してください。使用方法はfetch.tsのコメントを参照してください。
 - これはパブリックなサイトであり、また meta referrer タグでreferrerをoriginのみに制限しているので、外部へのリンクに `rel="noreferrer"` をつける必要はありません。また現代のモダンなブラウザでは `noopener` も不要です。
 - shareページ(`/share/[cid]`)はNext.jsの標準的な開発環境（`pnpm run ndev`）では正しく動作しません。実際には [locale]/share/placeholder にあるダミーのページをエクスポートしたHTMLを本番環境のHonoバックエンドが書き換えることで動作しています。
 - playページでは、 FallingWindow コンポーネントで`rerenderIndex` というstateをrequestAnimationFrame内で更新することで毎フレームReactの再レンダリングを起こしています。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,7 @@ pnpm run nbuild
   - This project uses custom breakpoints such as `main-wide:` instead of standard `md:` or `lg:`.
   - Custom utility classes: `styles/utilities.css`
   - When the same styles are repeated, extract them into a Tailwind component in a `styles/*.css` file. Custom component names start with `fn-`.
+- For HTTP requests, we use [wretch](https://elbywan.github.io/wretch/) library instead of plain fetch API. Use the wrapper method `fetchBackend()` or `fetchAsset()` defined in `@/common/fetch.ts`.
 - The `/share/[cid]` page is special. It works by having the Hono backend rewrite the exported placeholder HTML at runtime. It does **not** work in the `pnpm run ndev` development environment.
   - Use `/{ja,en}/share/placeholder` for the placeholder page during development.
 - `/play` page

--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -6,7 +6,7 @@ export function shouldHideStatus(status: number) {
 }
 
 /**
- * fetch()におけるネットワークエラーと5xxのサーバーエラー、その他処理中に起きたロジックエラーを統一して扱うクラス。
+ * fetch()におけるネットワークエラーと5xxのサーバーエラーを統一して扱うクラス。
  */
 export class APIError extends Error {
   url: string;
@@ -38,7 +38,7 @@ export class APIError extends Error {
       this.message,
       // url内のパラメータ部分を消す (cid, lvIndex など)
       // TODO: 数値以外がパラメータになるAPIが今後作られた場合ロジックを変更する必要がある
-      new URL(this.url).pathname.replace(/\/[0-9]*/g, ""),
+      new URL(this.url).pathname.replace(/\/\d+/g, ""),
     ];
   }
 

--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -1,84 +1,75 @@
-import * as Sentry from "@sentry/nextjs";
-
-const fetchErrorStatus = 499;
+export const FETCH_ERROR_STATUS = 499;
 
 /**
- * fetch()におけるネットワークエラーと5xxのサーバーエラーを統一して扱うクラス。
- * サーバーエラーの場合は自動的にSentryへの送信も行う。
+ * fetch()におけるネットワークエラーと5xxのサーバーエラー、その他処理中に起きたロジックエラーを統一して扱うクラス。
  */
 export class APIError extends Error {
-  status: number | null;
-  original?: unknown; // 一応sentryから確認するため
-  // message: string;
-  constructor(status: number | null, message: string, original?: unknown) {
+  url: string;
+  status: number;
+  body: unknown;
+  fingerprint: string[];
+  /**
+   * false の場合、Sentryに報告し、さらに問い合わせフォームを出せる場所では出す
+   */
+  expected: boolean = false;
+  constructor(
+    url: string,
+    status: number,
+    message: string,
+    stack: string,
+    body: unknown
+  ) {
     super(message);
-    this.name = status ? `APIError-${status}` : "APIError";
+    this.name = `APIError-${status}`;
     this.status = status;
-    if (this.status === fetchErrorStatus) {
-      // 499はユーザーに表示しない
-      this.status = null;
+    if (status === FETCH_ERROR_STATUS) {
+      this.expected = true;
     }
-    this.original = original;
-    if (this.original instanceof Error) {
-      this.stack = this.original.stack;
-      this.original.stack = undefined;
-    } else if ("captureStackTrace" in Error) {
-      Error.captureStackTrace(this, APIError);
-    }
-    if (this.isServerSide()) {
-      Sentry.captureException(this);
-    }
-  }
-  static fetchError(original: unknown) {
-    if (
-      original instanceof TypeError ||
-      (original instanceof DOMException &&
-        ["AbortError", "NotAllowedError"].includes(original.name))
-    ) {
-      return new APIError(fetchErrorStatus, "fetchError", original);
-    } else {
-      Sentry.captureException(`Object is not fetch error: ${original}`);
-      throw original;
-    }
-  }
-  static badResponse(original: unknown) {
-    return new APIError(null, "badResponse", original);
-  }
-  static async fromRes(res: Response) {
-    let e: APIError;
-    try {
-      e = new APIError(res.status, (await res.json()).message || "");
-    } catch {
-      e = new APIError(res.status, "");
-    }
-    Error.captureStackTrace(e, APIError);
-    return e;
+    this.url = url;
+    this.stack = stack;
+    this.body = body;
+    this.fingerprint = [
+      this.name,
+      this.message,
+      // url内のパラメータ部分を消す (cid, lvIndex など)
+      // TODO: 数値以外がパラメータになるAPIが今後作られた場合ロジックを変更する必要がある
+      new URL(this.url).pathname.replace(/\/[0-9]*/g, ""),
+    ];
   }
 
   formatMsg(t: {
     (key: string): string;
     has: (key: string) => boolean;
   }): string {
-    if (t.has("api." + this.message)) {
+    if (this.status === FETCH_ERROR_STATUS) {
+      return t("api.fetchError");
+    } else if (t.has("api." + this.message)) {
       return t("api." + this.message);
     } else if (t.has(this.message)) {
       return t(this.message);
     } else {
-      return t("unknownApiError");
+      if (this.status === 400) {
+        return t("api.badRequest");
+      } else if (this.status === 404) {
+        return t("api.notFound");
+      } else {
+        return t("unknownApiError");
+      }
     }
   }
   format(t: { (key: string): string; has: (key: string) => boolean }): string {
-    if (this.status) {
+    if (this.status !== FETCH_ERROR_STATUS) {
       return `${this.status}: ${this.formatMsg(t)}`;
     } else {
       return this.formatMsg(t);
     }
   }
+}
 
-  isServerSide() {
-    return (
-      (this.status !== null && (this.status === 403 || this.status >= 500)) ||
-      this.message === "badResponse"
-    );
-  }
+/**
+ * expected をtrueにセットしてrethrow
+ */
+export function markAsExpected(e: APIError): never {
+  e.expected = true;
+  throw e;
 }

--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -1,4 +1,9 @@
 export const FETCH_ERROR_STATUS = 499;
+export const ABORT_ERROR_STATUS = 498;
+
+export function shouldHideStatus(status: number) {
+  return status === FETCH_ERROR_STATUS || status === ABORT_ERROR_STATUS;
+}
 
 /**
  * fetch()におけるネットワークエラーと5xxのサーバーエラー、その他処理中に起きたロジックエラーを統一して扱うクラス。
@@ -22,7 +27,7 @@ export class APIError extends Error {
     super(message);
     this.name = `APIError-${status}`;
     this.status = status;
-    if (status === FETCH_ERROR_STATUS) {
+    if (status === FETCH_ERROR_STATUS || status === ABORT_ERROR_STATUS) {
       this.expected = true;
     }
     this.url = url;
@@ -58,10 +63,10 @@ export class APIError extends Error {
     }
   }
   format(t: { (key: string): string; has: (key: string) => boolean }): string {
-    if (this.status !== FETCH_ERROR_STATUS) {
-      return `${this.status}: ${this.formatMsg(t)}`;
-    } else {
+    if (shouldHideStatus(this.status)) {
       return this.formatMsg(t);
+    } else {
+      return `${this.status}: ${this.formatMsg(t)}`;
     }
   }
 }

--- a/frontend/app/[locale]/common/briefCache.ts
+++ b/frontend/app/[locale]/common/briefCache.ts
@@ -19,18 +19,19 @@ interface Callbacks {
  * APIのレスポンスがエラーになり、かつcacheデータもない場合、onErrorを呼ぶ。fetchBrief()側でsentryへは送信済み。
  */
 export async function fetchBrief(cid: string, callbacks: Callbacks) {
-  window.caches
-    .keys()
-    .then((keys) =>
-      keys
-        .filter((k) => k.startsWith("brief") && k !== briefCacheName)
-        .forEach((k) => window.caches.delete(k))
-    );
   let cache: Cache | undefined = undefined;
   if ("caches" in window) {
+    window.caches
+      .keys()
+      .then((keys) =>
+        keys
+          .filter((k) => k.startsWith("brief") && k !== briefCacheName)
+          .forEach((k) => window.caches.delete(k))
+      );
     cache = await window.caches.open(briefCacheName);
   }
   let hasResult = false;
+  let cachePromise: Promise<void> | undefined = undefined;
 
   const staleLS = localStorage.getItem(briefKeyOld(cid));
   if (staleLS) {
@@ -39,7 +40,7 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
     callbacks.onResult(JSON.parse(staleLS) as ChartBrief);
     hasResult = true;
   } else {
-    cache?.match(`/api/brief/${cid}`).then(async (res) => {
+    cachePromise = cache?.match(`/api/brief/${cid}`).then(async (res) => {
       if (res) {
         callbacks.onResult((await res.json()) as ChartBrief);
         hasResult = true;
@@ -50,6 +51,7 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
   fetchBackend()
     .get(`/api/brief/${cid}`)
     .notFound(async () => {
+      await cachePromise;
       if ("caches" in window) {
         cache?.delete(`/api/brief/${cid}`);
       }
@@ -58,11 +60,14 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
       hasResult = false;
     })
     .res(async (res) => {
-      callbacks.onResult(v.parse(ChartBriefSchema(), await res.clone().json()));
+      const result = v.parse(ChartBriefSchema(), await res.clone().json());
+      await cachePromise;
+      callbacks.onResult(result);
       hasResult = true;
       await cache?.put(`/api/brief/${cid}`, res);
     })
-    .catch((e: unknown) => {
+    .catch(async (e: unknown) => {
+      await cachePromise;
       e = captureAndWrap(e, { cid });
       if (!hasResult) {
         callbacks.onError?.(e as Error);

--- a/frontend/app/[locale]/common/briefCache.ts
+++ b/frontend/app/[locale]/common/briefCache.ts
@@ -1,73 +1,71 @@
-import { ChartBrief } from "@falling-nikochan/chart";
+import { ChartBrief, ChartBriefSchema } from "@falling-nikochan/chart";
+import { captureAndWrap, fetchBackend } from "./fetch";
+import * as v from "valibot";
 
 function briefKeyOld(cid: string) {
   return "brief-" + cid;
 }
 const briefCacheName = "brief1";
 
-export async function fetchBrief(
-  cid: string,
-  noCache?: boolean
-): Promise<{ brief?: ChartBrief; ok: boolean; is404: boolean }> {
-  const fetchRes = fetch(process.env.BACKEND_PREFIX + `/api/brief/${cid}`, {
-    cache: noCache ? "no-store" : "default",
-  });
-  const staleLS = localStorage.getItem(briefKeyOld(cid));
-  let stale: string | undefined = undefined;
+interface Callbacks {
+  onResult: (brief: ChartBrief) => void;
+  onNotFound?: () => void;
+  onError?: (e: Error) => void;
+}
+/**
+ * cacheからbriefデータを取得し、あればonResultを呼ぶ。
+ * APIをfetchし、レスポンスが返ってきたら再度onResultを呼ぶ。
+ * APIのレスポンスが404だった場合は、onNotFoundを呼びcacheを消す。
+ * APIのレスポンスがエラーになり、かつcacheデータもない場合、onErrorを呼ぶ。fetchBrief()側でsentryへは送信済み。
+ */
+export async function fetchBrief(cid: string, callbacks: Callbacks) {
+  window.caches
+    .keys()
+    .then((keys) =>
+      keys
+        .filter((k) => k.startsWith("brief") && k !== briefCacheName)
+        .forEach((k) => window.caches.delete(k))
+    );
   let cache: Cache | undefined = undefined;
   if ("caches" in window) {
     cache = await window.caches.open(briefCacheName);
-    window.caches
-      .keys()
-      .then((keys) =>
-        keys
-          .filter((k) => k.startsWith("brief") && k !== briefCacheName)
-          .forEach((k) => window.caches.delete(k))
-      );
-    if (staleLS) {
-      cache.put(`/api/brief/${cid}`, new Response(staleLS));
-      localStorage.removeItem(briefKeyOld(cid));
-    }
-    stale =
-      staleLS ||
-      (await cache.match(`/api/brief/${cid}`).then((res) => res?.text()));
   }
-  if (stale && !noCache) {
-    fetchRes
-      .then(async (res) => {
-        if (res.ok) {
-          cache?.put(`/api/brief/${cid}`, res);
-        } else if (res.status == 404) {
-          cache?.delete(`/api/brief/${cid}`);
-          localStorage.removeItem(briefKeyOld(cid));
-        }
-      })
-      .catch(() => undefined);
-    return {
-      brief: JSON.parse(stale) as ChartBrief,
-      ok: true,
-      is404: false,
-    };
+  let hasResult = false;
+
+  const staleLS = localStorage.getItem(briefKeyOld(cid));
+  if (staleLS) {
+    cache?.put(`/api/brief/${cid}`, new Response(staleLS));
+    localStorage.removeItem(briefKeyOld(cid));
+    callbacks.onResult(JSON.parse(staleLS) as ChartBrief);
+    hasResult = true;
   } else {
-    try {
-      const res = await fetchRes;
-      if (res.ok) {
-        cache?.put(`/api/brief/${cid}`, res.clone());
-        const brief = (await res.json()) as ChartBrief;
-        return {
-          brief,
-          ok: true,
-          is404: false,
-        };
-      } else {
-        if (res.status == 404) {
-          cache?.delete(`/api/brief/${cid}`);
-          localStorage.removeItem(briefKeyOld(cid));
-        }
-        return { ok: false, is404: res.status == 404 };
+    cache?.match(`/api/brief/${cid}`).then(async (res) => {
+      if (res) {
+        callbacks.onResult((await res.json()) as ChartBrief);
+        hasResult = true;
       }
-    } catch {
-      return { ok: false, is404: false };
-    }
+    });
   }
+
+  fetchBackend()
+    .get(`/api/brief/${cid}`)
+    .notFound(async () => {
+      if ("caches" in window) {
+        cache?.delete(`/api/brief/${cid}`);
+      }
+      localStorage.removeItem(briefKeyOld(cid));
+      callbacks.onNotFound?.();
+      hasResult = false;
+    })
+    .res(async (res) => {
+      callbacks.onResult(v.parse(ChartBriefSchema(), await res.clone().json()));
+      hasResult = true;
+      await cache?.put(`/api/brief/${cid}`, res);
+    })
+    .catch((e: unknown) => {
+      e = captureAndWrap(e, { cid });
+      if (!hasResult) {
+        callbacks.onError?.(e as Error);
+      }
+    });
 }

--- a/frontend/app/[locale]/common/fetch.ts
+++ b/frontend/app/[locale]/common/fetch.ts
@@ -1,0 +1,163 @@
+import wretch from "wretch";
+import QueryStringAddon from "wretch/addons/queryString";
+import AbortAddon from "wretch/addons/abort";
+import { dedupe, retry } from "wretch/middlewares";
+import * as Sentry from "@sentry/nextjs";
+import { APIError, FETCH_ERROR_STATUS } from "./apiError";
+
+/**
+ * wretchのwrapper
+ *
+ * originを環境変数に従って変更したりfetchErrorをラップしたりなどのアプリ全体で共通で使われるヘルパーメソッドを適用した状態のwretchインスタンスを返す。
+ *
+ * fetchBackend()
+ *  .get("/foo")
+ *  .notFound(markAsExpected) // Sentryに送らなくて良い想定内のエラーをハンドル
+ *  .json((res) => ...)
+ *  // 以下optional:
+ *  .catch((e) => captureAndWrap(e)) // 想定外のエラーはErrorクラスでラップしてSentryに送りreturnする
+ *  .then((result_or_error) => ...)
+ *
+ * のように使う。
+ *
+ * fetchがエラーを投げたときと、レスポンスが4xxや5xxだった場合は APIError がthrowされる。
+ * catch()されなかったエラーは自動でSentryがキャッチし、整形してイベントとして送信される。
+ */
+export function fetchBackend() {
+  const referenceError = { stack: "" };
+  Error.captureStackTrace(referenceError, fetchBackend);
+  return wretch(process.env.BACKEND_PREFIX || window.location.origin)
+    .addon(QueryStringAddon)
+    .addon(AbortAddon())
+    .middlewares([dedupe()])
+    .customError(APIErrorTransformer(referenceError));
+}
+export function fetchAsset() {
+  const referenceError = { stack: "" };
+  Error.captureStackTrace(referenceError, fetchAsset);
+  return wretch(process.env.ASSET_PREFIX || window.location.origin)
+    .middlewares([
+      dedupe(),
+      retry({
+        // fetching static asset should not fail. infinite retry with error report
+        maxAttempts: 0,
+        until: (response) => !!response && response.ok,
+        onRetry: async ({ response, url }) => {
+          if (!response) {
+            // network error, do not report
+          } else {
+            let message: string;
+            try {
+              message = await response.text();
+            } catch {
+              message = response.statusText;
+            }
+            const we = new wretch.WretchError(message);
+            we.cause = referenceError;
+            // we.stack += "\nCAUSE: " + referenceError.stack;
+            we.response = response;
+            we.status = response.status;
+            we.url = url;
+            Sentry.captureException(we);
+          }
+          return {};
+        },
+        retryOnNetworkError: true,
+      }),
+    ])
+    .customError(APIErrorTransformer(referenceError));
+}
+
+function APIErrorTransformer(referenceError: { stack: string }) {
+  return async (
+    we: unknown,
+    res: Response | undefined,
+    req: { _url: string }
+  ): Promise<APIError> => {
+    if (we instanceof DOMException && we.name === "AbortError") {
+      // AbortErrorはネットワークエラーではないのでそのまま流す
+      // → AbortAddonの onAbort() (単にnameで判定している) でキャッチ
+      // wretchの型定義が微妙なのでここでDOMException型として返すと他のcatcherの型指定が面倒なことになる
+      return we as any;
+    }
+    const status =
+      we instanceof wretch.WretchError ? we.status : FETCH_ERROR_STATUS;
+    let message: string;
+    let body: unknown = undefined;
+    if (!res) {
+      message = "fetchError";
+      body = {
+        error: String(we),
+        ...(we && typeof we === "object" ? we : {}),
+      };
+    } else {
+      try {
+        const bodyText = await res.text();
+        try {
+          body = JSON.parse(bodyText);
+          if (body && typeof body === "object" && "message" in body) {
+            message = String(body.message);
+          } else {
+            message = bodyText.slice(0, 50);
+          }
+        } catch {
+          body = bodyText;
+          // cloudflareが返すエラーレスポンスのHTMLとかの可能性を考慮
+          // HTMLでなかった場合はbodyそのまま(長すぎる場合はslice)
+          message =
+            bodyText.match(/<title>\s*([\s\S]*?)\s*<\/title>/i)?.[1] ??
+            bodyText.slice(0, 50);
+        }
+      } catch (e) {
+        body = String(e);
+        message = "(Failed to parse body of error response)";
+      }
+    }
+    return new APIError(req._url, status, message, referenceError.stack, body);
+  };
+}
+
+/**
+ * エラーをSentryに報告する。
+ * 引数がErrorクラス型でない場合Errorクラスでラップし、そのエラーをreturnする。
+ */
+export function captureAndWrap(
+  e: unknown,
+  extra?: Record<string, unknown>
+): Error {
+  if (!(e instanceof Error)) {
+    e = new Error(String(e));
+    Error.captureStackTrace(e as Error, captureAndWrap);
+  }
+  Sentry.captureException(e, { extra });
+  console.error(e, { extra });
+  return e as Error;
+}
+
+export function formatErrorMsg(
+  e: Error,
+  t: { (key: string): string; has: (key: string) => boolean }
+) {
+  if (e instanceof APIError) {
+    return e.formatMsg(t);
+  } else {
+    return t("badResponse");
+  }
+}
+export function formatError(
+  e: Error,
+  t: { (key: string): string; has: (key: string) => boolean }
+) {
+  if (e instanceof APIError) {
+    return e.format(t);
+  } else {
+    return t("badResponse");
+  }
+}
+export function isExpectedError(e: Error): boolean {
+  if (e instanceof APIError) {
+    return e.expected;
+  } else {
+    return false;
+  }
+}

--- a/frontend/app/[locale]/common/fetch.ts
+++ b/frontend/app/[locale]/common/fetch.ts
@@ -3,7 +3,7 @@ import QueryStringAddon from "wretch/addons/queryString";
 import AbortAddon from "wretch/addons/abort";
 import { dedupe, retry } from "wretch/middlewares";
 import * as Sentry from "@sentry/nextjs";
-import { APIError, FETCH_ERROR_STATUS } from "./apiError";
+import { ABORT_ERROR_STATUS, APIError, FETCH_ERROR_STATUS } from "./apiError";
 
 /**
  * wretchのwrapper
@@ -74,18 +74,21 @@ function APIErrorTransformer(referenceError: { stack: string }) {
     res: Response | undefined,
     req: { _url: string }
   ): Promise<APIError> => {
-    if (we instanceof DOMException && we.name === "AbortError") {
-      // AbortErrorはネットワークエラーではないのでそのまま流す
-      // → AbortAddonの onAbort() (単にnameで判定している) でキャッチ
-      // wretchの型定義が微妙なのでここでDOMException型として返すと他のcatcherの型指定が面倒なことになる
-      return we as any;
-    }
     const status =
-      we instanceof wretch.WretchError ? we.status : FETCH_ERROR_STATUS;
+      we instanceof wretch.WretchError
+        ? we.status
+        : we instanceof DOMException && we.name === "AbortError"
+          ? ABORT_ERROR_STATUS
+          : FETCH_ERROR_STATUS;
     let message: string;
     let body: unknown = undefined;
     if (!res) {
-      message = "fetchError";
+      if (status === FETCH_ERROR_STATUS) {
+        // fetchErrorはユーザー向けメッセージがある
+        message = "fetchError";
+      } else {
+        message = String(we);
+      }
       body = {
         error: String(we),
         ...(we && typeof we === "object" ? we : {}),
@@ -127,6 +130,9 @@ export function captureAndWrap(
 ): Error {
   if (!(e instanceof Error)) {
     e = new Error(String(e));
+    Error.captureStackTrace(e as Error, captureAndWrap);
+  }
+  if (!(e as Error).stack) {
     Error.captureStackTrace(e as Error, captureAndWrap);
   }
   Sentry.captureException(e, { extra });

--- a/frontend/app/[locale]/common/fetch.ts
+++ b/frontend/app/[locale]/common/fetch.ts
@@ -21,7 +21,10 @@ import { ABORT_ERROR_STATUS, APIError, FETCH_ERROR_STATUS } from "./apiError";
  * のように使う。
  *
  * fetchがエラーを投げたときと、レスポンスが4xxや5xxだった場合は APIError がthrowされる。
- * catch()されなかったエラーは自動でSentryがキャッチし、整形してイベントとして送信される。
+ *
+ * 想定内のエラーがない場合はcatch()しなくてもよい。
+ * その場合はunhandledrejectionとして自動でSentryがキャッチし、整形してイベントとして送信される。
+ * (ネットワークエラーとAbortErrorはいずれの場合でもexpectedとしてマークされSentry送信の対象外)
  */
 export function fetchBackend() {
   const referenceError = { stack: "" };

--- a/frontend/app/[locale]/common/se.ts
+++ b/frontend/app/[locale]/common/se.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchAsset } from "./fetch";
 
 export type SEType = "hit" | "hitBig" | "beat" | "beat1";
 
@@ -139,14 +140,12 @@ export function useSE(
           ["beat1", audioBeat1],
         ] as const
       ).forEach(([name, audioBuffer]) =>
-        fetch(process.env.ASSET_PREFIX + `/assets/${name}.wav`).then(
-          async (res) => {
-            const aryBuf = await res.arrayBuffer();
+        fetchAsset()
+          .get(`/assets/${name}.wav`)
+          .arrayBuffer(async (aryBuf) => {
             const audio = await audioContext.current!.decodeAudioData(aryBuf);
             audioBuffer.current = audio;
-          },
-          () => undefined
-        )
+          })
       );
       return () => {
         gainNodeHit.current?.disconnect();

--- a/frontend/app/[locale]/common/shareLinkAndImage.tsx
+++ b/frontend/app/[locale]/common/shareLinkAndImage.tsx
@@ -20,6 +20,7 @@ import { useOSDetector } from "./pwaInstall";
 import Pic from "@icon-park/react/lib/icons/Pic";
 import Select from "./select";
 import { XLogo } from "./x";
+import { fetchBackend } from "./fetch";
 
 export function useShareLink(
   cid: string | undefined,
@@ -74,7 +75,9 @@ export function useShareLink(
       // og画像の生成は時間がかかるので、
       // 共有される前にogを1回fetchしておくことにより、
       // cloudflareにキャッシュさせる
-      void fetch(process.env.BACKEND_PREFIX + ogPath).catch(() => undefined);
+      fetchBackend()
+        .get(ogPath)
+        .res(() => undefined);
       if (withTitle) {
         navigator.clipboard.writeText(
           newTitle +
@@ -92,7 +95,9 @@ export function useShareLink(
   );
   const [shareData, setShareData] = useState<object | null>(null);
   const toAPI = useCallback(() => {
-    void fetch(process.env.BACKEND_PREFIX + ogPath).catch(() => undefined);
+    fetchBackend()
+      .get(ogPath)
+      .res(() => undefined);
     navigator.share(shareData!);
   }, [shareData, ogPath]);
   useEffect(() => {
@@ -221,10 +226,10 @@ export function ShareImageModalProvider(props: { children: React.ReactNode }) {
   const [imageBlob, setImageBlob] = useState<Blob>();
   useEffect(() => {
     if (modalOpened) {
-      fetch(process.env.BACKEND_PREFIX + ogPath).then(
-        (r) => r.blob().then((b) => setImageBlob(b)),
-        () => undefined
-      );
+      fetchBackend()
+        .get(ogPath)
+        .blob((b) => setImageBlob(b));
+      // TODO: エラーの場合imageBlobがundefinedのままになっている。エラーであることをユーザーに表示するべき
     }
   }, [ogPath, modalOpened]);
 

--- a/frontend/app/[locale]/common/sharePageModal.tsx
+++ b/frontend/app/[locale]/common/sharePageModal.tsx
@@ -2,7 +2,11 @@
 
 import clsx from "clsx/lite";
 import { titleShare, titleWithSiteName } from "@/common/title";
-import { ChartBrief, RecordGetSummary } from "@falling-nikochan/chart";
+import {
+  ChartBrief,
+  RecordGetSummary,
+  RecordGetSummarySchema,
+} from "@falling-nikochan/chart";
 import {
   createContext,
   ReactNode,
@@ -18,7 +22,8 @@ import { ShareBox } from "@/share/placeholder/shareBox";
 import { useRouter } from "next/navigation";
 import { useDelayedDisplayState } from "./delayedDisplayState";
 import { historyBackWithReview } from "./pwaInstall";
-import { APIError } from "./apiError";
+import { captureAndWrap, fetchBackend } from "./fetch";
+import * as v from "valibot";
 
 interface SharePageModalState {
   openModal: (cid: string) => void;
@@ -41,7 +46,7 @@ export function SharePageModalProvider(props: {
   const [modalCId, setModalCId] = useState<string | null>(null);
   const [modalBrief, setModalBrief] = useState<ChartBrief | null>(null);
   const [modalRecord, setModalRecord] = useState<
-    RecordGetSummary[] | APIError | null
+    RecordGetSummary[] | Error | null
   >(null);
   const [modalOpened, modalAppearing, setModalOpened] =
     useDelayedDisplayState(200);
@@ -68,25 +73,11 @@ export function SharePageModalProvider(props: {
         }
       });
       setModalRecord(null);
-      (async () => {
-        try {
-          const res = await fetch(
-            process.env.BACKEND_PREFIX + `/api/record/${cid}`
-          );
-          if (res.ok) {
-            try {
-              setModalRecord(await res.json());
-            } catch (e) {
-              console.error(e);
-              setModalRecord(APIError.badResponse(e));
-            }
-          } else {
-            setModalRecord(await APIError.fromRes(res));
-          }
-        } catch (e) {
-          setModalRecord(APIError.fetchError(e));
-        }
-      })();
+      fetchBackend()
+        .get(`/api/record/${cid}`)
+        .json((record) => v.parse(v.array(RecordGetSummarySchema()), record))
+        .catch((e: unknown) => captureAndWrap(e, { cid }))
+        .then((record) => setModalRecord(record));
       setModalOpened(true);
     },
     [th, setModalOpened, modalCId]

--- a/frontend/app/[locale]/common/sharePageModal.tsx
+++ b/frontend/app/[locale]/common/sharePageModal.tsx
@@ -66,11 +66,11 @@ export function SharePageModalProvider(props: {
       setModalBrief(null);
       setModalCId(cid);
       // document.title = titleShare(th, cid);
-      fetchBrief(cid).then((res) => {
-        if (res.ok) {
-          setModalBrief(res.brief!);
-          document.title = titleShare(th, cid, res.brief!);
-        }
+      fetchBrief(cid, {
+        onResult: (brief) => {
+          setModalBrief(brief);
+          document.title = titleShare(th, cid, brief);
+        },
       });
       setModalRecord(null);
       fetchBackend()

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -22,12 +22,12 @@ import {
   convertToLatest,
   updateBpmTimeSec,
   updateBarNum,
+  rateLimit,
 } from "@falling-nikochan/chart";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as msgpack from "@msgpack/msgpack";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { APIError } from "@/common/apiError";
 import saveAs from "file-saver";
 import YAML from "yaml";
 import { luaExec } from "@falling-nikochan/chart/dist/luaExec";
@@ -36,6 +36,9 @@ import * as v from "valibot";
 import fnCommandsLib from "fn-commands?raw";
 import fnCommandsPackageJson from "fn-commands/package.json";
 import { isInsideFrame } from "@/scale";
+import { captureAndWrap, fetchBackend } from "@/common/fetch";
+import { retry } from "wretch/middlewares";
+import { markAsExpected } from "@/common/apiError";
 
 interface Props {
   onLoad: (cid: string) => void;
@@ -55,7 +58,7 @@ export type ChartAndState =
         | "passwdFailedSilent"
         | "passwdFailed"
         | "rateLimited"
-        | APIError;
+        | Error;
     };
 export type LoadState = ChartAndState["state"];
 export class LocalLoadError {
@@ -65,7 +68,7 @@ export class LocalLoadError {
   }
 }
 export type LocalLoadState = undefined | "loading" | "ok" | LocalLoadError;
-export type SaveState = undefined | "saving" | "ok" | APIError;
+export type SaveState = undefined | "saving" | "ok" | Error;
 interface EditSession {
   cid: string | undefined;
   currentPasswd: CurrentPasswd;
@@ -82,6 +85,15 @@ export interface FetchChartOptions {
   savePasswd: boolean;
 }
 
+function chartFileRetryMiddleware() {
+  return retry({
+    delayTimer: rateLimit.chartFile * 1000 + 500,
+    delayRamp: (delay) => delay,
+    maxAttempts: 3,
+    until: (response) => !response || response.status !== 429,
+    resolveWithLatestResponse: true,
+  });
+}
 const encodeBase64Utf8 = (value: string) => {
   return btoa(
     Array.from(new TextEncoder().encode(value), (byte) =>
@@ -138,96 +150,91 @@ export function useChartState(props: Props) {
       setChartState({ state: "loading" });
       setSavePasswd(options.savePasswd);
 
-      const currentPasswd: CurrentPasswd = {
-        p: options.editPasswd,
+      const initialPasswd: CurrentPasswd = {
+        p: options.editPasswd || null,
         ph: getPasswd(cid),
         pbypass: options.bypass ? "1" : null,
       };
-      const authorization = chartAuthorization(currentPasswd);
-      let res: Response | null = null;
-      try {
-        for (let retry = 0; ; retry++) {
-          res = await fetch(process.env.BACKEND_PREFIX + `/api/chartFile/${cid}`, {
-            cache: "no-store",
-            credentials:
-              process.env.NODE_ENV === "development"
-                ? "include"
-                : "same-origin",
-            headers: authorization ? { Authorization: authorization } : undefined,
-          });
-          if (res.ok) {
-            try {
-              const chartRes = msgpack.decode(
-                await res.arrayBuffer()
-              ) as ChartUntil14;
-              if (options.savePasswd) {
-                if (options.editPasswd) {
-                  try {
-                    const res = await fetch(
-                      process.env.BACKEND_PREFIX + `/api/hashPasswd/${cid}`,
-                      {
-                        headers: {
-                          Authorization: basicAuthorization(options.editPasswd),
-                        },
-                        credentials:
-                          process.env.NODE_ENV === "development"
-                            ? "include"
-                            : "same-origin",
-                      }
-                    );
-                    const ph = await res.text();
-                    setPasswd(cid, ph);
-                    currentPasswd.ph = ph;
-                  } catch {
-                    //ignore
-                  }
-                }
-              } else {
-                // unsetPasswd(cid);
+      const result = await fetchBackend()
+        .url(`/api/chartFile/${cid}`)
+        .options({
+          cache: "no-store",
+          credentials:
+            process.env.NODE_ENV === "development" ? "include" : "same-origin",
+        })
+        .auth(chartAuthorization(initialPasswd) ?? "")
+        .middlewares([chartFileRetryMiddleware()])
+        .get()
+        // passwdPrompt has unique handler for 401 and 429 messages
+        .unauthorized(
+          () =>
+            ({
+              state: options.isFirst ? "passwdFailedSilent" : "passwdFailed",
+            }) as const
+        )
+        .error(429, () => ({ state: "rateLimited" }) as const)
+        .badRequest(markAsExpected)
+        .notFound(markAsExpected)
+        .arrayBuffer(async (buf) => {
+          const chartRes = msgpack.decode(buf) as ChartUntil14;
+          let updatedPh: string | undefined = undefined;
+          if (options.savePasswd) {
+            if (options.editPasswd) {
+              updatedPh = await fetchBackend()
+                .url(`/api/hashPasswd/${cid}`)
+                .options({
+                  credentials:
+                    process.env.NODE_ENV === "development"
+                      ? "include"
+                      : "same-origin",
+                })
+                .auth(basicAuthorization(options.editPasswd) ?? "")
+                .get()
+                .badRequest(() => undefined)
+                .notFound(() => undefined)
+                .text()
+                .catch((e: unknown) => {
+                  Sentry.captureException(e);
+                  console.error(e);
+                  return undefined; // ignore error and continue
+                });
+              if (updatedPh) {
+                setPasswd(cid, updatedPh);
               }
-              setChartState({
-                chart: new ChartEditing(await validateChart(chartRes), {
-                  luaExecutorRef,
-                  locale,
-                  cid,
-                  currentPasswd,
-                  convertedFrom: chartRes.ver,
-                }),
-                state: "ok",
-              });
-              onLoadRef.current(cid);
-            } catch (e) {
-              console.error(e);
-              setChartState({ state: APIError.badResponse(e) });
             }
           } else {
-            if (res.status === 401 || res.status === 400) {
-              if (options.isFirst) {
-                setChartState({ state: "passwdFailedSilent" });
-              } else {
-                setChartState({ state: "passwdFailed" });
-              }
-            } else if (res?.status === 429) {
-              if (retry < 3) {
-                await new Promise((r) =>
-                  setTimeout(
-                    r,
-                    Number(res?.headers.get("Retry-After")) * 1000 + 500
-                  )
-                );
-                continue;
-              }
-              setChartState({ state: "rateLimited" });
-            } else {
-              setChartState({ state: await APIError.fromRes(res) });
-            }
+            /* パスワード保存のチェックが外れたときに保存済みパスワードを消す処理だが、PR#973でコメントアウトされている。
+            issue#971:
+              ある譜面に「パスワードを保存する」のチェックを外してパスワードを入力すると、
+              すでにパスワードを保存済みの別の譜面を読み込んだ際に
+              「パスワードを保存する」がオフ かつ 保存済みパスワードを使って譜面をロードした 状態になり、バグる
+            (...つまりどういうこと?)
+            */
+            // unsetPasswd(cid);
           }
-          break;
-        }
-      } catch (e) {
-        console.error(e);
-        setChartState({ state: APIError.fetchError(e) });
+
+          const finalPasswd: CurrentPasswd = {
+            ...initialPasswd,
+            ...(updatedPh ? { ph: updatedPh } : {}),
+          };
+          const chart = new ChartEditing(await validateChart(chartRes), {
+            luaExecutorRef,
+            locale,
+            cid,
+            currentPasswd: finalPasswd,
+            convertedFrom: chartRes.ver,
+          });
+          return {
+            chart,
+            state: "ok" as const,
+          };
+        })
+        .catch((e: unknown) => ({ state: captureAndWrap(e, { cid }) }));
+
+      if (result.state === "ok") {
+        onLoadRef.current(cid);
       }
+      setChartState(result);
     },
     [locale]
   );
@@ -236,33 +243,39 @@ export function useChartState(props: Props) {
   const remoteSave = useCallback<() => Promise<void>>(async () => {
     if (chartState.state === "ok") {
       const onSave = async (cid: string) => {
-        const currentPasswd = chartState.chart.currentPasswd;
-        if (chartState.chart.changePasswd) {
-          currentPasswd.p = chartState.chart.changePasswd;
-        }
+        let currentPasswd = {
+          ...chartState.chart.currentPasswd,
+          ...(chartState.chart.changePasswd
+            ? { p: chartState.chart.changePasswd }
+            : {}),
+        };
         if (savePasswd) {
           if (currentPasswd.p) {
-            fetch(
-              process.env.BACKEND_PREFIX + `/api/hashPasswd/${cid}`,
-              {
-                headers: {
-                  Authorization: basicAuthorization(currentPasswd.p),
-                },
+            const updatedPh = await fetchBackend()
+              .url(`/api/hashPasswd/${cid}`)
+              .options({
                 credentials:
                   process.env.NODE_ENV === "development"
                     ? "include"
                     : "same-origin",
-              }
-            ).then(
-              async (res) => {
-                if (res.ok) {
-                  const ph = await res.text();
-                  setPasswd(cid, ph);
-                  currentPasswd.ph = ph;
-                }
-              },
-              () => undefined
-            );
+              })
+              .auth(basicAuthorization(currentPasswd.p))
+              .get()
+              .unauthorized(() => undefined)
+              .notFound(() => undefined)
+              .text()
+              .catch((e: unknown) => {
+                Sentry.captureException(e);
+                console.error(e);
+                return undefined; // ignore error and continue
+              });
+            if (updatedPh) {
+              setPasswd(cid, updatedPh);
+              currentPasswd = {
+                ...currentPasswd,
+                ph: updatedPh,
+              };
+            }
           }
         } else {
           unsetPasswd(cid);
@@ -272,85 +285,56 @@ export function useChartState(props: Props) {
 
       setSaveState("saving");
       if (chartState.chart.cid === undefined) {
-        try {
-          const res = await fetch(
-            process.env.BACKEND_PREFIX + `/api/newChartFile`,
-            {
-              method: "POST",
-              body: msgpack.encode(chartState.chart.toObject()),
-              cache: "no-store",
-              credentials:
-                process.env.NODE_ENV === "development"
-                  ? "include"
-                  : "same-origin",
-            }
-          );
-          if (res.ok) {
-            try {
-              const resBody = v.parse(
-                v.object({ cid: v.string() }),
-                await res.json()
-              );
-              onLoadRef.current(resBody.cid);
-              onSave(resBody.cid);
-              setSaveState("ok");
-              return;
-            } catch (e) {
-              setSaveState(APIError.badResponse(e));
-            }
-            return;
-          } else {
-            setSaveState(await APIError.fromRes(res));
-            return;
-          }
-        } catch (e) {
-          console.error(e);
-          setSaveState(APIError.fetchError(e));
-          return;
-        }
+        await fetchBackend()
+          .url(`/api/newChartFile`)
+          .body(msgpack.encode(chartState.chart.toObject()))
+          .options({
+            cache: "no-store",
+            credentials:
+              process.env.NODE_ENV === "development"
+                ? "include"
+                : "same-origin",
+          })
+          .post()
+          .notFound(markAsExpected)
+          .error(409, markAsExpected)
+          .error(413, markAsExpected)
+          .error(429, markAsExpected)
+          .json(async (res) => {
+            const resBody = v.parse(v.object({ cid: v.string() }), res);
+            onLoadRef.current(resBody.cid);
+            await onSave(resBody.cid);
+            return "ok" as const;
+          })
+          .catch((e: unknown) => captureAndWrap(e))
+          .then((result) => setSaveState(result));
       } else {
-        const authorization = chartAuthorization(chartState.chart.currentPasswd);
-        try {
-          for (let retry = 0; ; retry++) {
-            const res = await fetch(
-              process.env.BACKEND_PREFIX + `/api/chartFile/${chartState.chart.cid}`,
-              {
-                method: "POST",
-                body: msgpack.encode(chartState.chart.toObject()),
-                cache: "no-store",
-                credentials:
-                  process.env.NODE_ENV === "development"
-                    ? "include"
-                    : "same-origin",
-                headers: authorization
-                  ? { Authorization: authorization }
-                  : undefined,
-              }
-            );
-            if (res.ok) {
-              onSave(chartState.chart.cid);
-              setSaveState("ok");
-              return;
-            } else {
-              if (res.status === 429 && retry < 3) {
-                await new Promise((r) =>
-                  setTimeout(
-                    r,
-                    Number(res?.headers.get("Retry-After")) * 1000 + 500
-                  )
-                );
-                continue;
-              }
-              setSaveState(await APIError.fromRes(res));
-              return;
-            }
-            break;
-          }
-        } catch (e) {
-          console.error(e);
-          setSaveState(APIError.fetchError(e));
-          return;
-        }
+        await fetchBackend()
+          .url(`/api/chartFile/${chartState.chart.cid}`)
+          .body(msgpack.encode(chartState.chart.toObject()))
+          .options({
+            cache: "no-store",
+            credentials:
+              process.env.NODE_ENV === "development"
+                ? "include"
+                : "same-origin",
+          })
+          .auth(chartAuthorization(chartState.chart.currentPasswd) ?? "")
+          .middlewares([chartFileRetryMiddleware()])
+          .post()
+          .unauthorized(markAsExpected)
+          .notFound(markAsExpected)
+          .error(409, markAsExpected)
+          .error(413, markAsExpected)
+          .error(429, markAsExpected)
+          .res(async () => {
+            await onSave(chartState.chart.cid!);
+            return "ok" as const;
+          })
+          .catch((e: unknown) =>
+            captureAndWrap(e, { cid: chartState.chart.cid })
+          )
+          .then((result) => setSaveState(result));
       }
     } else {
       throw new Error("chart is empty");
@@ -372,47 +356,27 @@ export function useChartState(props: Props) {
         }
       }
 
-      const q = new URLSearchParams(
-        Object.entries(chartState.chart.currentPasswd).filter(([, v]) => v)
-      );
-      try {
-        for (let retry = 0; ; retry++) {
-          const res = await fetch(
-            process.env.BACKEND_PREFIX +
-              `/api/chartFile/${chartState.chart.cid}?` +
-              q.toString(),
-            {
-              method: "DELETE",
-              cache: "no-store",
-              credentials:
-                process.env.NODE_ENV === "development"
-                  ? "include"
-                  : "same-origin",
-            }
-          );
-          if (res.ok) {
-            if (isStandalone() || isInsideFrame()) {
-              history.back();
-            } else {
-              window.close();
-            }
+      await fetchBackend()
+        .url(`/api/chartFile/${chartState.chart.cid}`)
+        .options({
+          cache: "no-store",
+          credentials:
+            process.env.NODE_ENV === "development" ? "include" : "same-origin",
+        })
+        .auth(chartAuthorization(chartState.chart.currentPasswd) ?? "")
+        .middlewares([chartFileRetryMiddleware()])
+        .delete()
+        .unauthorized(() => undefined)
+        .notFound(() => undefined)
+        .error(429, () => undefined)
+        .res(() => {
+          if (isStandalone() || isInsideFrame()) {
+            history.back();
           } else {
-            if (res.status === 429 && retry < 3) {
-              await new Promise((r) =>
-                setTimeout(
-                  r,
-                  Number(res?.headers.get("Retry-After")) * 1000 + 500
-                )
-              );
-              continue;
-            }
+            window.close();
           }
-          break;
-        }
-      } catch (e) {
-        console.error(e);
-        Sentry.captureException(e);
-      }
+        });
+      // TODO: エラーの場合ユーザーにエラーメッセージを表示する?
     } else {
       throw new Error("chart is empty");
     }

--- a/frontend/app/[locale]/edit/metaTab.tsx
+++ b/frontend/app/[locale]/edit/metaTab.tsx
@@ -16,7 +16,7 @@ import { isStandalone } from "@/common/pwaInstall";
 import { useRouter } from "next/navigation";
 import { isInsideFrame, useDisplayMode } from "@/scale.js";
 import { LocalLoadError, LocalLoadState, SaveState } from "./chartState";
-import { APIError } from "@/common/apiError";
+import { formatError } from "@/common/fetch";
 
 interface Props {
   chart?: ChartEditing;
@@ -192,8 +192,8 @@ export function MetaTab(props: Props2) {
         <span className="inline-block ml-1 ">
           {props.saveState === "ok"
             ? t("saveDone")
-            : props.saveState instanceof APIError
-              ? props.saveState.format(te)
+            : props.saveState instanceof Error
+              ? formatError(props.saveState, te)
               : !props.chart?.meta.ytId
                 ? t("saveFail.noId")
                 : !props.chart?.cid && !props.chart?.changePasswd

--- a/frontend/app/[locale]/edit/passwdPrompt.tsx
+++ b/frontend/app/[locale]/edit/passwdPrompt.tsx
@@ -7,7 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import { FetchChartOptions, LoadState } from "./chartState";
 import { SlimeSVG } from "@/common/slime";
 import { rateLimit } from "@falling-nikochan/chart";
-import { APIError, FETCH_ERROR_STATUS } from "@/common/apiError";
+import {
+  APIError,
+  FETCH_ERROR_STATUS,
+  shouldHideStatus,
+} from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
 import {
   historyBackWithReview,
@@ -55,7 +59,7 @@ export function PasswdPrompt(props: PasswdProps) {
     return (
       <>
         {props.loadStatus instanceof APIError &&
-          props.loadStatus.status !== FETCH_ERROR_STATUS && (
+          !shouldHideStatus(props.loadStatus.status) && (
             <h4 className="fn-heading-box">Error {props.loadStatus.status}</h4>
           )}
         <p className="mb-3">{formatErrorMsg(props.loadStatus, te)}</p>

--- a/frontend/app/[locale]/edit/passwdPrompt.tsx
+++ b/frontend/app/[locale]/edit/passwdPrompt.tsx
@@ -7,11 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { FetchChartOptions, LoadState } from "./chartState";
 import { SlimeSVG } from "@/common/slime";
 import { rateLimit } from "@falling-nikochan/chart";
-import {
-  APIError,
-  FETCH_ERROR_STATUS,
-  shouldHideStatus,
-} from "@/common/apiError";
+import { APIError, shouldHideStatus } from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
 import {
   historyBackWithReview,

--- a/frontend/app/[locale]/edit/passwdPrompt.tsx
+++ b/frontend/app/[locale]/edit/passwdPrompt.tsx
@@ -7,13 +7,14 @@ import { useEffect, useRef, useState } from "react";
 import { FetchChartOptions, LoadState } from "./chartState";
 import { SlimeSVG } from "@/common/slime";
 import { rateLimit } from "@falling-nikochan/chart";
-import { APIError } from "@/common/apiError";
+import { APIError, FETCH_ERROR_STATUS } from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
 import {
   historyBackWithReview,
   useStandaloneDetector,
 } from "@/common/pwaInstall";
 import { useInsideFrameDetector } from "@/scale";
+import { formatErrorMsg, isExpectedError } from "@/common/fetch";
 
 interface PasswdProps {
   loadStatus: LoadState;
@@ -50,14 +51,15 @@ export function PasswdPrompt(props: PasswdProps) {
         Loading...
       </p>
     );
-  } else if (props.loadStatus instanceof APIError) {
+  } else if (props.loadStatus instanceof Error) {
     return (
       <>
-        {props.loadStatus.status && (
-          <h4 className="fn-heading-box">Error {props.loadStatus.status}</h4>
-        )}
-        <p className="mb-3">{props.loadStatus.formatMsg(te)}</p>
-        {props.loadStatus.isServerSide() && <LinksOnError />}
+        {props.loadStatus instanceof APIError &&
+          props.loadStatus.status !== FETCH_ERROR_STATUS && (
+            <h4 className="fn-heading-box">Error {props.loadStatus.status}</h4>
+          )}
+        <p className="mb-3">{formatErrorMsg(props.loadStatus, te)}</p>
+        {!isExpectedError(props.loadStatus) && <LinksOnError />}
         {(standalone || insideFrame) && (
           <p>
             <Button text={t("back")} onClick={historyBackWithReview} />

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -213,25 +213,25 @@ export function ChartList(props: Props) {
         if (b !== null && !b.fetched && !b.fetching) {
           b.fetching = true;
           changed = true;
-          fetchBrief(b.cid).then(({ brief, is404 }) => {
-            setBriefs((briefs) => {
-              if (
-                Array.isArray(briefs) &&
-                briefs[i] !== null &&
-                briefs[i]!.cid === b.cid
-              ) {
-                if (is404) {
-                  briefs[i] = null;
-                } else {
+          fetchBrief(b.cid, {
+            onResult: (brief) =>
+              setBriefs((briefs) => {
+                if (Array.isArray(briefs) && briefs.at(i)?.cid === b.cid) {
+                  briefs = briefs.slice();
                   briefs[i]!.fetched = true;
                   briefs[i]!.brief = brief;
                 }
-                return briefs.slice();
-              } else {
-                // そんなことあるのか...?
                 return briefs;
-              }
-            });
+              }),
+            onNotFound: () =>
+              setBriefs((briefs) => {
+                if (Array.isArray(briefs) && briefs.at(i)?.cid === b.cid) {
+                  briefs = briefs.slice();
+                  briefs[i] = null;
+                }
+                return briefs;
+              }),
+            onError: (e) => setBriefs(e),
           });
         }
       }

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -17,8 +17,9 @@ import { fetchBrief } from "@/common/briefCache.js";
 import { useResizeDetector } from "react-resize-detector";
 import { useDisplayMode, useInsideFrameDetector } from "@/scale.jsx";
 import { ButtonHighlight } from "@/common/button.jsx";
-import { APIError } from "@/common/apiError.js";
 import { Scrollable } from "@/common/scrollable.js";
+import { captureAndWrap, fetchBackend, formatError } from "@/common/fetch.js";
+import * as v from "valibot";
 
 interface PProps {
   locale: string;
@@ -83,7 +84,7 @@ export interface ChartLineBrief {
 interface Props {
   classNameOuter?: string;
   type?: ChartListType;
-  briefs?: ChartLineBrief[] | APIError | undefined;
+  briefs?: ChartLineBrief[] | Error | undefined;
   fetchAll?: boolean;
   fixedRows?: number; // 表示数を固定する
   containerHeight?: number;
@@ -108,9 +109,9 @@ export function ChartList(props: Props) {
 
   // props.briefs が初期値 (prerenderされたsample譜面リストなどの場合はすでにfetch済みのbriefを渡し、そうでない場合はChartList内でfetchする)
   const [briefs, setBriefs] = useState<
-    (ChartLineBrief | null)[] | APIError | undefined
+    (ChartLineBrief | null)[] | Error | undefined
   >(props.briefs || undefined);
-  const prevPropBriefs = useRef<ChartLineBrief[] | APIError | undefined>(
+  const prevPropBriefs = useRef<ChartLineBrief[] | Error | undefined>(
     props.briefs
   );
   useEffect(() => {
@@ -138,23 +139,17 @@ export function ChartList(props: Props) {
         break;
       case "latest":
       case "popular":
-        void (async () => {
-          try {
-            const latestRes = await fetch(
-              process.env.BACKEND_PREFIX + `/api/${props.type}`,
-              { cache: "default" }
-            );
-            if (latestRes.ok) {
-              const latestCId = (await latestRes.json()) as { cid: string }[];
-              setBriefs(latestCId.map(({ cid }) => ({ cid, fetched: false })));
-            } else {
-              setBriefs(await APIError.fromRes(latestRes));
-            }
-          } catch (e) {
-            console.error(e);
-            setBriefs(APIError.fetchError(e));
-          }
-        })();
+        fetchBackend()
+          .url(`/api/${props.type}`)
+          .options({ cache: "default" })
+          .get()
+          .json((latest) =>
+            v
+              .parse(v.array(v.object({ cid: v.string() })), latest)
+              .map(({ cid }) => ({ cid, fetched: false }))
+          )
+          .catch((e: unknown) => captureAndWrap(e, { type: props.type }))
+          .then((latest) => setBriefs(latest));
     }
   }, [props.type]);
 
@@ -268,7 +263,7 @@ export function ChartList(props: Props) {
     }
   }, [briefs, props.type]);
 
-  const filteredBriefs: ChartLineBrief[] | APIError | undefined = Array.isArray(
+  const filteredBriefs: ChartLineBrief[] | Error | undefined = Array.isArray(
     briefs
   )
     ? fetchAll
@@ -438,7 +433,7 @@ export function ChartList(props: Props) {
           Loading...
         </div>
       ) : briefs && "message" in briefs ? (
-        <div className="fn-cl-message">{briefs.format(te)}</div>
+        <div className="fn-cl-message">{formatError(briefs, te)}</div>
       ) : Array.isArray(briefs) && briefs.length === 0 ? (
         <div className="fn-cl-message">
           {props.search ? t("notFound") : t("empty")}

--- a/frontend/app/[locale]/main/edit/clientPage.tsx
+++ b/frontend/app/[locale]/main/edit/clientPage.tsx
@@ -14,8 +14,9 @@ import { isStandalone, useSafariDetector } from "@/common/pwaInstall.js";
 import { useRouter } from "next/navigation";
 import Youtube from "@icon-park/react/lib/icons/Youtube.js";
 import Caution from "@icon-park/react/lib/icons/Caution.js";
-import { APIError } from "@/common/apiError.js";
 import { isInsideFrame } from "@/scale.jsx";
+import { captureAndWrap, fetchBackend, formatError } from "@/common/fetch.js";
+import { markAsExpected } from "@/common/apiError.js";
 
 export default function EditTab({ locale }: { locale: string }) {
   const t = useTranslations("main.edit");
@@ -24,38 +25,34 @@ export default function EditTab({ locale }: { locale: string }) {
 
   const isSafari = useSafariDetector();
 
-  const [cidErrorMsg, setCIdErrorMsg] = useState<APIError>();
+  const [cidErrorMsg, setCIdErrorMsg] = useState<Error>();
   const [cidFetching, setCidFetching] = useState<boolean>(false);
   const [inputCId, setInputCId] = useState<string>("");
   const gotoCId = async (cid: string) => {
     setCIdErrorMsg(undefined);
     setCidFetching(true);
-    try {
-      const res = await fetch(
-        process.env.BACKEND_PREFIX + `/api/brief/${cid}`,
-        {
-          cache: "no-store",
-        }
-      );
-      setCidFetching(false);
-      if (res.ok) {
+    await fetchBackend()
+      .url(`/api/brief/${cid}`)
+      .options({
+        cache: "no-store",
+      })
+      .get()
+      .notFound(markAsExpected)
+      .res(() => {
         if (isStandalone() || isInsideFrame()) {
           router.push(`/${locale}/edit?cid=${cid}`);
         } else {
           window.open(`/${locale}/edit?cid=${cid}`, "_blank")?.focus(); // これで新しいタブが開かない場合がある
         }
+        setCidFetching(false);
         setCIdErrorMsg(undefined);
         setInputCId(cid);
-      } else {
-        setCIdErrorMsg(await APIError.fromRes(res));
+      })
+      .catch((e: unknown) => {
+        setCidFetching(false);
+        setCIdErrorMsg(captureAndWrap(e));
         setInputCId("");
-      }
-    } catch (e) {
-      console.error(e);
-      setCidFetching(false);
-      setCIdErrorMsg(APIError.fetchError(e));
-      setInputCId("");
-    }
+      });
   };
 
   return (
@@ -107,7 +104,11 @@ export default function EditTab({ locale }: { locale: string }) {
             <SlimeSVG />
             Loading...
           </span>
-          <span className="ml-1 inline-block">{cidErrorMsg?.format(te)}</span>
+          {cidErrorMsg instanceof Error && (
+            <span className="ml-1 inline-block">
+              {formatError(cidErrorMsg, te)}
+            </span>
+          )}
         </h3>
         <p>{t("inputIdDesc")}</p>
       </section>

--- a/frontend/app/[locale]/main/play/clientPage.tsx
+++ b/frontend/app/[locale]/main/play/clientPage.tsx
@@ -22,11 +22,12 @@ import { useSharePageModal } from "@/common/sharePageModal.jsx";
 import { useResizeDetector } from "react-resize-detector";
 import { useDisplayMode } from "@/scale.jsx";
 import { XLogo } from "@/common/x.jsx";
-import { APIError } from "@/common/apiError.js";
 import { useRouter, useSearchParams } from "next/navigation.js";
 import { ButtonHighlight } from "@/common/button.js";
 import { Range2 } from "@/common/range.js";
 import Search from "@icon-park/react/lib/icons/Search";
+import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
+import * as v from "valibot";
 
 interface Props {
   locale: string;
@@ -119,7 +120,7 @@ function PlayTabInternal(
 
   const abortSearching = useRef<AbortController | null>(null);
   const [searchResult, setSearchResult] = useState<
-    ChartLineBrief[] | APIError | undefined
+    ChartLineBrief[] | Error | undefined
   >();
 
   useLayoutEffect(() => {
@@ -132,12 +133,12 @@ function PlayTabInternal(
     }
     setWaitingDebounce(false);
     setSearchResult(undefined);
-    const apiParams = new URLSearchParams({
+    const apiParams = {
       q: params.search,
       sort: params.sort,
       difficultyMin: String(params.minLv),
       difficultyMax: String(params.maxLv),
-    });
+    };
     if (!params.search) {
       document.title = titleWithSiteName(t("title"));
     } else {
@@ -146,27 +147,35 @@ function PlayTabInternal(
       );
     }
     abortSearching.current = new AbortController();
-    fetch(process.env.BACKEND_PREFIX + `/api/search?${apiParams.toString()}`, {
-      signal: abortSearching.current.signal,
-    })
-      .then(async (res) => {
-        if (res.ok) {
-          setSearchResult(
-            (await res.json()).map(
-              (r: { cid: string; updatedAt?: number }) => ({
-                cid: r.cid,
-                updatedAt: r.updatedAt,
-                fetched: false,
+    fetchBackend()
+      .url(`/api/search`)
+      .query(apiParams)
+      .signal(abortSearching.current)
+      .get()
+      .onAbort(() => undefined) // ignore.
+      .json((res) =>
+        v
+          .parse(
+            v.array(
+              v.object({
+                cid: v.string(),
+                count: v.optional(v.number()),
+                updatedAt: v.optional(v.number()),
               })
-            )
-          );
-        } else {
-          setSearchResult(await APIError.fromRes(res));
+            ),
+            res
+          )
+          .map((r) => ({
+            cid: r.cid,
+            updatedAt: r.updatedAt,
+            fetched: false,
+          }))
+      )
+      .catch((e: unknown) => captureAndWrap(e))
+      .then((res) => {
+        if (res !== undefined) {
+          setSearchResult(res);
         }
-      })
-      .catch((e) => {
-        console.error(e);
-        setSearchResult(APIError.fetchError(e));
       });
   }, [t, params.search, params.sort, params.maxLv, params.minLv]);
 

--- a/frontend/app/[locale]/main/policies/ossLicensesList.tsx
+++ b/frontend/app/[locale]/main/policies/ossLicensesList.tsx
@@ -9,6 +9,7 @@ import RightOne from "@icon-park/react/lib/icons/RightOne.js";
 import Close from "@icon-park/react/lib/icons/Close";
 import { ExternalLink } from "@/common/extLink";
 import { LicenseEntry, normalizeRepositoryURL } from "next-license-list";
+import { fetchAsset } from "@/common/fetch";
 
 export function OSSLicensesList({
   frontendLicenses,
@@ -22,14 +23,13 @@ export function OSSLicensesList({
   );
   useEffect(() => {
     if (workerLicenses === null) {
-      fetch(process.env.ASSET_PREFIX + "/oss-licenses/worker.json")
-        .then((res) => res.json())
-        .then((data) =>
+      fetchAsset()
+        .get("/oss-licenses/worker.json")
+        .json((data) =>
           setWorkerLicenses(
             (data as LicenseEntry[]).map((e) => normalizeRepositoryURL(e))
           )
-        )
-        .catch(() => []);
+        );
     }
   }, [workerLicenses]);
   const licenses: LicenseEntry[] = Array.isArray(frontendLicenses)

--- a/frontend/app/[locale]/main/shareInternal/clientPage.tsx
+++ b/frontend/app/[locale]/main/shareInternal/clientPage.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { IndexMain } from "../main.js";
-import { ChartBrief, RecordGetSummary } from "@falling-nikochan/chart";
+import {
+  ChartBrief,
+  RecordGetSummary,
+  RecordGetSummarySchema,
+} from "@falling-nikochan/chart";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { titleShare } from "@/common/title.js";
 import { ShareBox } from "@/share/placeholder/shareBox.jsx";
 import { fetchBrief } from "@/common/briefCache.js";
-import { APIError } from "@/common/apiError.js";
+import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
+import * as v from "valibot";
 
 export default function ShareInternal({ locale }: { locale: string }) {
   const t = useTranslations("share");
@@ -15,9 +20,7 @@ export default function ShareInternal({ locale }: { locale: string }) {
   const [cid, setCId] = useState<string | null>(null);
   const [brief, setBrief] = useState<ChartBrief | null>(null);
   const [fromPlay, setFromPlay] = useState<boolean | null>(null);
-  const [record, setRecord] = useState<RecordGetSummary[] | APIError | null>(
-    null
-  );
+  const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(null);
   const [sessionError, setSessionError] = useState<boolean>(false);
   useEffect(() => {
     const param = new URLSearchParams(window.location.search);
@@ -34,25 +37,11 @@ export default function ShareInternal({ locale }: { locale: string }) {
         }
       });
       setRecord(null);
-      (async () => {
-        try {
-          const res = await fetch(
-            process.env.BACKEND_PREFIX + `/api/record/${cid}`
-          );
-          if (res.ok) {
-            try {
-              setRecord(await res.json());
-            } catch (e) {
-              console.error(e);
-              setRecord(APIError.badResponse(e));
-            }
-          } else {
-            setRecord(await APIError.fromRes(res));
-          }
-        } catch (e) {
-          setRecord(APIError.fetchError(e));
-        }
-      })();
+      fetchBackend()
+        .get(`/api/record/${cid}`)
+        .json((record) => v.parse(v.array(RecordGetSummarySchema()), record))
+        .catch((e: unknown) => captureAndWrap(e, { cid }))
+        .then((record) => setRecord(record));
     } else {
       setSessionError(true);
     }

--- a/frontend/app/[locale]/main/shareInternal/clientPage.tsx
+++ b/frontend/app/[locale]/main/shareInternal/clientPage.tsx
@@ -30,11 +30,11 @@ export default function ShareInternal({ locale }: { locale: string }) {
       setCId(cid);
       setFromPlay(fromPlay);
       document.title = titleShare(t, cid);
-      fetchBrief(cid).then((res) => {
-        if (res.ok) {
-          setBrief(res.brief!);
-          document.title = titleShare(t, cid, res.brief!);
-        }
+      fetchBrief(cid, {
+        onResult: (brief) => {
+          setBrief(brief);
+          document.title = titleShare(t, cid, brief);
+        },
       });
       setRecord(null);
       fetchBackend()

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -97,7 +97,7 @@ export function InitPlay({ locale }: { locale: string }) {
       if (q.cid) {
         setCid(q.cid);
         setLvIndex(q.lvIndex);
-        void (async () => setChartBrief((await fetchBrief(q.cid!)).brief))();
+        fetchBrief(q.cid!, { onResult: (brief) => setChartBrief(brief) });
         setEditing(false);
       } else {
         setErrorMsg(te("noSession"));

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -28,6 +28,7 @@ import {
   loadChart,
   ChartSeqData,
   Level15Play,
+  RecordGetSummarySchema,
 } from "@falling-nikochan/chart";
 import { YouTubePlayer } from "@/common/youtube.js";
 import { ChainDisp, ScoreDisp } from "./score.js";
@@ -64,8 +65,10 @@ import { useRealFPS } from "@/common/fpsCalculator.jsx";
 import { IrasutoyaLikeGrass } from "@/common/irasutoyaLike.jsx";
 import { getQueryOptions, QueryOptions } from "./queryOption.js";
 import { ButtonHighlight } from "@/common/button.jsx";
-import { APIError } from "@/common/apiError.js";
 import { useFlash } from "./useFlash.js";
+import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
+import * as v from "valibot";
+import { markAsExpected } from "@/common/apiError.js";
 
 export function InitPlay({ locale }: { locale: string }) {
   const te = useTranslations("error");
@@ -78,7 +81,7 @@ export function InitPlay({ locale }: { locale: string }) {
   const [chartSeq, setChartSeq] = useState<ChartSeqData>();
   const [editing, setEditing] = useState<boolean>(false);
 
-  const [errorMsg, setErrorMsg] = useState<string | APIError>();
+  const [errorMsg, setErrorMsg] = useState<string | Error>();
   useEffect(() => {
     const q = getQueryOptions();
     setQueryOptions(q);
@@ -110,54 +113,38 @@ export function InitPlay({ locale }: { locale: string }) {
       setChartSeq(loadChart(session.level));
       setErrorMsg(undefined);
     } else {
-      void (async () => {
-        try {
-          const res = await fetch(
-            process.env.BACKEND_PREFIX +
-              `/api/playFile/${session?.cid ?? q.cid}` +
-              `/${session?.lvIndex ?? q.lvIndex}`,
-            { cache: "no-store" }
-          );
-          if (res.ok) {
-            try {
-              currentChartVer satisfies 16; // update the code below when chart version is bumped
-              const seq = msgpack.decode(await res.arrayBuffer()) as
-                | Level6Play
-                | Level15Play;
-              console.log("seq.ver", seq.ver);
-              if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
-                switch (seq.ver) {
-                  case 6:
-                  case 15:
-                  case 16:
-                    setChartSeq(loadChart(seq));
-                    break;
-                  default:
-                    seq satisfies never;
-                }
-                setErrorMsg(undefined);
-                addRecent("play", session?.cid ?? q.cid ?? "");
-                updatePlayCountForReview();
-              } else {
-                // seq satisfies never;
-                setChartSeq(undefined);
-                setErrorMsg(te("chartVersion", { ver: (seq as any)?.ver }));
-              }
-            } catch (e) {
-              setChartSeq(undefined);
-              console.error(e);
-              setErrorMsg(APIError.badResponse(e));
-            }
+      const cid = session?.cid ?? q.cid;
+      const lvIndex = session?.lvIndex ?? q.lvIndex;
+      fetchBackend()
+        .url(`/api/playFile/${cid}/${lvIndex}`)
+        .options({ cache: "no-store" })
+        .get()
+        .badRequest(markAsExpected)
+        .notFound(markAsExpected)
+        .arrayBuffer((buf) => {
+          currentChartVer satisfies 16; // update the code below when chart version is bumped
+          const seq = msgpack.decode(buf) as Level6Play | Level15Play;
+          console.log("seq.ver", seq.ver);
+          if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
+            addRecent("play", cid ?? "");
+            updatePlayCountForReview();
+            return { seq: loadChart(seq), error: undefined };
           } else {
-            setChartSeq(undefined);
-            setErrorMsg(await APIError.fromRes(res));
+            // seq satisfies never;
+            return {
+              seq: undefined,
+              error: te("chartVersion", { ver: (seq as any)?.ver }),
+            };
           }
-        } catch (e) {
-          setChartSeq(undefined);
-          console.error(e);
-          setErrorMsg(APIError.fetchError(e));
-        }
-      })();
+        })
+        .catch((e: unknown) => ({
+          seq: undefined,
+          error: captureAndWrap(e, { cid, lvIndex }),
+        }))
+        .then(({ seq, error }) => {
+          setChartSeq(seq);
+          setErrorMsg(error);
+        });
     }
   }, [te]);
 
@@ -176,7 +163,7 @@ export function InitPlay({ locale }: { locale: string }) {
 }
 
 interface Props {
-  apiErrorMsg?: string | APIError;
+  apiErrorMsg?: string | Error;
   cid?: string;
   lvIndex: number;
   chartBrief?: ChartBrief;
@@ -198,9 +185,7 @@ function Play(props: Props) {
   const te = useTranslations("error");
   const t = useTranslations("play");
 
-  const [record, setRecord] = useState<
-    RecordGetSummary | APIError | undefined
-  >(); // for showing in the result dialog
+  const [record, setRecord] = useState<RecordGetSummary | Error | undefined>(); // for showing in the result dialog
 
   const [initAnim, setInitAnim] = useState<boolean>(false);
   useEffect(() => {
@@ -541,7 +526,7 @@ function Play(props: Props) {
   const [ytReady, setYtReady] = useState<boolean>(false);
   const [ytError, setYtError] = useState<number | null>(null);
   const [initDone, setInitDone] = useState<boolean>(false);
-  const [errorMsg, setErrorMsg] = useState<string | APIError>();
+  const [errorMsg, setErrorMsg] = useState<string | Error>();
   const [showLoading, setShowLoading] = useState<boolean>(false);
   const showLoadingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [giveUpWaitingFps, setGiveUpWaitingFps] = useState<boolean>(false);
@@ -659,30 +644,15 @@ function Play(props: Props) {
             });
             reloadBestScore();
           }
-          (async () => {
-            try {
-              const res = await fetch(
-                process.env.BACKEND_PREFIX + `/api/record/${cid}`
-              );
-              if (res.ok) {
-                try {
-                  const records: RecordGetSummary[] = await res.json();
-                  setRecord(
-                    records.find(
-                      (r) => r.lvHash === chartBrief!.levels[lvIndex]?.hash
-                    )
-                  );
-                } catch (e) {
-                  console.error(e);
-                  setRecord(APIError.badResponse(e));
-                }
-              } else {
-                setRecord(await APIError.fromRes(res));
-              }
-            } catch (e) {
-              setRecord(APIError.fetchError(e));
-            }
-          })();
+          fetchBackend()
+            .get(`/api/record/${cid}`)
+            .json((record) =>
+              v
+                .parse(v.array(RecordGetSummarySchema()), record)
+                .find((r) => r.lvHash === chartBrief!.levels[lvIndex]?.hash)
+            )
+            .catch((e: unknown) => captureAndWrap(e, { cid }))
+            .then((record) => setRecord(record));
         }
         const t = setTimeout(() => {
           setShowResult(true);
@@ -697,10 +667,9 @@ function Play(props: Props) {
                 chartBrief.levels[lvIndex].hash,
                 auto
               );
-              fetch(process.env.BACKEND_PREFIX + `/api/record/${cid}`, {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
+              fetchBackend()
+                .url(`/api/record/${cid}`)
+                .json({
                   lvHash: chartBrief.levels[lvIndex].hash,
                   auto,
                   score,
@@ -711,8 +680,12 @@ function Play(props: Props) {
                   fb: bigScore === bigScoreRate,
                   editing,
                   factor,
-                } satisfies RecordPost),
-              }).catch(() => undefined);
+                } satisfies RecordPost)
+                .post()
+                .notFound(() => undefined)
+                .error(429, () => undefined)
+                .res()
+                .catch((e: unknown) => captureAndWrap(e, { cid }));
             } catch {
               // ignore errors from updateRecordFactor
             }

--- a/frontend/app/[locale]/play/fallingWindow.tsx
+++ b/frontend/app/[locale]/play/fallingWindow.tsx
@@ -16,6 +16,7 @@ import { useDisplayMode } from "@/scale.js";
 import { useRealFPS } from "@/common/fpsCalculator";
 import { DisplayNikochan } from "./displayNikochan";
 import { OffsetEstimator } from "./offsetEstimator";
+import { fetchAsset } from "@/common/fetch";
 
 type Props = {
   className?: string;
@@ -207,13 +208,9 @@ export default function FallingWindow(props: Props) {
   useEffect(() => {
     Promise.all(
       [0, 1, 2, 3].map(async (i) => {
-        // TODO: エラーハンドリング
-        const res = await fetch(
-          process.env.ASSET_PREFIX +
-            `/assets/nikochan${i}.svg` +
-            process.env.ASSET_QUERY_NIKOCHAN
-        );
-        const svg = await res.text();
+        const svg = await fetchAsset()
+          .get(`/assets/nikochan${i}.svg` + process.env.ASSET_QUERY_NIKOCHAN)
+          .text();
         // chromeではcreateImageBitmap()でsvgをきれいにresizeできるが、
         // firefoxではbitmap化してから拡大縮小するようなので、svg自体をリサイズしてからbitmap化する必要がある
         const svgResized = svg
@@ -373,10 +370,9 @@ export default function FallingWindow(props: Props) {
     Promise.all(
       Array.from(new Array(13)).map((_, i) =>
         [4, 6, 8, 10, 12].includes(i)
-          ? // TODO: エラーハンドリング
-            fetch(process.env.ASSET_PREFIX + `/assets/particle${i}.svg`)
-              .then((res) => res.text())
-              .then((text) => `data:image/svg+xml;base64,${btoa(text)}`)
+          ? fetchAsset()
+              .get(`/assets/particle${i}.svg`)
+              .text((text) => `data:image/svg+xml;base64,${btoa(text)}`)
           : ""
       )
     ).then((urls) => {

--- a/frontend/app/[locale]/play/messageBox.tsx
+++ b/frontend/app/[locale]/play/messageBox.tsx
@@ -25,7 +25,11 @@ import DropDown from "@/common/dropdown";
 import DownOne from "@icon-park/react/lib/icons/DownOne";
 import { Scrollable } from "@/common/scrollable";
 import { HelpIcon } from "@/common/caption";
-import { APIError, FETCH_ERROR_STATUS } from "@/common/apiError";
+import {
+  APIError,
+  FETCH_ERROR_STATUS,
+  shouldHideStatus,
+} from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
 import { formatErrorMsg, isExpectedError } from "@/common/fetch";
 
@@ -479,7 +483,7 @@ export function InitErrorMessage(props: MessageProps3) {
       onPointerDown={(e) => e.stopPropagation()}
       onPointerUp={(e) => e.stopPropagation()}
     >
-      {status && status !== FETCH_ERROR_STATUS && (
+      {status && !shouldHideStatus(status) && (
         <h4 className="fn-heading-box">Error {status}</h4>
       )}
       <p className="mb-3">{message}</p>

--- a/frontend/app/[locale]/play/messageBox.tsx
+++ b/frontend/app/[locale]/play/messageBox.tsx
@@ -25,8 +25,9 @@ import DropDown from "@/common/dropdown";
 import DownOne from "@icon-park/react/lib/icons/DownOne";
 import { Scrollable } from "@/common/scrollable";
 import { HelpIcon } from "@/common/caption";
-import { APIError } from "@/common/apiError";
+import { APIError, FETCH_ERROR_STATUS } from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
+import { formatErrorMsg, isExpectedError } from "@/common/fetch";
 
 interface MessageProps {
   className?: string;
@@ -462,7 +463,7 @@ interface MessageProps3 {
   className?: string;
   isTouch: boolean;
   exit: () => void;
-  msg: string | APIError;
+  msg: string | Error;
 }
 export function InitErrorMessage(props: MessageProps3) {
   const t = useTranslations("play.message");
@@ -470,7 +471,7 @@ export function InitErrorMessage(props: MessageProps3) {
 
   const status = props.msg instanceof APIError ? props.msg.status : undefined;
   const message =
-    props.msg instanceof APIError ? props.msg.formatMsg(te) : props.msg;
+    props.msg instanceof Error ? formatErrorMsg(props.msg, te) : props.msg;
 
   return (
     <CenterBox
@@ -478,11 +479,18 @@ export function InitErrorMessage(props: MessageProps3) {
       onPointerDown={(e) => e.stopPropagation()}
       onPointerUp={(e) => e.stopPropagation()}
     >
-      {status && <h4 className="fn-heading-box">Error {status}</h4>}
-      <p className="mb-3">{message}</p>
-      {props.msg instanceof APIError && props.msg.isServerSide() && (
-        <LinksOnError />
+      {status && status !== FETCH_ERROR_STATUS && (
+        <h4 className="fn-heading-box">Error {status}</h4>
       )}
+      <p className="mb-3">{message}</p>
+
+      {
+        // play/clientPage.tsx で生成されるstring型のerrorMsgはすべてexpectedのエラー
+        props.msg instanceof Error && !isExpectedError(props.msg) && (
+          <LinksOnError />
+        )
+      }
+      {!(props.msg instanceof APIError) && <LinksOnError />}
       <p>
         <Button
           text={t("exit")}

--- a/frontend/app/[locale]/play/messageBox.tsx
+++ b/frontend/app/[locale]/play/messageBox.tsx
@@ -490,7 +490,6 @@ export function InitErrorMessage(props: MessageProps3) {
           <LinksOnError />
         )
       }
-      {!(props.msg instanceof APIError) && <LinksOnError />}
       <p>
         <Button
           text={t("exit")}

--- a/frontend/app/[locale]/play/messageBox.tsx
+++ b/frontend/app/[locale]/play/messageBox.tsx
@@ -25,11 +25,7 @@ import DropDown from "@/common/dropdown";
 import DownOne from "@icon-park/react/lib/icons/DownOne";
 import { Scrollable } from "@/common/scrollable";
 import { HelpIcon } from "@/common/caption";
-import {
-  APIError,
-  FETCH_ERROR_STATUS,
-  shouldHideStatus,
-} from "@/common/apiError";
+import { APIError, shouldHideStatus } from "@/common/apiError";
 import { LinksOnError } from "@/common/errorPageComponent";
 import { formatErrorMsg, isExpectedError } from "@/common/fetch";
 

--- a/frontend/app/[locale]/play/result.tsx
+++ b/frontend/app/[locale]/play/result.tsx
@@ -18,7 +18,6 @@ import { useTranslations } from "next-intl";
 import { useShareLink } from "@/common/shareLinkAndImage";
 import { useDisplayMode } from "@/scale";
 import { RecordHistogram } from "@/common/recordHistogram";
-import { APIError } from "@/common/apiError";
 
 export const resultAnimDelays = [100, 500, 500, 500, 750, 750, 500] as const;
 
@@ -37,7 +36,7 @@ interface Props extends ResultParams {
   reset: () => void;
   exit: () => void;
   largeResult: boolean;
-  record: RecordGetSummary | APIError | undefined;
+  record: RecordGetSummary | Error | undefined;
 }
 export default function Result(props: Props) {
   const t = useTranslations("play.result");
@@ -275,7 +274,7 @@ export default function Result(props: Props) {
           </div>
         )}
         {props.showRecord &&
-          !(props.record instanceof APIError) &&
+          !(props.record instanceof Error) &&
           props.record?.histogram &&
           props.record.count >= 5 && (
             <div className="mb-2" style={{ ...appearingAnimation3(7) }}>

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -6,6 +6,7 @@ import {
   ChartBrief,
   deserializeResultParams,
   RecordGetSummary,
+  RecordGetSummarySchema,
   ResultParams,
 } from "@falling-nikochan/chart";
 import { useEffect, useState } from "react";
@@ -16,9 +17,10 @@ import { Box } from "@/common/box.js";
 import { RedirectedWarning } from "@/common/redirectedWarning.js";
 import { TitleAsLink } from "@/common/titleLogo.jsx";
 import { MobileFooter } from "@/common/footer.jsx";
-import { APIError } from "@/common/apiError.js";
 import { PCHeader2 } from "@/common/header.js";
 import { Features, PoliciesAndLinks } from "@/clientPage.js";
+import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
+import * as v from "valibot";
 
 const dummyBrief = {
   title: "placeholder",
@@ -52,7 +54,7 @@ export default function ShareChart(props: Props) {
   const [cid, setCId] = useState<string>("");
   // const { res, brief } = await getBrief(cid, true);
   const [brief, setBrief] = useState<ChartBrief | null>(null);
-  const [record, setRecord] = useState<RecordGetSummary[] | APIError | null>(
+  const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(
     null
   );
   const [sharedResult, setSharedResult] = useState<ResultParams | null>(null);
@@ -80,25 +82,11 @@ export default function ShareChart(props: Props) {
       }
     }, 100);
     setRecord(null);
-    (async () => {
-      try {
-        const res = await fetch(
-          process.env.BACKEND_PREFIX + `/api/record/${cid}`
-        );
-        if (res.ok) {
-          try {
-            setRecord(await res.json());
-          } catch (e) {
-            console.error(e);
-            setRecord(APIError.badResponse(e));
-          }
-        } else {
-          setRecord(await APIError.fromRes(res));
-        }
-      } catch (e) {
-        setRecord(APIError.fetchError(e));
-      }
-    })();
+    fetchBackend()
+      .get(`/api/record/${cid}`)
+      .json((record) => v.parse(v.array(RecordGetSummarySchema()), record))
+      .catch((e: unknown) => captureAndWrap(e, { cid }))
+      .then((record) => setRecord(record));
     if (searchParams.get("result")) {
       try {
         setSharedResult(deserializeResultParams(searchParams.get("result")!));

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -54,9 +54,7 @@ export default function ShareChart(props: Props) {
   const [cid, setCId] = useState<string>("");
   // const { res, brief } = await getBrief(cid, true);
   const [brief, setBrief] = useState<ChartBrief | null>(null);
-  const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(
-    null
-  );
+  const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(null);
   const [sharedResult, setSharedResult] = useState<ResultParams | null>(null);
 
   useEffect(() => {

--- a/frontend/app/[locale]/share/placeholder/playOption.tsx
+++ b/frontend/app/[locale]/share/placeholder/playOption.tsx
@@ -28,14 +28,14 @@ import { BadgeStatus, getBadge, LevelBadge } from "@/common/levelBadge";
 import { SlimeSVG } from "@/common/slime";
 import ArrowRight from "@icon-park/react/lib/icons/ArrowRight";
 import { useShareLink } from "@/common/shareLinkAndImage";
-import { APIError } from "@/common/apiError";
 import { isInsideFrame } from "@/scale";
+import { formatError } from "@/common/fetch";
 
 interface Props {
   locale: string;
   cid: string;
   brief: ChartBrief;
-  record: RecordGetSummary[] | APIError | null;
+  record: RecordGetSummary[] | Error | null;
 }
 export function PlayOption(props: Props) {
   const t = useTranslations("share");
@@ -215,7 +215,7 @@ function LevelButton(props: {
 function SelectedLevelInfo(props: {
   cid: string;
   brief: ChartBrief;
-  record: RecordGetSummary[] | APIError | null;
+  record: RecordGetSummary[] | Error | null;
   selectedLevel: number;
   locale: string;
 }) {
@@ -223,10 +223,10 @@ function SelectedLevelInfo(props: {
   const te = useTranslations("error");
   const [showBestDetail, setShowBestDetail] = useState(false);
 
-  const selectedRecord: RecordGetSummary | APIError | undefined =
+  const selectedRecord: RecordGetSummary | Error | undefined =
     props.selectedLevel === null
       ? undefined
-      : props.record instanceof APIError
+      : props.record instanceof Error
         ? props.record
         : props.record?.find(
             (r) => r.lvHash === props.brief.levels[props.selectedLevel]?.hash
@@ -322,25 +322,24 @@ function SelectedLevelInfo(props: {
       <p className="mt-2 min-w-65 ">
         {/* histogramの幅 w-5 x13 */}
         {t("otherPlayers")}
-        {selectedRecord !== undefined &&
-          !(selectedRecord instanceof APIError) && (
-            <span className="ml-2 text-sm">({selectedRecord.count || 0})</span>
-          )}
+        {selectedRecord !== undefined && !(selectedRecord instanceof Error) && (
+          <span className="ml-2 text-sm">({selectedRecord.count || 0})</span>
+        )}
       </p>
       <span className={clsx(props.record === null ? "block" : "hidden")}>
         <SlimeSVG />
         Loading...
       </span>
       {selectedRecord !== undefined &&
-        !(selectedRecord instanceof APIError) &&
+        !(selectedRecord instanceof Error) &&
         selectedRecord.count >= 5 && (
           <RecordHistogram
             histogram={selectedRecord.histogram}
             bestScoreTotal={selectedBestScore ? totalScore : null}
           />
         )}
-      {selectedRecord instanceof APIError && (
-        <p className="text-dim">{selectedRecord.format(te)}</p>
+      {selectedRecord instanceof Error && (
+        <p className="text-dim">{formatError(selectedRecord, te)}</p>
       )}
       <button
         className={clsx(

--- a/frontend/app/[locale]/share/placeholder/shareBox.tsx
+++ b/frontend/app/[locale]/share/placeholder/shareBox.tsx
@@ -54,15 +54,19 @@ export function ShareBox(props: Props) {
 
   const [ytMeta, setYtMeta] = useState<YtMeta | null>(null);
   useEffect(() => {
-    fetchBackend()
-      .url(`/api/ytMeta/${cid}`)
-      .query({ lang: locale })
-      .get()
-      .json((res) => setYtMeta(v.parse(YtMetaSchema(), res)))
-      .catch((e) => {
-        captureAndWrap(e, { cid });
-        setYtMeta(null);
-      });
+    if (cid) {
+      fetchBackend()
+        .url(`/api/ytMeta/${cid}`)
+        .query({ lang: locale })
+        .get()
+        .json((res) => setYtMeta(v.parse(YtMetaSchema(), res)))
+        .catch((e) => {
+          captureAndWrap(e, { cid });
+          setYtMeta(null);
+        });
+    } else {
+      setYtMeta(null);
+    }
   }, [cid, locale]);
 
   return (

--- a/frontend/app/[locale]/share/placeholder/shareBox.tsx
+++ b/frontend/app/[locale]/share/placeholder/shareBox.tsx
@@ -17,12 +17,20 @@ import { SharedResultBox } from "./sharedResult.js";
 import { useColorThief } from "@/common/colorThief.js";
 import { ExternalLink } from "@/common/extLink.jsx";
 import { ButtonHighlight } from "@/common/button.jsx";
-import { APIError } from "@/common/apiError.js";
+import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
+import * as v from "valibot";
+
+const YtMetaSchema = () =>
+  v.object({
+    title: v.string(),
+    channelTitle: v.string(),
+  });
+type YtMeta = v.InferOutput<ReturnType<typeof YtMetaSchema>>;
 
 interface Props {
   cid: string | undefined;
   brief: ChartBrief | null;
-  record: RecordGetSummary[] | APIError | null;
+  record: RecordGetSummary[] | Error | null;
   sharedResult?: ResultParams | null;
   locale: string;
   backButton?: () => void;
@@ -44,26 +52,17 @@ export function ShareBox(props: Props) {
   const shareLink = useShareLink(cid, brief, locale);
   const colorThief = useColorThief();
 
-  interface YtMeta {
-    title: string;
-    channelTitle: string;
-  }
   const [ytMeta, setYtMeta] = useState<YtMeta | null>(null);
   useEffect(() => {
-    if (cid) {
-      fetch(
-        process.env.BACKEND_PREFIX + `/api/ytMeta/${cid}?lang=${locale}`
-      ).then(
-        async (res) => {
-          if (res.ok) {
-            setYtMeta(await res.json());
-          } else {
-            setYtMeta(null);
-          }
-        },
-        () => setYtMeta(null)
-      );
-    }
+    fetchBackend()
+      .url(`/api/ytMeta/${cid}`)
+      .query({ lang: locale })
+      .get()
+      .json((res) => setYtMeta(v.parse(YtMetaSchema(), res)))
+      .catch((e) => {
+        captureAndWrap(e, { cid });
+        setYtMeta(null);
+      });
   }, [cid, locale]);
 
   return (

--- a/frontend/app/[locale]/topDemo.tsx
+++ b/frontend/app/[locale]/topDemo.tsx
@@ -8,6 +8,7 @@ import * as msgpack from "@msgpack/msgpack";
 import { useColorThief } from "./common/colorThief";
 import clsx from "clsx/lite";
 import { ChartListItem } from "./main/chartList";
+import { fetchBackend } from "./common/fetch";
 
 export interface DemoChart {
   cid: string;
@@ -74,28 +75,20 @@ export function TopDemo(
       props.lvIndex !== undefined &&
       props.offset !== undefined
     ) {
-      fetch(
-        process.env.BACKEND_PREFIX +
-          `/api/seqFile/${props.cid}/${props.lvIndex}`
-      ).then(
-        (res) => {
-          if (res.ok) {
-            res.arrayBuffer().then((buf) => {
-              const seq = msgpack.decode(buf) as ChartSeqData;
-              resetNotesAll(
-                seq.notes.map((n) => ({
-                  ...n,
-                  done: 0,
-                  bigDone: false,
-                })),
-                props.offset! - seq.offset
-              );
-              currentTimeSec.current = props.offset! - seq.offset;
-            });
-          }
-        },
-        () => undefined
-      );
+      fetchBackend()
+        .get(`/api/seqFile/${props.cid}/${props.lvIndex}`)
+        .arrayBuffer((buf) => {
+          const seq = msgpack.decode(buf) as ChartSeqData;
+          resetNotesAll(
+            seq.notes.map((n) => ({
+              ...n,
+              done: 0,
+              bigDone: false,
+            })),
+            props.offset! - seq.offset
+          );
+          currentTimeSec.current = props.offset! - seq.offset;
+        });
     }
   }, [notesAll, resetNotesAll, props.cid, props.lvIndex, props.offset]);
 

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -1,3 +1,4 @@
+import { APIError } from "@/common/apiError";
 import * as Sentry from "@sentry/nextjs";
 
 // Sentryの初期化箇所はここ以外に app/[locale]/edit/luaExecWorker.ts にもあるので注意！(そちらも同様に編集すること)
@@ -16,6 +17,21 @@ Sentry.init({
     // transportOptions type is not recognized correctly: https://github.com/getsentry/sentry-javascript/issues/13548
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any,
+  beforeSend(event, hint) {
+    if (
+      hint.syntheticException instanceof DOMException &&
+      hint.syntheticException.name === "AbortError"
+    ) {
+      return null;
+    }
+    if (hint.syntheticException instanceof APIError) {
+      if (hint.syntheticException.expected) {
+        return null;
+      }
+      event.fingerprint = hint.syntheticException.fingerprint;
+    }
+    return event;
+  },
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "remote-web-worker": "^0.0.9",
     "valibot": "^1.3.1",
     "wasmoon": "^1.16.0",
+    "wretch": "^3.0.8",
     "yaml": "^2.8.3"
   },
   "devDependencies": {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["dom", "dom.iterable", "es2017", "es2021.string", "es2023.array"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2017",
+      "es2021.string",
+      "es2022.error",
+      "es2023.array"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -34,7 +34,7 @@ export default {
     unknownApiError: "An error occurred on the server",
     noSession: "Failed to load session data",
     chartVersion: "The version of the chart data (ver. {ver}) is invalid",
-    badResponse: "Failed to process the server response",
+    badResponse: "An unknown error occurred",
     ytError: "Error on the YouTube video ({code})",
     noYtId: "No YouTube video is specified",
     seqEmpty: "The chart data is empty",

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -34,7 +34,7 @@ export default {
     unknownApiError: "サーバーで何らかのエラーが発生しました",
     noSession: "セッションデータを読み込めません",
     chartVersion: "譜面データのバージョン (ver. {ver}) が正しくありません",
-    badResponse: "サーバーからの応答を処理できませんでした",
+    badResponse: "何らかのエラーが発生しました",
     ytError: "YouTube 動画再生のエラー ({code})",
     noYtId: "再生する YouTube 動画が指定されていません",
     seqEmpty: "譜面データが空です",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,7 +153,7 @@ importers:
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/loader':
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+        version: 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -162,13 +162,13 @@ importers:
         version: 3.1.3
       '@next/mdx':
         specifier: 16.1.7
-        version: 16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))
+        version: 16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))
       '@sentry/browser':
         specifier: ^10.52.0
         version: 10.52.0
       '@sentry/nextjs':
         specifier: ^10.52.0
-        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       ace-builds:
         specifier: ^1.43.5
         version: 1.43.6
@@ -198,7 +198,7 @@ importers:
         version: 4.12.0(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(typescript@5.9.3)
       next-license-list:
         specifier: ^1.0.1
-        version: 1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+        version: 1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       pretty-checkbox:
         specifier: ^3.0.3
         version: 3.0.3
@@ -229,6 +229,9 @@ importers:
       wasmoon:
         specifier: ^1.16.0
         version: 1.16.0
+      wretch:
+        specifier: ^3.0.8
+        version: 3.0.8
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -5308,6 +5311,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wretch@3.0.8:
+    resolution: {integrity: sha512-HDDFvyELFUVZFiw4hb/QfMkuh+xwHwJoRjCCTDO+E9ik3TrRJSVI7MmzSKQemimeDH9EwIRmQuh4HTgEcVcYVw==}
+    engines: {node: '>=22'}
+
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -6414,12 +6421,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))':
+  '@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -6478,11 +6485,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/mdx@16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))':
+  '@next/mdx@16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      '@mdx-js/loader': 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+      '@mdx-js/loader': 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
 
   '@next/swc-darwin-arm64@16.1.7':
@@ -7073,7 +7080,7 @@ snapshots:
 
   '@sentry/core@10.52.0': {}
 
-  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))':
+  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -7085,7 +7092,7 @@ snapshots:
       '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/react': 10.52.0(react@19.2.6)
       '@sentry/vercel-edge': 10.52.0
-      '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+      '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       next: 16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0)
       rollup: 4.60.3
       stacktrace-parser: 0.1.11
@@ -7165,10 +7172,10 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.52.0
 
-  '@sentry/webpack-plugin@5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))':
+  '@sentry/webpack-plugin@5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.2.0
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9660,9 +9667,9 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-license-list@1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)):
+  next-license-list@1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
     dependencies:
-      webpack-license-plugin: 4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+      webpack-license-plugin: 4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
     transitivePeerDependencies:
       - webpack
 
@@ -10458,13 +10465,13 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)):
+  terser-webpack-plugin@5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
     optionalDependencies:
       postcss: 8.5.14
 
@@ -10745,13 +10752,13 @@ snapshots:
       webpack: 5.106.2(webpack-cli@7.0.2)
       webpack-merge: 6.0.1
 
-  webpack-license-plugin@4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)):
+  webpack-license-plugin@4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
     dependencies:
       chalk: 5.6.2
       lodash: 4.18.1
       needle: 3.3.1
       spdx-expression-validate: 2.0.0
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2)
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
       webpack-sources: 3.4.1
 
   webpack-license-plugin@4.5.1(webpack@5.106.2):
@@ -10771,7 +10778,7 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2):
+  webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -10794,7 +10801,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2))
+      terser-webpack-plugin: 5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
@@ -10917,6 +10924,8 @@ snapshots:
       pako: 1.0.11
 
   word-wrap@1.2.5: {}
+
+  wretch@3.0.8: {}
 
   ws@8.20.1: {}
 

--- a/route/src/api/search.ts
+++ b/route/src/api/search.ts
@@ -121,6 +121,8 @@ const searchApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   async (c) => {
     let { q, sort, difficultyMin, difficultyMax } = c.req.valid("query");
 
+    return c.json({message: "a"}, 400)
+
     const normalizedQueries = q
       ? Array.from(
           new Set(

--- a/route/src/api/search.ts
+++ b/route/src/api/search.ts
@@ -121,8 +121,6 @@ const searchApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
   async (c) => {
     let { q, sort, difficultyMin, difficultyMax } = c.req.valid("query");
 
-    return c.json({message: "a"}, 400)
-
     const normalizedQueries = q
       ? Array.from(
           new Set(


### PR DESCRIPTION
#1135
* wretchライブラリを導入。fetchBackend, fetchAsset関数でラップ
* APIErrorクラスをリファクタ。
  * staticメソッドで呼び出し側が個別にAPIErrorを作っていたのをやめ、エラーの分類とメッセージの処理はwretchのcustomErrorの中で統一的に行う。
  * Sentryへの送信はAPIErrorの中で行わず、呼び出し側で行う。unknownからError型への変換、stackがない場合の追加、Sentryへの送信、という処理が頻出なのでcaptureAndWrap関数にまとめた
* ネットワークエラーとAbortエラーはSentryに送信されないようにする。(instrumentation-client.ts)
  * また、それ以外でもエラーが想定内の箇所ではmarkAsExpected(e)でexpectedフラグを立て、Sentryがキャプチャしても送信されないようにする。
* fetchBriefを複数回値を返す仕様に変更