### PR TITLE
バックエンドにSentry導入

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,8 @@ AIエージェントは以下の特殊な構成に注意してください。
 - バックエンドのエントリーポイントは、Node.js用の route/serve-local.ts 、Bun用の route/serve-bun-prod.ts 、Cloudflare Worker用の route/serve-cf.js 、Vercel用の api/index.js 、Service Workerで実行される worker/entry.ts (リダイレクトなど一部のロジックのみ) の5箇所あります。変更する際はこれらすべてを更新してください。
 - バックエンドが処理するパスを追加した場合には vercel.json のrewritesの更新も必要な場合があります。
 - 異常時のレスポンスはjsonで `{message: "事前に定義されたメッセージ"}` の形式でなければなりません。メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているもの、または空でなければなりません。
-    - `throw new HTTPException(4xx, {message: "事前に定義されたメッセージ", cause: optional_data})` とすることでグローバルなエラーハンドラー(`src/error.ts`)がそれをJSONに整形して返します。
-    - `ValiError` をthrowするか、HTTPExceptionの`cause`に渡すと、グローバルなエラーハンドラーが`message`に加えてvalibotのissueを含んだレスポンスを返します。 したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchしたり手動でjsonにして返す必要はありません。
-    - `hono-openapi` のvalidatorを使用する場合は第3引数に `sValidatorHook()` を渡すことでバリデーションエラーが上記のValiErrorの処理と同じロジックに流れます。
+    - 想定外のエラーについてはthrowされたものをグローバルなエラーハンドラー(`src/error.ts`)がJSONに整形して返します。したがってそれぞれのAPIのハンドラーで想定外のエラーをcatchして500エラーレスポンスを返す必要はありません。
+    - ValiErrorや外部fetchのResponseをもとにthrowする場合の形式については`src/error.ts`の `onError` のコメントを参照してください。
 - /api 以下のAPIには既存のAPIと同様にOpenAPIのドキュメントを記述してください。異常時のレスポンスのスキーマは `await errorLiteral("メッセージ")` (またはvalibotのissueを含む場合 `await validationErrorSchema("メッセージ")`) で記述してください。
 
 ### 3. Frontend Code

--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,14 @@
+## ver. 16.13 - 2025/06/06 [#1187](https://github.com/na-trium-144/falling-nikochan/pull/1187)
+
+* バックエンドにSentry導入
+    * cloudflare, bun, vercelにsentryを導入
+        * deploy時のsourcemap送信は未実装
+    * HTTPException(500)ではなく意味のあるErrorを投げるようにする
+        * imageGenerationFailedエラーを廃止し、そのままエラーをthrow→onErrorがキャッチし、sentryに送信
+        * unsupportedChartVersionエラーを409に移動
+        * getYTDataEntryはundefinedを返すのではなくエラーをthrowする仕様に変更
+    * fetchBrief,fetchStaticは異常時にResponseを含むErrorをthrowする仕様に変更
+
 ## ver. 16.11 - 2025/06/04 [#1153](https://github.com/na-trium-144/falling-nikochan/pull/1153)
 
 * APIのエラーレスポンスのmessageの改善 [#1152](https://github.com/na-trium-144/falling-nikochan/pull/1152)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,9 +145,8 @@ pnpm run ldev
 
 - When code branches depending on the deployment target, the Hono App creation is made into a function. (`const fooApp = async (config: ...) => new Hono(...)`)
 - The error response must be in JSON format and be in the form of `{message: "predefined message"}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js` or empty.
-  - By using `throw new HTTPException(4xx, {message: "predefined message", cause: optional_data})`, the global error handler (`src/error.ts`) will format it into JSON and return it.
-  - Throwing a `ValiError` or passing it as the `cause` of an HTTPException will cause the global error handler to return a response that includes the valibot issues in addition to the `message`. Therefore, you should always use `v.parse()` in each API handler and do not need to catch it or manually format it into JSON and return it.
-  - When using the `hono-openapi` validator, passing `sValidatorHook()` as the third argument will cause validation errors to flow to the same logic as the ValiError processing described above.
+  - For unexpected errors, the global error handler (`src/error.ts`) formats the thrown error into JSON and returns it. Therefore, it is not necessary for each API handler to catch unexpected errors and return a 500 error response.
+  - For the format when throwing errors based on ValiError or responses from external fetch, please refer to the comments in `onError` in `src/error.ts`.
 - For APIs under /api, please write OpenAPI documentation like existing APIs.
 
 ### Frontend

--- a/api/index.js
+++ b/api/index.js
@@ -34,9 +34,11 @@ Sentry.init({
   integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
   includeLocalVariables: true,
 });
+const sentryMiddleware = (app) =>
+  Sentry.sentry(app, { shouldHandleError: () => false });
 
 const app = new Hono({ strict: false });
-app.use(Sentry.sentry(app));
+app.use(sentryMiddleware(app));
 app
   .use(compress())
   .route(
@@ -45,7 +47,7 @@ app
       getConnInfo,
       fetchBrief: fetchBrief({
         fetchStatic,
-        sentry: Sentry.sentry,
+        sentry: sentryMiddleware,
         captureException: Sentry.captureException,
         setTransactionName: (name) =>
           void Sentry.getCurrentScope().setTransactionName(name),
@@ -58,7 +60,7 @@ app
       ImageResponse,
       fetchBrief: fetchBrief({
         fetchStatic,
-        sentry: Sentry.sentry,
+        sentry: sentryMiddleware,
         captureException: Sentry.captureException,
         setTransactionName: (name) =>
           void Sentry.getCurrentScope().setTransactionName(name),
@@ -73,7 +75,7 @@ app
     shareApp({
       fetchBrief: fetchBrief({
         fetchStatic,
-        sentry: Sentry.sentry,
+        sentry: sentryMiddleware,
         captureException: Sentry.captureException,
         setTransactionName: (name) =>
           void Sentry.getCurrentScope().setTransactionName(name),

--- a/api/index.js
+++ b/api/index.js
@@ -39,12 +39,26 @@ const app = new Hono({ strict: false });
 app.use(Sentry.sentry(app));
 app
   .use(compress())
-  .route("/api", await apiApp({ getConnInfo }))
+  .route(
+    "/api",
+    await apiApp({
+      getConnInfo,
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: Sentry.sentry,
+        captureException: Sentry.captureException,
+      }),
+    })
+  )
   .route(
     "/og",
     ogApp({
       ImageResponse,
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: Sentry.sentry,
+        captureException: Sentry.captureException,
+      }),
       fetchStatic,
     })
   )
@@ -53,7 +67,11 @@ app
   .route(
     "/share",
     shareApp({
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: Sentry.sentry,
+        captureException: Sentry.captureException,
+      }),
       fetchStatic,
     })
   )

--- a/api/index.js
+++ b/api/index.js
@@ -47,6 +47,8 @@ app
         fetchStatic,
         sentry: Sentry.sentry,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
     })
   )
@@ -58,6 +60,8 @@ app
         fetchStatic,
         sentry: Sentry.sentry,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
       fetchStatic,
     })
@@ -71,6 +75,8 @@ app
         fetchStatic,
         sentry: Sentry.sentry,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
       fetchStatic,
     })
@@ -81,6 +87,8 @@ app
     onError({
       fetchStatic,
       captureException: Sentry.captureException,
+      setTransactionName: (name) =>
+        void Sentry.getCurrentScope().setTransactionName(name),
     })
   )
   .notFound(notFound);

--- a/api/index.js
+++ b/api/index.js
@@ -19,12 +19,25 @@ import { Hono } from "hono";
 import { ImageResponse } from "@vercel/og";
 import { getConnInfo } from "hono/vercel";
 import { compress } from "hono/compress";
+import * as Sentry from "@sentry/hono/node";
+import packageJson from "@falling-nikochan/route/package.json" with { type: "json" };
 
 // export const config = {
 //   runtime: "nodejs",
 // };
 
-const app = new Hono({ strict: false })
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  release: `${packageJson.version}-v-${process.env.VERCEL_DEPLOYMENT_ID}`,
+  environment: process.env.VERCEL_TARGET_ENV,
+  sendDefaultPii: false,
+  integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
+  includeLocalVariables: true,
+});
+
+const app = new Hono({ strict: false });
+app.use(Sentry.sentry(app));
+app
   .use(compress())
   .route("/api", await apiApp({ getConnInfo }))
   .route(
@@ -46,7 +59,12 @@ const app = new Hono({ strict: false })
   )
   .route("/", redirectApp({ fetchStatic }))
   .use(languageDetector())
-  .onError(onError({ fetchStatic }))
+  .onError(
+    onError({
+      fetchStatic,
+      captureException: Sentry.captureException,
+    })
+  )
   .notFound(notFound);
 
 export const GET = handle(app);

