### PR TITLE
webworkerのエラーハンドリング

### DIFF
--- a/frontend/app/[locale]/edit/luaExecWorker.ts
+++ b/frontend/app/[locale]/edit/luaExecWorker.ts
@@ -7,7 +7,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tunnel: process.env.SENTRY_TUNNEL || undefined,
   release: process.env.SENTRY_RELEASE,
-  environment: (process.env.TITLE_SUFFIX || "production").toLowerCase(),
+  environment:
+    "lua-" + (process.env.TITLE_SUFFIX || "production").toLowerCase(),
   sendDefaultPii: false,
   integrations: [Sentry.extraErrorDataIntegration({ depth: 10 })],
   transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport),

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -94,7 +94,7 @@ export function useLuaExecutor(): LuaExecutor {
       if (worker.current === null) {
         worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
         worker.current.addEventListener("error", (e) => {
-          console.error(e)
+          console.error(e);
           setRunning(false);
           setStdout([]);
           // e.messageが空の場合がある

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -93,6 +93,16 @@ export function useLuaExecutor(): LuaExecutor {
       });
       if (worker.current === null) {
         worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
+        worker.current.addEventListener("error", (e) => {
+          console.error(e)
+          setRunning(false);
+          setStdout([]);
+          // e.messageが空の場合がある
+          setErr([e.message || "Unknown error"]);
+          setErrLine(-1);
+          workerResolver.current?.(null);
+          workerResolver.current = null;
+        });
         worker.current.addEventListener(
           "message",
           ({ data }: { data: LuaExecResult }) => {
@@ -108,7 +118,7 @@ export function useLuaExecutor(): LuaExecutor {
               }
               workerResolver.current = null;
             } else {
-              throw new Error("luaExecWorker finished but resolver is null");
+              console.error("luaExecWorker finished but resolver is null");
             }
           }
         );

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -38,8 +38,22 @@ const AceEditor = dynamic(
 );
 import type { Selection } from "ace-builds-internal/selection";
 import type { WorkerInput } from "./luaExecWorker";
+
 // https://github.com/vercel/next.js/discussions/29415
-import "remote-web-worker";
+// import "remote-web-worker";
+// nikochanでは同一originからも同じスクリプトにアクセス可能なので、
+// 無理にクロスオリジンのスクリプトを読み込まず単にurlのoriginを書き換えるだけでok
+if (typeof window !== "undefined") {
+  const BaseWorker = window.Worker;
+  window.Worker = class Worker extends BaseWorker {
+    constructor(scriptURL: string | URL, options?: WorkerOptions) {
+      super(
+        new URL(new URL(scriptURL).pathname, window.location.origin),
+        options
+      );
+    }
+  };
+}
 
 export function useLuaExecutor(): LuaExecutor {
   const [stdout, setStdout] = useState<string[]>([]);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,6 @@
     "react-dom": "^19.2.6",
     "react-range": "^1.10.0",
     "react-resize-detector": "^12.3.0",
-    "remote-web-worker": "^0.0.9",
     "valibot": "^1.3.1",
     "wasmoon": "^1.16.0",
     "wretch": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       react-resize-detector:
         specifier: ^12.3.0
         version: 12.3.0(react@19.2.6)
-      remote-web-worker:
-        specifier: ^0.0.9
-        version: 0.0.9
       valibot:
         specifier: ^1.3.1
         version: 1.3.1(typescript@5.9.3)
@@ -4795,9 +4792,6 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
-
-  remote-web-worker@0.0.9:
-    resolution: {integrity: sha512-TguJhQVWeeL2zWqLQpTfq/uIOpXRHHq7SI6fw6xTIJfSN/ojiKUqV16oAhPD8zH71MFy3FHqSoQEx2cks5gcAA==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -10246,8 +10240,6 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
-
-  remote-web-worker@0.0.9: {}
 
   require-from-string@2.0.2: {}
 


### PR DESCRIPTION
close #1137
- **remote-web-workerを単にurlのoriginを書き換えるだけのパッチに変更**
- **luaExecWorker内のenvironmentを分ける**
- **worker自体のエラー時にメッセージを表示**