--- a/api/index.js
+++ b/api/index.js
@@ -28,7 +28,7 @@ import packageJson from "@falling-nikochan/route/package.json" with { type: "jso
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  release: `${packageJson.version}-v-${process.env.VERCEL_DEPLOYMENT_ID}`,
+  release: `${packageJson.version}-v-${process.env.VERCEL_URL.replace(".vercel.app", "")}`,
   environment: process.env.VERCEL_TARGET_ENV,
   sendDefaultPii: false,
   integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "16.12.0",
+  "version": "16.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -15,6 +15,7 @@ export default {
       levelNotFound: "The specified level does not exist",
       // 409
       oldChartVersion: "The chart data version is not up to date",
+      unsupportedChartVersion: "Unsupported chart data version",
       // 410
       noLongerSupportedAPI: "This API is no longer supported",
       // 413
@@ -28,8 +29,6 @@ export default {
       tooManyRequest: "Please wait a while and try again",
       // 500
       unknownApiError: "An error occurred on the server",
-      imageGenerationFailed: "Failed to generate the image",
-      unsupportedChartVersion: "Unsupported chart data version",
       // 499
       fetchError: "Failed to connect to the server (offline?)",
     },

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -15,6 +15,7 @@ export default {
       levelNotFound: "指定したレベルのデータはありません",
       // 409
       oldChartVersion: "譜面データのバージョンが最新ではありません",
+      unsupportedChartVersion: "サポートされていない譜面バージョンです",
       // 410
       noLongerSupportedAPI: "サポートされていない API です",
       // 413
@@ -28,8 +29,6 @@ export default {
       tooManyRequest: "しばらく待ってからやり直してください",
       // 500
       unknownApiError: "サーバーで何らかのエラーが発生しました",
-      imageGenerationFailed: "画像生成に失敗しました",
-      unsupportedChartVersion: "サポートされていない譜面バージョンです",
       // 499
       fetchError: "サーバーへ接続できません (オフライン?)",
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@falling-nikochan/route": "workspace:*",
+    "@sentry/hono": "^10.56.0",
     "@vercel/og": "^0.11.1",
     "hono": "^4.12.23"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@falling-nikochan/route':
         specifier: workspace:*
         version: link:route
+      '@sentry/hono':
+        specifier: ^10.56.0
+        version: 10.56.0(@sentry/bun@10.56.0)(@sentry/cloudflare@10.56.0)(@sentry/node@10.56.0)(hono@4.12.23)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
@@ -2013,12 +2016,20 @@ packages:
     resolution: {integrity: sha512-diywyuc/H7VTUR+W5ryVmLF+0X4UP1OskMqb6V8RSAvJHcj2JmIm7uP+Fc6ACTno+b6AUShwT/L4xVXzO6X9Cw==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/server-utils@10.56.0':
+    resolution: {integrity: sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==}
+    engines: {node: '>=18'}
+
   '@sentry/babel-plugin-component-annotate@5.2.0':
     resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
     engines: {node: '>= 18'}
 
   '@sentry/browser@10.52.0':
     resolution: {integrity: sha512-ijL9jN86oXwXQWbwhPlEb70ODJSEmjxQEQdnZkC4gDWbjswcwvRsVJPYk+1xl2ir2iZixRIHipVxDcLwian35g==}
+    engines: {node: '>=18'}
+
+  '@sentry/bun@10.56.0':
+    resolution: {integrity: sha512-o/lS0bVKyUv1d18IQHrogAmcCharIvN975dqmRIp3xx+UM9mSoNadxKuzqx6rrdXtbZ6cDwC4cn1oNHmlq2jsA==}
     engines: {node: '>=18'}
 
   '@sentry/bundler-plugin-core@5.2.0':
@@ -2077,9 +2088,41 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@sentry/cloudflare@10.56.0':
+    resolution: {integrity: sha512-4PH6joEJbS2+f0yWSatE/vPfE4sbtDQxdPDcsiQ8642nEH8WxKIWWPgRknfLRClmShxzQpwDXJZRJc3rcm4QtQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   '@sentry/core@10.52.0':
     resolution: {integrity: sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A==}
     engines: {node: '>=18'}
+
+  '@sentry/core@10.56.0':
+    resolution: {integrity: sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/hono@10.56.0':
+    resolution: {integrity: sha512-laMFRd+3Z8Oc9jZEkI6n5GUK0sCgep/9bmeQqgtQbRQzHAibmejxd8ZUr2kaKVtqrNOVmLAdxRB/hizyR1tmeQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x
+      '@sentry/bun': 10.56.0
+      '@sentry/cloudflare': 10.56.0
+      '@sentry/node': 10.56.0
+      hono: ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@sentry/bun':
+        optional: true
+      '@sentry/cloudflare':
+        optional: true
+      '@sentry/node':
+        optional: true
 
   '@sentry/nextjs@10.52.0':
     resolution: {integrity: sha512-yOdXYgHAVm+yLLPoXaq9ZgiTMKilDMnOl36fwvOz1TKwaRTtcmON/evli3GrDJ2g4uithwHzk+8lgVXxBAdEtg==}
@@ -2111,12 +2154,49 @@ packages:
       '@opentelemetry/semantic-conventions':
         optional: true
 
+  '@sentry/node-core@10.56.0':
+    resolution: {integrity: sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
   '@sentry/node@10.52.0':
     resolution: {integrity: sha512-9+p3KJUk3rHO1HOEZuSknP2RgKCJZONDm4HWgkVDtVBtocb66KLtVlMjc59d2/bWP7tM3wc877tpG30quFfU9g==}
     engines: {node: '>=18'}
 
+  '@sentry/node@10.56.0':
+    resolution: {integrity: sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==}
+    engines: {node: '>=18'}
+
   '@sentry/opentelemetry@10.52.0':
     resolution: {integrity: sha512-Sc7StsvC0bwhMcgDfTRWUIexO5cNzzKUurvUwtpgQUnxO7AzexU3lkY3yHYDsCbWYAEQMXAgQYQtbcqoh+Ie7g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@sentry/opentelemetry@10.56.0':
+    resolution: {integrity: sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -7020,6 +7100,11 @@ snapshots:
       '@sentry-internal/browser-utils': 10.52.0
       '@sentry/core': 10.52.0
 
+  '@sentry-internal/server-utils@10.56.0':
+    dependencies:
+      '@sentry/core': 10.56.0
+    optional: true
+
   '@sentry/babel-plugin-component-annotate@5.2.0': {}
 
   '@sentry/browser@10.52.0':
@@ -7029,6 +7114,15 @@ snapshots:
       '@sentry-internal/replay': 10.52.0
       '@sentry-internal/replay-canvas': 10.52.0
       '@sentry/core': 10.52.0
+
+  '@sentry/bun@10.56.0':
+    dependencies:
+      '@sentry/core': 10.56.0
+      '@sentry/node': 10.56.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+    optional: true
 
   '@sentry/bundler-plugin-core@5.2.0':
     dependencies:
@@ -7087,7 +7181,25 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/cloudflare@10.56.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.56.0
+    optional: true
+
   '@sentry/core@10.52.0': {}
+
+  '@sentry/core@10.56.0': {}
+
+  '@sentry/hono@10.56.0(@sentry/bun@10.56.0)(@sentry/cloudflare@10.56.0)(@sentry/node@10.56.0)(hono@4.12.23)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.56.0
+      hono: 4.12.23
+    optionalDependencies:
+      '@sentry/bun': 10.56.0
+      '@sentry/cloudflare': 10.56.0
+      '@sentry/node': 10.56.0
 
   '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
     dependencies:
@@ -7126,6 +7238,19 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@sentry/node-core@10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.56.0
+      '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    optional: true
+
   '@sentry/node@10.52.0':
     dependencies:
       '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
@@ -7161,6 +7286,23 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
+  '@sentry/node@10.56.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry-internal/server-utils': 10.56.0
+      '@sentry/core': 10.56.0
+      '@sentry/node-core': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+    optional: true
+
   '@sentry/opentelemetry@10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -7168,6 +7310,15 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@sentry/core': 10.52.0
+
+  '@sentry/opentelemetry@10.56.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.56.0
+    optional: true
 
   '@sentry/react@10.52.0(react@19.2.6)':
     dependencies:

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "16.12.0",
+  "version": "16.13.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -17,10 +17,21 @@ import { Hono } from "hono";
 import { logger } from "hono/logger";
 import { ImageResponse } from "@vercel/og";
 import { getConnInfo } from "hono/bun";
+import * as Sentry from "@sentry/hono/bun";
+import packageJson from "./package.json" with { type: "json" };
 
 const port = 8787;
 
-const app = new Hono<{ Bindings: Bindings }>({ strict: false })
+const app = new Hono<{ Bindings: Bindings }>({ strict: false });
+app.use(
+  Sentry.sentry(app, {
+    dsn: process.env.SENTRY_DSN,
+    release: `${packageJson.version}-bun`,
+    sendDefaultPii: false,
+    integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
+  })
+);
+app
   .use(logger())
   .route("/api", await apiApp({ getConnInfo }))
   .route(
@@ -61,7 +72,12 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
     })
   )
   .use(languageDetector())
-  .onError(onError({ fetchStatic }))
+  .onError(
+    onError({
+      fetchStatic,
+      captureException: Sentry.captureException,
+    })
+  )
   .notFound(notFound);
 
 export default {

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -42,6 +42,8 @@ app
         fetchStatic,
         sentry: sentryMiddleware,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
     })
   )
@@ -53,6 +55,8 @@ app
         fetchStatic,
         sentry: sentryMiddleware,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
       fetchStatic,
     })
@@ -66,6 +70,8 @@ app
         fetchStatic,
         sentry: sentryMiddleware,
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
       fetchStatic,
     })
@@ -95,6 +101,8 @@ app
     onError({
       fetchStatic,
       captureException: Sentry.captureException,
+      setTransactionName: (name) =>
+        void Sentry.getCurrentScope().setTransactionName(name),
     })
   )
   .notFound(notFound);

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -28,6 +28,7 @@ const sentryMiddleware = (app) =>
     release: `${packageJson.version}-bun`,
     sendDefaultPii: false,
     integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
+    shouldHandleError: () => false,
   });
 
 const app = new Hono<{ Bindings: Bindings }>({ strict: false });

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -22,23 +22,38 @@ import packageJson from "./package.json" with { type: "json" };
 
 const port = 8787;
 
-const app = new Hono<{ Bindings: Bindings }>({ strict: false });
-app.use(
+const sentryMiddleware = (app) =>
   Sentry.sentry(app, {
     dsn: process.env.SENTRY_DSN,
     release: `${packageJson.version}-bun`,
     sendDefaultPii: false,
     integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
-  })
-);
+  });
+
+const app = new Hono<{ Bindings: Bindings }>({ strict: false });
+app.use(sentryMiddleware(app));
 app
   .use(logger())
-  .route("/api", await apiApp({ getConnInfo }))
+  .route(
+    "/api",
+    await apiApp({
+      getConnInfo,
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: sentryMiddleware,
+        captureException: Sentry.captureException,
+      }),
+    })
+  )
   .route(
     "/og",
     ogApp({
       ImageResponse,
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: sentryMiddleware,
+        captureException: Sentry.captureException,
+      }),
       fetchStatic,
     })
   )
@@ -47,7 +62,11 @@ app
   .route(
     "/share",
     shareApp({
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: sentryMiddleware,
+        captureException: Sentry.captureException,
+      }),
       fetchStatic,
     })
   )

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -26,9 +26,13 @@ const sentryConfig = (env) => ({
   sendDefaultPii: false,
   integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
 });
+const sentryHonoConfig = (env) => ({
+  ...sentryConfig(env),
+  shouldHandleError: () => false,
+});
 
 const app = new Hono({ strict: false });
-app.use(Sentry.sentry(app, sentryConfig));
+app.use(Sentry.sentry(app, sentryHonoConfig));
 app
   .route(
     "/api",
@@ -36,7 +40,7 @@ app
       getConnInfo,
       fetchBrief: fetchBrief({
         fetchStatic,
-        sentry: (app) => Sentry.sentry(app, sentryConfig),
+        sentry: (app) => Sentry.sentry(app, sentryHonoConfig),
         captureException: Sentry.captureException,
         setTransactionName: (name) =>
           void Sentry.getCurrentScope().setTransactionName(name),
@@ -57,7 +61,7 @@ app
     shareApp({
       fetchBrief: fetchBrief({
         fetchStatic,
-        sentry: (app) => Sentry.sentry(app, sentryConfig),
+        sentry: (app) => Sentry.sentry(app, sentryHonoConfig),
         captureException: Sentry.captureException,
         setTransactionName: (name) =>
           void Sentry.getCurrentScope().setTransactionName(name),

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -76,14 +76,30 @@ export default Sentry.withSentry(sentryConfig, {
         if (res.status < 500) {
           return res;
         } else {
-          console.log(
-            "passthrough request returned:",
-            res.status,
-            await res.text()
+          Sentry.captureException(
+            new Error(
+              `passthrough request to ${url.hostname} failed (${res.status})`
+            ),
+            {
+              extra: {
+                url: url,
+                status: res.status,
+                body: await res.text(),
+              },
+            }
           );
         }
       } catch (e) {
-        console.log("passthrough request failed:", e);
+        Sentry.captureException(
+          new Error(`passthrough request to ${url.hostname} failed`, {
+            cause: e,
+          }),
+          {
+            extra: {
+              url: url,
+            },
+          }
+        );
         // passthrough
       }
     }

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -30,7 +30,17 @@ const sentryConfig = (env) => ({
 const app = new Hono({ strict: false });
 app.use(Sentry.sentry(app, sentryConfig));
 app
-  .route("/api", await apiApp({ getConnInfo }))
+  .route(
+    "/api",
+    await apiApp({
+      getConnInfo,
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: (app) => Sentry.sentry(app, sentryConfig),
+        captureException: Sentry.captureException,
+      }),
+    })
+  )
   .get("/og/*", (c) => {
     const url = new URL(c.req.raw.url);
     return c.redirect(
@@ -43,7 +53,11 @@ app
   .route(
     "/share",
     shareApp({
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: (app) => Sentry.sentry(app, sentryConfig),
+        captureException: Sentry.captureException,
+      }),
       fetchStatic,
     })
   )

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -38,6 +38,8 @@ app
         fetchStatic,
         sentry: (app) => Sentry.sentry(app, sentryConfig),
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
     })
   )
@@ -57,6 +59,8 @@ app
         fetchStatic,
         sentry: (app) => Sentry.sentry(app, sentryConfig),
         captureException: Sentry.captureException,
+        setTransactionName: (name) =>
+          void Sentry.getCurrentScope().setTransactionName(name),
       }),
       fetchStatic,
     })
@@ -67,6 +71,8 @@ app
     onError({
       fetchStatic,
       captureException: Sentry.captureException,
+      setTransactionName: (name) =>
+        void Sentry.getCurrentScope().setTransactionName(name),
     })
   )
   .notFound(notFound);

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -15,10 +15,21 @@ import {
 import { Hono } from "hono";
 import { env } from "hono/adapter";
 import { getConnInfo } from "hono/cloudflare-workers";
+import * as Sentry from "@sentry/hono/cloudflare";
+import packageJson from "@falling-nikochan/route/package.json" with { type: "json" };
 
 const fetchStatic = (e, url) => e.ASSETS.fetch(url);
+const sentryConfig = (env) => ({
+  dsn: env.SENTRY_DSN,
+  release: `${packageJson.version}-cf-${env.CF_VERSION_METADATA.id}`,
+  environment: env.CF_VERSION_METADATA.tag,
+  sendDefaultPii: false,
+  integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
+});
 
-const app = new Hono({ strict: false })
+const app = new Hono({ strict: false });
+app.use(Sentry.sentry(app, sentryConfig));
+app
   .route("/api", await apiApp({ getConnInfo }))
   .get("/og/*", (c) => {
     const url = new URL(c.req.raw.url);
@@ -38,10 +49,15 @@ const app = new Hono({ strict: false })
   )
   .route("/", redirectApp({ fetchStatic }))
   .use(languageDetector())
-  .onError(onError({ fetchStatic }))
+  .onError(
+    onError({
+      fetchStatic,
+      captureException: Sentry.captureException,
+    })
+  )
   .notFound(notFound);
 
-export default {
+export default Sentry.withSentry(sentryConfig, {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
@@ -96,4 +112,4 @@ export default {
       })()
     );
   },
-};
+});

--- a/route/serve-local.ts
+++ b/route/serve-local.ts
@@ -25,12 +25,26 @@ console.log(`Server is running on http://localhost:${port}`);
 
 const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .use(logger())
-  .route("/api", await apiApp({ getConnInfo }))
+  .route(
+    "/api",
+    await apiApp({
+      getConnInfo,
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: null,
+        captureException: () => "",
+      }),
+    })
+  )
   .route(
     "/og",
     ogApp({
       ImageResponse,
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: null,
+        captureException: () => "",
+      }),
       fetchStatic,
     })
   )
@@ -40,7 +54,11 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
   .route(
     "/share",
     shareApp({
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: null,
+        captureException: () => "",
+      }),
       fetchStatic,
     })
   )

--- a/route/serve-local.ts
+++ b/route/serve-local.ts
@@ -65,7 +65,7 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
     })
   )
   .use(languageDetector())
-  .onError(onError({ fetchStatic }))
+  .onError(onError({ fetchStatic, captureException: () => "" }))
   .notFound(notFound);
 
 serve({

--- a/route/serve-local.ts
+++ b/route/serve-local.ts
@@ -32,7 +32,8 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
       fetchBrief: fetchBrief({
         fetchStatic,
         sentry: null,
-        captureException: () => "",
+        captureException: null,
+        setTransactionName: null,
       }),
     })
   )
@@ -43,7 +44,8 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
       fetchBrief: fetchBrief({
         fetchStatic,
         sentry: null,
-        captureException: () => "",
+        captureException: null,
+        setTransactionName: null,
       }),
       fetchStatic,
     })
@@ -57,7 +59,8 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
       fetchBrief: fetchBrief({
         fetchStatic,
         sentry: null,
-        captureException: () => "",
+        captureException: null,
+        setTransactionName: null,
       }),
       fetchStatic,
     })
@@ -83,7 +86,9 @@ const app = new Hono<{ Bindings: Bindings }>({ strict: false })
     })
   )
   .use(languageDetector())
-  .onError(onError({ fetchStatic, captureException: () => "" }))
+  .onError(
+    onError({ fetchStatic, captureException: null, setTransactionName: null })
+  )
   .notFound(notFound);
 
 serve({

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -75,7 +75,10 @@ const apiApp = async (config: {
     .route("/hashPasswd", hashPasswdApp)
     .route("/record", await recordApp({ getConnInfo: config.getConnInfo }))
     .route("/ip", forwardCheckApp({ getConnInfo: config.getConnInfo }))
-    .route("/oembed", await oembedApp({ fetchBrief: config.fetchBrief }));
+    .route("/oembed", await oembedApp({ fetchBrief: config.fetchBrief }))
+    .get("/debug-sentry", () => {
+      throw new Error("My first sentry error!");
+    });
   apiApp.get(
     "/openapi.json",
     openAPIRouteHandler(apiApp, {

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -1,7 +1,7 @@
-import { Context, Hono } from "hono";
+import { Context, ExecutionContext, Hono } from "hono";
 import { cors } from "hono/cors";
 import briefApp from "./brief.js";
-import { backendOrigin, Bindings, fetchBrief, fetchStatic } from "../env.js";
+import { backendOrigin, Bindings } from "../env.js";
 import chartFileApp from "./chartFile.js";
 import newChartFileApp from "./newChartFile.js";
 import playFileApp from "./playFile.js";
@@ -13,7 +13,7 @@ import { join, dirname } from "node:path";
 import dotenv from "dotenv";
 import searchApp from "./search.js";
 import { bodyLimit } from "hono/body-limit";
-import { docSchemas, fileMaxSize } from "@falling-nikochan/chart";
+import { ChartBrief, docSchemas, fileMaxSize } from "@falling-nikochan/chart";
 import { openAPIRouteHandler } from "hono-openapi";
 import packageJson from "../../package.json" with { type: "json" };
 import { Scalar } from "@scalar/hono-api-reference";
@@ -26,6 +26,11 @@ dotenv.config({ path: join(dirname(process.cwd()), ".env") });
 
 const apiApp = async (config: {
   getConnInfo: (c: Context) => ConnInfo | null;
+  fetchBrief: (
+    e: Bindings,
+    cid: string,
+    ctx: ExecutionContext | undefined
+  ) => Promise<ChartBrief>;
 }) => {
   const apiApp = new Hono<{ Bindings: Bindings }>({ strict: false })
     .use(
@@ -70,10 +75,7 @@ const apiApp = async (config: {
     .route("/hashPasswd", hashPasswdApp)
     .route("/record", await recordApp({ getConnInfo: config.getConnInfo }))
     .route("/ip", forwardCheckApp({ getConnInfo: config.getConnInfo }))
-    .route(
-      "/oembed",
-      await oembedApp({ fetchBrief: fetchBrief({ fetchStatic }) })
-    );
+    .route("/oembed", await oembedApp({ fetchBrief: config.fetchBrief }));
   apiApp.get(
     "/openapi.json",
     openAPIRouteHandler(apiApp, {

--- a/route/src/api/chart.ts
+++ b/route/src/api/chart.ts
@@ -674,6 +674,6 @@ export function entryToChart(
       } as Chart15;
     default:
       entry satisfies never;
-      throw new HTTPException(500, { message: "unsupportedChartVersion" });
+      throw new HTTPException(409, { message: "unsupportedChartVersion" });
   }
 }

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -493,7 +493,9 @@ const chartFileApp = async (config: {
                 cid,
                 updatedAt,
                 ip,
-                await getYTDataEntry(env(c), db, newChart.ytId),
+                await getYTDataEntry(env(c), db, newChart.ytId).catch(
+                  () => undefined
+                ),
                 pSecretSalt,
                 entry,
                 newSaveHashes

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -201,7 +201,9 @@ const newChartFileApp = async (config: {
                 cid,
                 updatedAt,
                 ip,
-                await getYTDataEntry(env(c), db, newChart.ytId),
+                await getYTDataEntry(env(c), db, newChart.ytId).catch(
+                  () => undefined
+                ),
                 pSecretSalt,
                 null
               )

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -47,7 +47,7 @@ const oembedApp = async (config: {
     e: Bindings,
     cid: string,
     ctx: ExecutionContext | undefined
-  ) => Response | Promise<Response>;
+  ) => Promise<ChartBrief>;
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false }).get(
     "/",
@@ -121,11 +121,7 @@ const oembedApp = async (config: {
       } catch {
         //ignore
       }
-      const briefRes = await config.fetchBrief(env(c), cid, executionCtx);
-      if (!briefRes.ok) {
-        return briefRes;
-      }
-      const brief = (await briefRes.json()) as ChartBrief;
+      const brief = await config.fetchBrief(env(c), cid, executionCtx);
 
       const iframeURL = new URL(
         `/share/${cid}`,

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -134,7 +134,7 @@ const playFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
           break;
         default:
           chart satisfies never;
-          throw new HTTPException(500, { message: "unsupportedChartVersion" });
+          throw new HTTPException(409, { message: "unsupportedChartVersion" });
       }
 
       const filename = `${cid}.${lvIndex}.fn${level.ver}p.mpk`;

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -136,7 +136,7 @@ const seqFileApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
           break;
         default:
           chart satisfies never;
-          throw new HTTPException(500, { message: "unsupportedChartVersion" });
+          throw new HTTPException(409, { message: "unsupportedChartVersion" });
       }
 
       const filename = `${cid}.${lvIndex}.fnseq.mpk`;

--- a/route/src/api/ytData.ts
+++ b/route/src/api/ytData.ts
@@ -1,6 +1,7 @@
 import { Db } from "mongodb";
 import { Bindings } from "../env.js";
 import moji from "moji";
+import { fetchError } from "../error.js";
 
 export interface YTDataEntry {
   ytId: string;
@@ -68,11 +69,11 @@ export async function getYTDataEntry(
             id: ytId,
             key: e.YOUTUBE_API_KEY,
           })
-      );
+      ).catch(fetchError(e));
       if (!res.ok) {
-        const e = new Error(`Failed to fetch YT data (${res.status})`);
-        (e as any).body = await res.text();
-        throw e;
+        throw new Error(`Failed to fetch YT data (${res.status})`, {
+          cause: res,
+        });
       }
       const data: any = await res.json();
       console.log(data);

--- a/route/src/api/ytData.ts
+++ b/route/src/api/ytData.ts
@@ -52,39 +52,32 @@ export async function getYTDataEntry(
   e: Bindings,
   db: Db,
   ytId: string
-): Promise<YTDataEntry | undefined> {
+): Promise<YTDataEntry> {
   const entry = await db.collection<YTDataEntry>("ytData").findOne({ ytId });
   if (entry && entry.lastFetched > Date.now() - 24 * 60 * 60 * 1000) {
     return entry;
   } else {
     if (!e.YOUTUBE_API_KEY) {
-      console.error("YOUTUBE_API_KEY not set");
-      return undefined;
-    }
-    const res = await fetch(
-      "https://www.googleapis.com/youtube/v3/videos?" +
-        new URLSearchParams({
-          part: "snippet,localizations",
-          id: ytId,
-          key: e.YOUTUBE_API_KEY,
-        })
-    ).catch(() => null);
-    if (!res) {
-      console.error(`Failed to fetch YT data for ${ytId}`);
-      return undefined;
-    }
-    if (!res.ok) {
-      console.error(
-        `Failed to fetch YT data for ${ytId}: ${res.status} ${await res.text()}`
-      );
-      return undefined;
+      throw new Error("YOUTUBE_API_KEY not set");
     }
     try {
+      const res = await fetch(
+        "https://www.googleapis.com/youtube/v3/videos?" +
+          new URLSearchParams({
+            part: "snippet,localizations",
+            id: ytId,
+            key: e.YOUTUBE_API_KEY,
+          })
+      );
+      if (!res.ok) {
+        const e = new Error(`Failed to fetch YT data (${res.status})`);
+        (e as any).body = await res.text();
+        throw e;
+      }
       const data: any = await res.json();
       console.log(data);
       if (data.items.length !== 1) {
-        console.error("items.length !== 1");
-        return undefined;
+        throw new Error("items.length !== 1");
       }
       const entry: YTDataEntry = {
         ytId,
@@ -99,9 +92,9 @@ export async function getYTDataEntry(
         .collection<YTDataEntry>("ytData")
         .updateOne({ ytId }, { $set: entry }, { upsert: true });
       return entry;
-    } catch (e) {
-      console.error("Failed to parse YT data", e);
-      return undefined;
+    } catch (e: any) {
+      e.ytId = ytId; // Sentryに報告されたときのために追加情報としてytIdを入れておく
+      throw e;
     }
   }
 }

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -13,7 +13,6 @@ import {
   validationErrorSchema,
 } from "../error.js";
 import { getYTDataEntry } from "./ytData.js";
-import { HTTPException } from "hono/http-exception";
 
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 86400;
@@ -76,28 +75,23 @@ const ytMetaApp = new Hono<{ Bindings: Bindings }>({ strict: false }).get(
       const entry = await getChartEntryCompressed(db, cid, null);
       const ytId = entry.ytId;
       const ytData = await getYTDataEntry(env(c), db, ytId);
-      if (ytData) {
-        let title =
-          // exact match
-          ytData.localizations[lang]?.title ??
-          // partial match
-          Object.entries(ytData.localizations).find(([key]) =>
-            key.startsWith(lang.split("-")[0])
-          )?.[1].title ??
-          // use en
-          ytData.localizations["en"]?.title ??
-          Object.entries(ytData.localizations).find(([key]) =>
-            key.startsWith("en")
-          )?.[1].title ??
-          // default
-          ytData.title;
-        return c.json({ title, channelTitle: ytData.channelTitle }, 200, {
-          "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
-        });
-      } else {
-        // todo: better error message
-        throw new HTTPException(500);
-      }
+      let title =
+        // exact match
+        ytData.localizations[lang]?.title ??
+        // partial match
+        Object.entries(ytData.localizations).find(([key]) =>
+          key.startsWith(lang.split("-")[0])
+        )?.[1].title ??
+        // use en
+        ytData.localizations["en"]?.title ??
+        Object.entries(ytData.localizations).find(([key]) =>
+          key.startsWith("en")
+        )?.[1].title ??
+        // default
+        ytData.title;
+      return c.json({ title, channelTitle: ytData.channelTitle }, 200, {
+        "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+      });
     } finally {
       await client.close();
     }

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -66,7 +66,7 @@ export function backendOrigin(c: Context<{ Bindings: Bindings }>): string {
 }
 /**
  * src/api/brief.ts を用いてbriefデータを取得。
- * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseをthrowする
+ * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseを含むErrorをthrowする
  */
 export const fetchBrief =
   (config: {
@@ -98,7 +98,7 @@ export const fetchBrief =
   };
 /**
  * URLをfetch()してリソースを取得。
- * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseをthrowする
+ * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseを含むErrorをthrowする
  */
 export async function fetchStatic(e: Bindings, url: URL) {
   const res = await fetch(new URL(url.pathname, e.ASSET_PREFIX || url.origin), {

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -3,9 +3,11 @@ import { languageDetector as honoLanguageDetector } from "hono/language";
 import dotenv from "dotenv";
 import { dirname, join } from "node:path";
 import briefApp from "./api/brief.js";
-import { Context, ExecutionContext, Hono } from "hono";
+import { Context, ExecutionContext, Hono, MiddlewareHandler } from "hono";
 import { fetchError, onError } from "./error.js";
 import { env } from "hono/adapter";
+import type { captureException } from "@sentry/hono/node";
+import type { ChartBrief } from "@falling-nikochan/chart";
 
 export interface Bindings {
   ASSETS?: { fetch: typeof fetch };
@@ -62,18 +64,42 @@ export function backendOrigin(c: Context<{ Bindings: Bindings }>): string {
     return url.origin;
   }
 }
+/**
+ * src/api/brief.ts を用いてbriefデータを取得。
+ * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseをthrowする
+ */
 export const fetchBrief =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
+    sentry: ((app: Hono<{ Bindings: Bindings }>) => MiddlewareHandler) | null;
+    captureException: typeof captureException;
   }) =>
-  (e: Bindings, cid: string, ctx: ExecutionContext | undefined) => {
-    return new Hono<{ Bindings: Bindings }>({ strict: false })
-      .route("/api/brief", briefApp)
-      .onError(onError({ fetchStatic: config.fetchStatic }))
-      .request(`/api/brief/${cid}`, undefined, e, ctx);
+  async (e: Bindings, cid: string, ctx: ExecutionContext | undefined) => {
+    const app = new Hono<{ Bindings: Bindings }>({ strict: false });
+    if (config.sentry) {
+      app.use(config.sentry(app));
+    }
+    app.route("/api/brief", briefApp).onError(
+      onError({
+        fetchStatic: config.fetchStatic,
+        captureException: config.captureException,
+      })
+    );
+    const res = await Promise.resolve(
+      app.request(`/api/brief/${cid}`, undefined, e, ctx)
+    ).catch(fetchError(e));
+    if (res.ok) {
+      return (await res.json()) as ChartBrief;
+    } else {
+      throw res;
+    }
   };
-export function fetchStatic(e: Bindings, url: URL) {
-  return fetch(new URL(url.pathname, e.ASSET_PREFIX || url.origin), {
+/**
+ * URLをfetch()してリソースを取得。
+ * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseをthrowする
+ */
+export async function fetchStatic(e: Bindings, url: URL) {
+  const res = await fetch(new URL(url.pathname, e.ASSET_PREFIX || url.origin), {
     headers: {
       // https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation
       // same as VERCEL_AUTOMATION_BYPASS_SECRET but manually set for preview env only
@@ -84,6 +110,11 @@ export function fetchStatic(e: Bindings, url: URL) {
         : {}),
     },
   }).catch(fetchError(e));
+  if (res.ok) {
+    return res;
+  } else {
+    throw res;
+  }
 }
 
 export function languageDetector() {

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -91,7 +91,9 @@ export const fetchBrief =
     if (res.ok) {
       return (await res.json()) as ChartBrief;
     } else {
-      throw res;
+      throw new Error(`failed to fetch /api/brief/${cid} (${res.status})`, {
+        cause: res,
+      });
     }
   };
 /**
@@ -113,7 +115,7 @@ export async function fetchStatic(e: Bindings, url: URL) {
   if (res.ok) {
     return res;
   } else {
-    throw res;
+    throw new Error(`failed to fetch ${url} (${res.status})`, { cause: res });
   }
 }
 

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -68,25 +68,28 @@ export function backendOrigin(c: Context<{ Bindings: Bindings }>): string {
  * src/api/brief.ts を用いてbriefデータを取得。
  * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseを含むErrorをthrowする
  */
-export const fetchBrief =
-  (config: {
-    fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
-    sentry: ((app: Hono<{ Bindings: Bindings }>) => MiddlewareHandler) | null;
-    captureException: typeof captureException | null;
-    setTransactionName: ((name: string) => undefined) | null;
-  }) =>
-  async (e: Bindings, cid: string, ctx: ExecutionContext | undefined) => {
-    const app = new Hono<{ Bindings: Bindings }>({ strict: false });
-    if (config.sentry) {
-      app.use(config.sentry(app));
-    }
-    app.route("/api/brief", briefApp).onError(
-      onError({
-        fetchStatic: config.fetchStatic,
-        captureException: config.captureException,
-        setTransactionName: config.setTransactionName,
-      })
-    );
+export const fetchBrief = (config: {
+  fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
+  sentry: ((app: Hono<{ Bindings: Bindings }>) => MiddlewareHandler) | null;
+  captureException: typeof captureException | null;
+  setTransactionName: ((name: string) => undefined) | null;
+}) => {
+  const app = new Hono<{ Bindings: Bindings }>({ strict: false });
+  if (config.sentry) {
+    app.use(config.sentry(app));
+  }
+  app.route("/api/brief", briefApp).onError(
+    onError({
+      fetchStatic: config.fetchStatic,
+      captureException: config.captureException,
+      setTransactionName: config.setTransactionName,
+    })
+  );
+  return async (
+    e: Bindings,
+    cid: string,
+    ctx: ExecutionContext | undefined
+  ) => {
     const res = await Promise.resolve(
       app.request(`/api/brief/${cid}`, undefined, e, ctx)
     ).catch(fetchError(e));
@@ -98,6 +101,7 @@ export const fetchBrief =
       });
     }
   };
+};
 /**
  * URLをfetch()してリソースを取得。
  * ネットワークエラー時HTTPException(502), エラーレスポンス時Responseを含むErrorをthrowする

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -72,7 +72,8 @@ export const fetchBrief =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
     sentry: ((app: Hono<{ Bindings: Bindings }>) => MiddlewareHandler) | null;
-    captureException: typeof captureException;
+    captureException: typeof captureException | null;
+    setTransactionName: ((name: string) => undefined) | null;
   }) =>
   async (e: Bindings, cid: string, ctx: ExecutionContext | undefined) => {
     const app = new Hono<{ Bindings: Bindings }>({ strict: false });
@@ -83,6 +84,7 @@ export const fetchBrief =
       onError({
         fetchStatic: config.fetchStatic,
         captureException: config.captureException,
+        setTransactionName: config.setTransactionName,
       })
     );
     const res = await Promise.resolve(

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -5,7 +5,7 @@ import { env } from "hono/adapter";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import * as v from "valibot";
 import { ContentfulStatusCode } from "hono/utils/http-status";
-import type { captureException } from "@sentry/node";
+import type { captureException } from "@sentry/hono/node";
 
 export function notFound(): Response {
   throw new HTTPException(404);
@@ -40,6 +40,21 @@ export function sValidatorHook() {
     }
   };
 }
+
+/**
+ * APIの異常時のレスポンスはjsonで `{message: "事前に定義されたメッセージ"}` の形式でなければならない。
+ * メッセージは `i18n/{ja,en}/error.js` 内の`api`に定義されているものでなければならない。
+ *
+ * このエラーハンドラーはthrowされた例外を上記のレスポンスフォーマットに整形する。
+ * したがってそれぞれのrouteで想定外のエラーをcatchして500レスポンスなどにする必要はない。
+ * * `HTTPException(4xx, {message: "事前に定義されたメッセージ"})` をthrowするとそのメッセージをそのまま返す。
+ * * `ValiError` をthrowするか、HTTPExceptionの`cause`に渡すと、`message`に加えてvalibotのissueを含んだレスポンスを返す。
+ *    したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchしたり手動でjsonにして返す必要はない
+ * * `hono-openapi` のvalidatorを使用する場合は第3引数に `sValidatorHook()` を渡すことで
+ *    バリデーションエラーが上記のValiErrorの処理と同じロジックに流れる。
+ * * Response をthrowするとそのbodyをパースし、JSON形式で message が含まれていればそれを返す。
+ *    body形式がそれ以外の場合unknownAPIErrorにする。
+ */
 export const onError =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
@@ -62,7 +77,8 @@ export const onError =
       const lang = c.get("language") || "en";
       let status: ContentfulStatusCode;
       let message: string = "";
-      let others: object = {};
+      let others: object = {}; // レスポンスに含まれる
+      let extra: object = {}; // レスポンスに含まれない、Sentryに送られる
       if (v.isValiError(err)) {
         status = 400;
         others = {
@@ -77,6 +93,24 @@ export const onError =
             flattened: v.flatten(err.cause.issues),
             issues: err.cause.issues,
           };
+        }
+      } else if (err instanceof Response) {
+        status = err.status as ContentfulStatusCode;
+        try {
+          const bodyText = await err.text();
+          try {
+            const body = JSON.parse(bodyText);
+            if (body && typeof body === "object" && "message" in body) {
+              message = String(body.message);
+              others = body;
+            } else {
+              extra = { body };
+            }
+          } catch {
+            extra = { body: bodyText };
+          }
+        } catch (e) {
+          extra = { bodyReadError: String(e) };
         }
       } else {
         status = 500;
@@ -95,6 +129,7 @@ export const onError =
             status,
             message,
             ...others,
+            ...extra,
           },
         });
       }

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -5,6 +5,7 @@ import { env } from "hono/adapter";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import * as v from "valibot";
 import { ContentfulStatusCode } from "hono/utils/http-status";
+import type { captureException } from "@sentry/node";
 
 export function notFound(): Response {
   throw new HTTPException(404);
@@ -43,6 +44,7 @@ export const onError =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
     isTest?: boolean;
+    captureException: typeof captureException;
   }) =>
   async (err: unknown, c: Context) => {
     if (err instanceof Error) {
@@ -87,6 +89,16 @@ export const onError =
       };
       message = message || messageFallbacks[status] || "";
 
+      if (status >= 500) {
+        config.captureException(err, {
+          extra: {
+            status,
+            message,
+            ...others,
+          },
+        });
+      }
+
       if (c.req.path.startsWith("/api") || c.req.path.startsWith("/og")) {
         return c.json(
           {
@@ -117,6 +129,7 @@ export const onError =
       }
     } catch (e) {
       console.error("While handling the above error, another error thrown:", e);
+      config.captureException(e, { extra: { err: String(err) } });
       return c.body(null, 500);
     }
   };

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -52,8 +52,7 @@ export function sValidatorHook() {
  *    したがってそれぞれのAPIのハンドラーでは常に `v.parse()` を使用し、catchしたり手動でjsonにして返す必要はない
  * * `hono-openapi` のvalidatorを使用する場合は第3引数に `sValidatorHook()` を渡すことで
  *    バリデーションエラーが上記のValiErrorの処理と同じロジックに流れる。
- * * Response をthrowするとそのbodyをパースし、JSON形式で message が含まれていればそれを返す。
- *    body形式がそれ以外の場合unknownAPIErrorにする。
+ * * cause に Response を含むエラーをthrowするとそのbodyをパースし、JSON形式で message が含まれていればそれを返す。
  */
 export const onError =
   (config: {
@@ -75,7 +74,7 @@ export const onError =
     }
     try {
       const lang = c.get("language") || "en";
-      let status: ContentfulStatusCode;
+      let status: ContentfulStatusCode = 500;
       let message: string = "";
       let others: object = {}; // レスポンスに含まれる
       let extra: object = {}; // レスポンスに含まれない、Sentryに送られる
@@ -88,16 +87,17 @@ export const onError =
       } else if (err instanceof HTTPException) {
         status = err.status;
         message = err.message;
-        if (v.isValiError(err.cause)) {
-          others = {
-            flattened: v.flatten(err.cause.issues),
-            issues: err.cause.issues,
-          };
-        }
-      } else if (err instanceof Response) {
-        status = err.status as ContentfulStatusCode;
+      }
+      if (err instanceof Error && v.isValiError(err.cause)) {
+        others = {
+          flattened: v.flatten(err.cause.issues),
+          issues: err.cause.issues,
+        };
+      }
+      if (err instanceof Error && err.cause instanceof Response) {
+        status = err.cause.status as ContentfulStatusCode;
         try {
-          const bodyText = await err.text();
+          const bodyText = await err.cause.text();
           try {
             const body = JSON.parse(bodyText);
             if (body && typeof body === "object" && "message" in body) {
@@ -112,8 +112,6 @@ export const onError =
         } catch (e) {
           extra = { bodyReadError: String(e) };
         }
-      } else {
-        status = 500;
       }
 
       const messageFallbacks: Record<number, string> = {

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -2,6 +2,7 @@ import { Context } from "hono";
 import { backendOrigin, Bindings } from "./env.js";
 import { HTTPException } from "hono/http-exception";
 import { env } from "hono/adapter";
+import { matchedRoutes } from "hono/route";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import * as v from "valibot";
 import { ContentfulStatusCode } from "hono/utils/http-status";
@@ -58,7 +59,8 @@ export const onError =
   (config: {
     fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
     isTest?: boolean;
-    captureException: typeof captureException;
+    captureException: typeof captureException | null;
+    setTransactionName: ((name: string) => undefined) | null;
   }) =>
   async (err: unknown, c: Context) => {
     if (err instanceof Error) {
@@ -71,6 +73,14 @@ export const onError =
       }
     } else {
       console.error(`Error handler triggered in ${c.req.path}: ${err}`);
+    }
+    // routeハンドラーのあとにmiddlewareがある場合があり、routePath(c, -1)で正しく取得できないので、
+    // pathが最長のハンドラーを採用する
+    const route = matchedRoutes(c)
+      .sort((a, b) => a.path.length - b.path.length)
+      .at(-1);
+    if (route && config.setTransactionName) {
+      config.setTransactionName(`${route.method} ${route.path}`);
     }
     try {
       const lang = c.get("language") || "en";
@@ -122,7 +132,7 @@ export const onError =
       message = message || messageFallbacks[status] || "";
 
       if (status >= 500) {
-        config.captureException(err, {
+        config.captureException?.(err, {
           extra: {
             status,
             message,
@@ -162,7 +172,7 @@ export const onError =
       }
     } catch (e) {
       console.error("While handling the above error, another error thrown:", e);
-      config.captureException(e, { extra: { err: String(err) } });
+      config.captureException?.(e, { extra: { err: String(err) } });
       return c.body(null, 500);
     }
   };

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -288,15 +288,10 @@ const ogApp = (config: {
           }))
         ),
       }) as Response;
-      if (imRes.ok && imRes.body) {
-        return c.body(imRes.body, 200, {
-          "Content-Type": imRes.headers.get("Content-Type") || "",
-          "Cache-Control": cacheControl(env(c), 315360000),
-        });
-      } else {
-        console.error(imRes);
-        throw new HTTPException(500, { message: "imageGenerationFailed" });
-      }
+      return c.body(imRes.body!, imRes.status as 200, {
+        "Content-Type": imRes.headers.get("Content-Type") || "",
+        "Cache-Control": cacheControl(env(c), 315360000),
+      });
     })
     .get("/:cid{[0-9]+}", (c) =>
       // deprecated (used until ver8.11)

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -42,8 +42,8 @@ const ogApp = (config: {
     e: Bindings,
     cid: string,
     ctx: ExecutionContext | undefined
-  ) => Response | Promise<Response>;
-  fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
+  ) => Promise<ChartBrief>;
+  fetchStatic: (e: Bindings, url: URL) => Promise<Response>;
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
     .use("/*", cors({ origin: "*" }))
@@ -60,20 +60,7 @@ const ogApp = (config: {
         } catch {
           //ignore
         }
-        const briefRes = await config.fetchBrief(env(c), cid, executionCtx);
-        if (!briefRes.ok) {
-          let message = "";
-          try {
-            message =
-              ((await briefRes.json()) as { message?: string }).message || "";
-          } catch {
-            //
-          }
-          throw new HTTPException(briefRes.status as 401 | 404 | 500, {
-            message,
-          });
-        }
-        const brief = (await briefRes.json()) as ChartBrief;
+        const brief = await config.fetchBrief(env(c), cid, executionCtx);
         const lvType = levelTypes.indexOf(
           brief.levels.filter((l) => !l.unlisted).at(0)?.type || ""
         );
@@ -183,9 +170,8 @@ const ogApp = (config: {
         default:
           throw new HTTPException(404);
       }
-      const pBgImageBin = new Promise<Response>((res) =>
-        res(config.fetchStatic(env(c), new URL(imagePath, backendOrigin(c))))
-      )
+      const pBgImageBin = config
+        .fetchStatic(env(c), new URL(imagePath, backendOrigin(c)))
         .then((bgImage) => bgImage.arrayBuffer())
         .then((buf) => {
           const bgImageBuf = new Uint8Array(buf);
@@ -224,11 +210,8 @@ const ogApp = (config: {
             break;
         }
         if (imagePath) {
-          pInputTypeImageBin = new Promise<Response>((res) =>
-            res(
-              config.fetchStatic(env(c), new URL(imagePath, backendOrigin(c)))
-            )
-          )
+          pInputTypeImageBin = config
+            .fetchStatic(env(c), new URL(imagePath, backendOrigin(c)))
             .then((image) => image.arrayBuffer())
             .then((buf) => {
               const inputTypeImageBuf = new Uint8Array(buf);

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -196,16 +196,17 @@ const shareApp = (config: {
           */
         });
       } else {
-        let message = "";
+        const briefBody = await briefRes.text();
         try {
-          message =
-            ((await briefRes.json()) as { message?: string }).message || "";
+          const message =JSON.parse(briefBody).mesage;
+          throw new HTTPException(briefRes.status as 401 | 404 | 500, {
+            message,
+          });
         } catch {
-          //
+          const e = new Error("Failed to fetch brief");
+          (e as any).body = briefBody;
+          throw e;
         }
-        throw new HTTPException(briefRes.status as 401 | 404 | 500, {
-          message,
-        });
       }
     });
 

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -14,7 +14,6 @@ import {
   levelTypes,
   ResultParams,
 } from "@falling-nikochan/chart";
-import { HTTPException } from "hono/http-exception";
 import packageJson from "../package.json" with { type: "json" };
 import { env } from "hono/adapter";
 import { Context, ExecutionContext, Hono } from "hono";
@@ -30,8 +29,8 @@ const shareApp = (config: {
     e: Bindings,
     cid: string,
     ctx: ExecutionContext | undefined
-  ) => Response | Promise<Response>;
-  fetchStatic: (e: Bindings, url: URL) => Response | Promise<Response>;
+  ) => Promise<ChartBrief>;
+  fetchStatic: (e: Bindings, url: URL) => Promise<Response>;
   languageDetector?: (c: Context, next: () => Promise<void>) => Promise<void>;
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
@@ -69,124 +68,114 @@ const shareApp = (config: {
       //   );
       // }
       const pRes = config.fetchStatic(env(c), placeholderUrl);
-      const briefRes = await pBriefRes;
-      if (briefRes.ok) {
-        const brief = (await briefRes.json()) as ChartBrief;
-        const res = await pRes;
-        let newTitle = brief.composer
-          ? t("titleWithComposer", {
-              title: brief.title,
-              composer: brief.composer,
-              cid: cid,
-            })
-          : t("title", {
-              title: brief.title,
-              cid: cid,
-            });
-        if (resultParams) {
-          if (resultParams.date) {
-            newTitle = t("titleWithResult", {
-              title: newTitle,
-              date: resultParams.date.toLocaleDateString(qLang),
-            });
-          } else {
-            newTitle = t("titleWithResultNoDate", {
-              title: newTitle,
-            });
-          }
+      const brief = await pBriefRes;
+      const res = await pRes;
+      let newTitle = brief.composer
+        ? t("titleWithComposer", {
+            title: brief.title,
+            composer: brief.composer,
+            cid: cid,
+          })
+        : t("title", {
+            title: brief.title,
+            cid: cid,
+          });
+      if (resultParams) {
+        if (resultParams.date) {
+          newTitle = t("titleWithResult", {
+            title: newTitle,
+            date: resultParams.date.toLocaleDateString(qLang),
+          });
+        } else {
+          newTitle = t("titleWithResultNoDate", {
+            title: newTitle,
+          });
         }
-        const newDescription = resultParams
-          ? t("descriptionWithResult", {
-              chartCreator: brief.chartCreator || t("chartCreatorEmpty"),
-              title: brief.title,
-              level:
-                (resultParams.lvName ? resultParams.lvName + " " : "") +
-                levelTypes[resultParams.lvType] +
-                "-" +
-                resultParams.lvDifficulty.toString(),
-              playbackRate:
-                resultParams.playbackRate4 !== 4
-                  ? `, ${tr("playbackRate")}×${resultParams.playbackRate4 / 4}`
-                  : "",
-              score: (resultParams.score100 / 100).toString(),
-              status:
-                resultParams.chainScore100 === chainScoreRate * 100
-                  ? " (" + // additional space on left side
-                    (resultParams.baseScore100 === baseScoreRate * 100
-                      ? tr("perfect")
-                      : tr("full")) +
-                    (resultParams.bigScore100 === bigScoreRate * 100
-                      ? "+"
-                      : "") +
-                    "!)"
-                  : "",
-            })
-          : t("description", {
-              chartCreator: brief.chartCreator || t("chartCreatorEmpty"),
-              title: brief.title,
-            });
-        const briefStr = JSON.stringify(brief);
-        const thisURL = new URL(
-          `/share/${cid}`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
-        const oembedJsonURL = new URL(
-          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=json`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
-        const oembedXmlURL = new URL(
-          `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=xml`,
-          env(c).BACKEND_PREFIX || new URL(c.req.url).origin
-        );
-        // キャッシュが正しく動作するように、クエリパラメータの順番が常に一定である必要がある
-        const ogQuery = new URLSearchParams();
-        ogQuery.set("lang", qLang);
-        if (resultParams) ogQuery.set("result", qResult!);
-        ogQuery.set("v", packageJson.version);
-        let replacedBody = (await res.text())
-          .replaceAll('/share/placeholder\\"', `/share/${cid}\\"`) // for canonical URL in script tag
-          .replaceAll('/share/placeholder"', `/share/${cid}"`) // for canonical URL
-          .replaceAll('\\"PLACEHOLDER_TITLE', '\\"' + escapeJs(newTitle)) // "{...\"TITLE\"}" inside script tag
-          .replaceAll("PLACEHOLDER_TITLE", escapeHtml(newTitle)) // <title>TITLE</title>, "TITLE" inside meta tag
-          .replaceAll(
-            "https://placeholder_og_image/",
-            // キャッシュ対策のためクエリにバージョンを入れ、ogの仕様変更した場合に再取得してもらえるようにする
-            new URL(
-              (resultParams ? `/og/result/${cid}?` : `/og/share/${cid}?`) +
-                ogQuery.toString(),
-              backendOrigin(c)
-            ).toString()
-          )
-          .replaceAll(
-            '\\"PLACEHOLDER_DESCRIPTION',
-            '\\"' + escapeJs(newDescription)
-          )
-          .replaceAll("PLACEHOLDER_DESCRIPTION", escapeHtml(newDescription))
-          .replaceAll('\\"PLACEHOLDER_BRIEF', '\\"' + escapeJs(briefStr))
-          .replaceAll("PLACEHOLDER_BRIEF", escapeHtml(briefStr))
-          .replaceAll(
-            "https://placeholder_oembed/json",
-            oembedJsonURL.toString()
-          )
-          .replaceAll(
-            "https://placeholder_oembed/xml",
-            oembedXmlURL.toString()
-          );
-        if (c.req.path.startsWith("/share") && lang !== qLang) {
-          const q = new URLSearchParams(c.req.query());
-          q.delete("lang");
-          const newPath = c.req.path + (q.toString() ? "?" + q.toString() : "");
-          replacedBody =
-            replacedBody.slice(0, replacedBody.indexOf("<body")) +
-            "<body><script>" +
-            `location.replace("${newPath}");` +
-            "</script></body></html>";
-        }
+      }
+      const newDescription = resultParams
+        ? t("descriptionWithResult", {
+            chartCreator: brief.chartCreator || t("chartCreatorEmpty"),
+            title: brief.title,
+            level:
+              (resultParams.lvName ? resultParams.lvName + " " : "") +
+              levelTypes[resultParams.lvType] +
+              "-" +
+              resultParams.lvDifficulty.toString(),
+            playbackRate:
+              resultParams.playbackRate4 !== 4
+                ? `, ${tr("playbackRate")}×${resultParams.playbackRate4 / 4}`
+                : "",
+            score: (resultParams.score100 / 100).toString(),
+            status:
+              resultParams.chainScore100 === chainScoreRate * 100
+                ? " (" + // additional space on left side
+                  (resultParams.baseScore100 === baseScoreRate * 100
+                    ? tr("perfect")
+                    : tr("full")) +
+                  (resultParams.bigScore100 === bigScoreRate * 100 ? "+" : "") +
+                  "!)"
+                : "",
+          })
+        : t("description", {
+            chartCreator: brief.chartCreator || t("chartCreatorEmpty"),
+            title: brief.title,
+          });
+      const briefStr = JSON.stringify(brief);
+      const thisURL = new URL(
+        `/share/${cid}`,
+        env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+      );
+      const oembedJsonURL = new URL(
+        `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=json`,
+        env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+      );
+      const oembedXmlURL = new URL(
+        `/api/oembed?url=${encodeURIComponent(thisURL.toString())}&format=xml`,
+        env(c).BACKEND_PREFIX || new URL(c.req.url).origin
+      );
+      // キャッシュが正しく動作するように、クエリパラメータの順番が常に一定である必要がある
+      const ogQuery = new URLSearchParams();
+      ogQuery.set("lang", qLang);
+      if (resultParams) ogQuery.set("result", qResult!);
+      ogQuery.set("v", packageJson.version);
+      let replacedBody = (await res.text())
+        .replaceAll('/share/placeholder\\"', `/share/${cid}\\"`) // for canonical URL in script tag
+        .replaceAll('/share/placeholder"', `/share/${cid}"`) // for canonical URL
+        .replaceAll('\\"PLACEHOLDER_TITLE', '\\"' + escapeJs(newTitle)) // "{...\"TITLE\"}" inside script tag
+        .replaceAll("PLACEHOLDER_TITLE", escapeHtml(newTitle)) // <title>TITLE</title>, "TITLE" inside meta tag
+        .replaceAll(
+          "https://placeholder_og_image/",
+          // キャッシュ対策のためクエリにバージョンを入れ、ogの仕様変更した場合に再取得してもらえるようにする
+          new URL(
+            (resultParams ? `/og/result/${cid}?` : `/og/share/${cid}?`) +
+              ogQuery.toString(),
+            backendOrigin(c)
+          ).toString()
+        )
+        .replaceAll(
+          '\\"PLACEHOLDER_DESCRIPTION',
+          '\\"' + escapeJs(newDescription)
+        )
+        .replaceAll("PLACEHOLDER_DESCRIPTION", escapeHtml(newDescription))
+        .replaceAll('\\"PLACEHOLDER_BRIEF', '\\"' + escapeJs(briefStr))
+        .replaceAll("PLACEHOLDER_BRIEF", escapeHtml(briefStr))
+        .replaceAll("https://placeholder_oembed/json", oembedJsonURL.toString())
+        .replaceAll("https://placeholder_oembed/xml", oembedXmlURL.toString());
+      if (c.req.path.startsWith("/share") && lang !== qLang) {
+        const q = new URLSearchParams(c.req.query());
+        q.delete("lang");
+        const newPath = c.req.path + (q.toString() ? "?" + q.toString() : "");
+        replacedBody =
+          replacedBody.slice(0, replacedBody.indexOf("<body")) +
+          "<body><script>" +
+          `location.replace("${newPath}");` +
+          "</script></body></html>";
+      }
 
-        return c.text(replacedBody, 200, {
-          "Content-Type": res.headers.get("Content-Type") || "text/plain",
-          "Cache-Control": cacheControl(env(c), null),
-          /*
+      return c.text(replacedBody, 200, {
+        "Content-Type": res.headers.get("Content-Type") || "text/plain",
+        "Cache-Control": cacheControl(env(c), null),
+        /*
           Linkヘッダーかmetaタグのどちらかがあればいいはずだが、
           Linkタグは例えばdiscordで動作しないらしい?: https://github.com/discord/discord-api-docs/issues/7370
           "Link": [
@@ -194,20 +183,7 @@ const shareApp = (config: {
             `<${oembedXmlURL.toString()}>; rel="alternate"; type="text/xml+oembed"; title="${escapeHtml(newTitle)}"`,
           ],
           */
-        });
-      } else {
-        const briefBody = await briefRes.text();
-        try {
-          const message =JSON.parse(briefBody).mesage;
-          throw new HTTPException(briefRes.status as 401 | 404 | 500, {
-            message,
-          });
-        } catch {
-          const e = new Error("Failed to fetch brief");
-          (e as any).body = briefBody;
-          throw e;
-        }
-      }
+      });
     });
 
 function escapeJs(str: string): string {

--- a/route/tests/api/init.ts
+++ b/route/tests/api/init.ts
@@ -39,17 +39,37 @@ import { inspect } from "node:util";
 inspect.defaultOptions.depth = null;
 
 export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
-  .route("/api", await apiApp({ getConnInfo: () => null }))
+  .route(
+    "/api",
+    await apiApp({
+      getConnInfo: () => null,
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: null,
+        captureException: () => "",
+      }),
+    })
+  )
   .route(
     "/share",
     shareApp({
-      fetchBrief: fetchBrief({ fetchStatic }),
+      fetchBrief: fetchBrief({
+        fetchStatic,
+        sentry: null,
+        captureException: () => "",
+      }),
       fetchStatic,
     })
   )
   .route("/", redirectApp({ fetchStatic }))
   .use(languageDetector())
-  .onError(onError({ fetchStatic, isTest: true }))
+  .onError(
+    onError({
+      fetchStatic,
+      isTest: true,
+      captureException: () => "",
+    })
+  )
   .notFound(notFound);
 
 export const dummyCid = "100000";

--- a/route/tests/api/init.ts
+++ b/route/tests/api/init.ts
@@ -46,7 +46,8 @@ export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
       fetchBrief: fetchBrief({
         fetchStatic,
         sentry: null,
-        captureException: () => "",
+        captureException: null,
+        setTransactionName: null,
       }),
     })
   )
@@ -56,7 +57,8 @@ export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
       fetchBrief: fetchBrief({
         fetchStatic,
         sentry: null,
-        captureException: () => "",
+        captureException: null,
+        setTransactionName: null,
       }),
       fetchStatic,
     })
@@ -67,7 +69,8 @@ export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
     onError({
       fetchStatic,
       isTest: true,
-      captureException: () => "",
+      captureException: null,
+      setTransactionName: null,
     })
   )
   .notFound(notFound);

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -563,7 +563,9 @@ const app = new Hono({ strict: false })
     return await fetchStatic(null, new URL(c.req.url));
   })
   .use(languageDetector)
-  .onError(onError({ fetchStatic, captureException: () => "" }))
+  .onError(
+    onError({ fetchStatic, captureException: null, setTransactionName: null })
+  )
   .notFound(notFound);
 
 self.addEventListener("install", () => {

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -466,7 +466,9 @@ const app = new Hono({ strict: false })
         if (res.ok) {
           return await res.json();
         } else {
-          throw res;
+          throw new Error(`failed to fetch /api/brief/${cid} (${res.status})`, {
+            cause: res,
+          });
         }
       },
       fetchStatic,

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -461,8 +461,14 @@ const app = new Hono({ strict: false })
     // fetch済みの新しいページ + 古いサーバーのコード ではバグを起こす可能性があるため、
     // /shareページ自体についてはfetchせずcacheにあるもののみを使用する
     shareApp({
-      fetchBrief: (_e, cid: string /*, _ctx */) =>
-        fetchAPI(self.origin + `/api/brief/${cid}`),
+      fetchBrief: async (_e, cid: string /*, _ctx */) => {
+        const res = await fetchAPI(self.origin + `/api/brief/${cid}`);
+        if (res.ok) {
+          return await res.json();
+        } else {
+          throw res;
+        }
+      },
       fetchStatic,
       languageDetector,
     })
@@ -555,7 +561,7 @@ const app = new Hono({ strict: false })
     return await fetchStatic(null, new URL(c.req.url));
   })
   .use(languageDetector)
-  .onError(onError({ fetchStatic }))
+  .onError(onError({ fetchStatic, captureException: () => "" }))
   .notFound(notFound);
 
 self.addEventListener("install", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,10 @@
     "directory": "frontend/out",
     "binding": "ASSETS",
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
+  "upload_source_maps": true,
   "triggers": {
     // "crons": ["*/15 * * * *"],
   },


### PR DESCRIPTION
- cloudflare, bun, vercelにsentryを導入
  - deploy時のsourcemap送信は未実装
- HTTPException(500)ではなく意味のあるErrorを投げるようにする
  - imageGenerationFailedエラーを廃止し、そのままエラーをthrow→onErrorがキャッチし、sentryに送信
  - unsupportedChartVersionエラーを409に移動
  - getYTDataEntryはundefinedを返すのではなくエラーをthrowする仕様に変更
- fetchBrief,fetchStaticは異常時にResponseを含むErrorをthrowする仕様に変更
