### PR TITLE
etag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ AIエージェントは以下の特殊な構成に注意してください。
     - 想定外のエラーについてはthrowされたものをグローバルなエラーハンドラー(`src/error.ts`)がJSONに整形して返します。したがってそれぞれのAPIのハンドラーで想定外のエラーをcatchして500エラーレスポンスを返す必要はありません。
     - ValiErrorや外部fetchのResponseをもとにthrowする場合の形式については`src/error.ts`の `onError` のコメントを参照してください。
 - /api 以下のAPIには既存のAPIと同様にOpenAPIのドキュメントを記述してください。異常時のレスポンスのスキーマは `await errorLiteral("メッセージ")` (またはvalibotのissueを含む場合 `await validationErrorSchema("メッセージ")`) で記述してください。
+- レスポンスが `Cache-Control: max-age=...` を返す場合は、Honoのcache middlewareに同じcacheControlを指定して併用します。
 
 ### 3. Frontend Code
 - すべてのフロントエンドのソースコードは frontend/app/[locale]/ ディレクトリ内にあります。 ja, en ディレクトリではなく文字通り [locale] という名前のディレクトリです(dynamic route)。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ AIエージェントは以下の特殊な構成に注意してください。
     - 想定外のエラーについてはthrowされたものをグローバルなエラーハンドラー(`src/error.ts`)がJSONに整形して返します。したがってそれぞれのAPIのハンドラーで想定外のエラーをcatchして500エラーレスポンスを返す必要はありません。
     - ValiErrorや外部fetchのResponseをもとにthrowする場合の形式については`src/error.ts`の `onError` のコメントを参照してください。
 - /api 以下のAPIには既存のAPIと同様にOpenAPIのドキュメントを記述してください。異常時のレスポンスのスキーマは `await errorLiteral("メッセージ")` (またはvalibotのissueを含む場合 `await validationErrorSchema("メッセージ")`) で記述してください。
-- レスポンスが `Cache-Control: max-age=...` を返す場合は、Honoのcache middlewareに同じcacheControlを指定して併用します。
+- レスポンスが `Cache-Control: max-age=...` を返す場合は、Honoのcache middlewareを併用します。
 
 ### 3. Frontend Code
 - すべてのフロントエンドのソースコードは frontend/app/[locale]/ ディレクトリ内にあります。 ja, en ディレクトリではなく文字通り [locale] という名前のディレクトリです(dynamic route)。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,7 @@ pnpm run ldev
   - For unexpected errors, the global error handler (`src/error.ts`) formats the thrown error into JSON and returns it. Therefore, it is not necessary for each API handler to catch unexpected errors and return a 500 error response.
   - For the format when throwing errors based on ValiError or responses from external fetch, please refer to the comments in `onError` in `src/error.ts`.
 - For APIs under /api, please write OpenAPI documentation like existing APIs.
+- If the response returns `Cache-Control: max-age=...`, specify the same cacheControl in the Hono cache middleware and use them together.
 
 ### Frontend
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ pnpm run ldev
   - For unexpected errors, the global error handler (`src/error.ts`) formats the thrown error into JSON and returns it. Therefore, it is not necessary for each API handler to catch unexpected errors and return a 500 error response.
   - For the format when throwing errors based on ValiError or responses from external fetch, please refer to the comments in `onError` in `src/error.ts`.
 - For APIs under /api, please write OpenAPI documentation like existing APIs.
-- If the response returns `Cache-Control: max-age=...`, specify the same cacheControl in the Hono cache middleware and use them together.
+- If the response returns `Cache-Control: max-age=...`, use Hono cache middleware them together.
 
 ### Frontend
 

--- a/frontend/app/[locale]/common/briefCache.ts
+++ b/frontend/app/[locale]/common/briefCache.ts
@@ -7,8 +7,11 @@ function briefKeyOld(cid: string) {
 }
 const briefCacheName = "brief1";
 
+// w/や引用符を除いた部分
+export const etagContentRegex = /\d+-[a-zA-Z0-9+/]+=*/;
+
 interface Callbacks {
-  onResult: (brief: ChartBrief) => void;
+  onResult: (brief: ChartBrief & { etag: string }) => void;
   onNotFound?: () => void;
   onError?: (e: Error) => void;
 }
@@ -37,19 +40,30 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
   if (staleLS) {
     cache?.put(`/api/brief/${cid}`, new Response(staleLS));
     localStorage.removeItem(briefKeyOld(cid));
-    callbacks.onResult(JSON.parse(staleLS) as ChartBrief);
+    callbacks.onResult({ ...(JSON.parse(staleLS) as ChartBrief), etag: "" });
     hasResult = true;
   } else {
     cachePromise = cache?.match(`/api/brief/${cid}`).then(async (res) => {
       if (res) {
-        callbacks.onResult((await res.json()) as ChartBrief);
+        callbacks.onResult({
+          ...((await res.json()) as ChartBrief),
+          etag:
+            res.headers.get("ETag")?.match(etagContentRegex)?.[0] ?? "",
+        });
         hasResult = true;
       }
     });
   }
 
   fetchBackend()
-    .get(`/api/brief/${cid}`)
+    .url(`/api/brief/${cid}`)
+    .query(
+      briefIsStale(cid)
+        ? // クエリパラメータをセットすることでキャッシュを回避し最新のbriefを取得する。パラメータ自体に意味はない。
+          { refreshKey: localStorage.getItem(briefStaleKey(cid)) }
+        : {}
+    )
+    .get()
     .notFound(async () => {
       await cachePromise;
       if ("caches" in window) {
@@ -62,7 +76,10 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
     .res(async (res) => {
       const result = v.parse(ChartBriefSchema(), await res.clone().json());
       await cachePromise;
-      callbacks.onResult(result);
+      callbacks.onResult({
+        ...result,
+        etag: res.headers.get("ETag")?.match(/\d+-[a-zA-Z0-9+/]+=*/)?.[0] ?? "",
+      });
       hasResult = true;
       await cache?.put(`/api/brief/${cid}`, res);
     })
@@ -73,4 +90,26 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
         callbacks.onError?.(e as Error);
       }
     });
+}
+
+export function briefStaleKey(cid: string) {
+  return `stale-${cid}`;
+}
+/**
+ * 412レスポンスを受け取った場合に、localStorageに時刻を保存
+ * その間fetchBrief()はリクエストにクエリパラメータをセットすることでキャッシュを回避し最新のbriefを取得する。
+ */
+export function refreshBrief(cid: string) {
+  localStorage.setItem(briefStaleKey(cid), String(Date.now()));
+}
+export function briefIsStale(cid: string) {
+  if (
+    localStorage.getItem(briefStaleKey(cid)) &&
+    Date.now() - Number(localStorage.getItem(briefStaleKey(cid))) < 600 * 1000
+  ) {
+    return true;
+  } else {
+    localStorage.removeItem(briefStaleKey(cid));
+    return false;
+  }
 }

--- a/frontend/app/[locale]/common/briefCache.ts
+++ b/frontend/app/[locale]/common/briefCache.ts
@@ -6,6 +6,7 @@ function briefKeyOld(cid: string) {
   return "brief-" + cid;
 }
 const briefCacheName = "brief1";
+export const playCacheName = "play1";
 
 // w/や引用符を除いた部分
 export const etagContentRegex = /\d+-[a-zA-Z0-9+/]+=*/;
@@ -28,7 +29,11 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
       .keys()
       .then((keys) =>
         keys
-          .filter((k) => k.startsWith("brief") && k !== briefCacheName)
+          .filter(
+            (k) =>
+              (k.startsWith("brief") && k !== briefCacheName) ||
+              (k.startsWith("play") && k !== playCacheName)
+          )
           .forEach((k) => window.caches.delete(k))
       );
     cache = await window.caches.open(briefCacheName);
@@ -47,8 +52,7 @@ export async function fetchBrief(cid: string, callbacks: Callbacks) {
       if (res) {
         callbacks.onResult({
           ...((await res.json()) as ChartBrief),
-          etag:
-            res.headers.get("ETag")?.match(etagContentRegex)?.[0] ?? "",
+          etag: res.headers.get("ETag")?.match(etagContentRegex)?.[0] ?? "",
         });
         hasResult = true;
       }

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -374,7 +374,7 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
             Promise.all(
               keys
                 .filter(
-                  (k) => !k.startsWith("brief") // used in @/common/briefCache
+                  (k) => !k.startsWith("brief") && !k.startsWith("play") // used in @/common/briefCache
                 )
                 .map((k) => caches.delete(k))
             )

--- a/frontend/app/[locale]/common/sharePageModal.tsx
+++ b/frontend/app/[locale]/common/sharePageModal.tsx
@@ -44,7 +44,9 @@ export function SharePageModalProvider(props: {
   const th = useTranslations("share");
   const tp = useTranslations("main.play");
   const [modalCId, setModalCId] = useState<string | null>(null);
-  const [modalBrief, setModalBrief] = useState<ChartBrief | null>(null);
+  const [modalBrief, setModalBrief] = useState<
+    (ChartBrief & { etag: string }) | null
+  >(null);
   const [modalRecord, setModalRecord] = useState<
     RecordGetSummary[] | Error | null
   >(null);

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -112,7 +112,7 @@ export default function Edit(props: {
               chart.toObject(),
               chart.currentLevelIndex || 0
             ),
-            editing: true,
+            editing: true as const,
           };
           setSessionData(data);
           initSession(data, sessionId);

--- a/frontend/app/[locale]/main/shareInternal/clientPage.tsx
+++ b/frontend/app/[locale]/main/shareInternal/clientPage.tsx
@@ -18,7 +18,9 @@ export default function ShareInternal({ locale }: { locale: string }) {
   const t = useTranslations("share");
   const te = useTranslations("error");
   const [cid, setCId] = useState<string | null>(null);
-  const [brief, setBrief] = useState<ChartBrief | null>(null);
+  const [brief, setBrief] = useState<(ChartBrief & { etag: string }) | null>(
+    null
+  );
   const [fromPlay, setFromPlay] = useState<boolean | null>(null);
   const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(null);
   const [sessionError, setSessionError] = useState<boolean>(false);

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -70,7 +70,7 @@ import * as v from "valibot";
 import { markAsExpected } from "@/common/apiError.js";
 import * as Sentry from "@sentry/nextjs";
 import { useDisplayMode } from "@/scale.js";
-import { refreshBrief } from "@/common/briefCache.js";
+import { playCacheName, refreshBrief } from "@/common/briefCache.js";
 
 export function InitPlay({ locale }: { locale: string }) {
   const te = useTranslations("error");
@@ -113,40 +113,71 @@ export function InitPlay({ locale }: { locale: string }) {
       setChartSeq(loadChart(session.level));
       setErrorMsg(undefined);
     } else {
-      fetchBackend()
-        .url(`/api/playFile/${session.cid}/${session.lvIndex}`)
-        .headers({ "If-Match": `"${session.brief.etag}"`, "If-None-Match": `"${session.brief.etag}"` })
-        .get()
-        .badRequest(markAsExpected)
-        .notFound(markAsExpected)
-        .error(412, (e) => {
-          refreshBrief(session.cid);
-          markAsExpected(e);
-        })
-        .arrayBuffer((buf) => {
-          currentChartVer satisfies 16; // update the code below when chart version is bumped
-          const seq = msgpack.decode(buf) as Level6Play | Level15Play;
-          console.log("seq.ver", seq.ver);
-          if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
-            addRecent("play", session.cid ?? "");
-            updatePlayCountForReview();
-            return { seq: loadChart(seq), error: undefined };
-          } else {
-            // seq satisfies never;
-            return {
-              seq: undefined,
-              error: te("chartVersion", { ver: (seq as any)?.ver }),
-            };
-          }
-        })
-        .catch((e: unknown) => ({
-          seq: undefined,
-          error: captureAndWrap(e),
-        }))
-        .then(({ seq, error }) => {
-          setChartSeq(seq);
-          setErrorMsg(error);
-        });
+      /*
+      briefデータのetagをIf-Matchで送り、持っているキャッシュのetagをIf-None-Matchで送る。
+      (少なくともchromeでは)If-Matchを送るとIf-None-Matchは自動送信されず、
+      304時のレスポンスもブラウザが自動処理してくれないようなので、
+      cache apiを使って自前でキャッシュ管理する。
+      初回は200が返る→キャッシュに保存
+      2回目以降は304が返る→キャッシュを使う
+      データに変更があった場合412が返るので、ユーザーにやり直させる
+      */
+      ("caches" in window
+        ? window.caches.open(playCacheName)
+        : Promise.resolve()
+      ).then(async (cache) => {
+        const url = `/api/playFile/${session.cid}/${session.lvIndex}`;
+        const prevFile = await cache?.match(url);
+        fetchBackend()
+          .url(url)
+          .headers({
+            "If-Match": `"${session.brief.etag}"`,
+            "If-None-Match": prevFile?.ok
+              ? (prevFile?.headers.get("ETag") ?? "")
+              : "",
+          })
+          .get()
+          .badRequest(markAsExpected)
+          .notFound(markAsExpected)
+          .error(412, (e) => {
+            refreshBrief(session.cid);
+            markAsExpected(e);
+          })
+          .error(304, (e) => {
+            if (prevFile && prevFile.ok) {
+              return prevFile;
+            } else {
+              throw e;
+            }
+          })
+          .res()
+          .then(async (res) => {
+            const buf = await res.clone().arrayBuffer();
+            currentChartVer satisfies 16; // update the code below when chart version is bumped
+            const seq = msgpack.decode(buf) as Level6Play | Level15Play;
+            console.log("seq.ver", seq.ver);
+            if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
+              addRecent("play", session.cid ?? "");
+              updatePlayCountForReview();
+              await cache?.put(url, res);
+              return { seq: loadChart(seq), error: undefined };
+            } else {
+              // seq satisfies never;
+              return {
+                seq: undefined,
+                error: te("chartVersion", { ver: (seq as any)?.ver }),
+              };
+            }
+          })
+          .catch((e: unknown) => ({
+            seq: undefined,
+            error: captureAndWrap(e),
+          }))
+          .then(({ seq, error }) => {
+            setChartSeq(seq);
+            setErrorMsg(error);
+          });
+      });
     }
   }, [te]);
 

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -46,7 +46,6 @@ import { getBestScore, setBestScore } from "@/common/bestScore.js";
 import BPMSign from "./bpmSign.js";
 import { getSession } from "./session.js";
 import { MusicArea } from "./musicArea.js";
-import { fetchBrief } from "@/common/briefCache.js";
 import { Level6Play } from "@falling-nikochan/chart";
 import { useTranslations } from "next-intl";
 import { SlimeSVG } from "@/common/slime.js";
@@ -71,6 +70,7 @@ import * as v from "valibot";
 import { markAsExpected } from "@/common/apiError.js";
 import * as Sentry from "@sentry/nextjs";
 import { useDisplayMode } from "@/scale.js";
+import { refreshBrief } from "@/common/briefCache.js";
 
 export function InitPlay({ locale }: { locale: string }) {
   const te = useTranslations("error");
@@ -88,23 +88,11 @@ export function InitPlay({ locale }: { locale: string }) {
     const q = getQueryOptions();
     setQueryOptions(q);
 
-    let cid: string | undefined = undefined;
-    let lvIndex: number | undefined = undefined;
-
     const session = getSession(q.sid);
     // history.replaceState(null, "", location.pathname);
-    if (session !== null) {
-      cid = session.cid;
-      lvIndex = session.lvIndex;
-      setChartBrief(session.brief);
-      setEditing(!!session.editing);
-    } else {
-      if (q.cid) {
-        cid = q.cid;
-        lvIndex = q.lvIndex;
-        fetchBrief(q.cid!, { onResult: (brief) => setChartBrief(brief) });
-        setEditing(false);
-      }
+    if (session === null) {
+      setErrorMsg(te("noSession"));
+      return;
     }
     // document.title =
     //   (session.editing ? "(テストプレイ) " : "") +
@@ -113,28 +101,34 @@ export function InitPlay({ locale }: { locale: string }) {
 
     Sentry.setContext("play.init", {
       ...q,
-      cid,
-      lvIndex,
+      cid: session.cid,
+      lvIndex: session.lvIndex,
     });
-    setCid(cid);
-    setLvIndex(lvIndex);
+    setCid(session.cid);
+    setLvIndex(session.lvIndex);
+    setChartBrief(session.brief);
+    setEditing(session.editing);
 
-    if (session?.level) {
+    if (session.editing) {
       setChartSeq(loadChart(session.level));
       setErrorMsg(undefined);
-    } else if (cid !== undefined && lvIndex !== undefined) {
+    } else {
       fetchBackend()
-        .url(`/api/playFile/${cid}/${lvIndex}`)
-        .options({ cache: "no-store" })
+        .url(`/api/playFile/${session.cid}/${session.lvIndex}`)
+        .headers({ "If-Match": `"${session.brief.etag}"`, "If-None-Match": `"${session.brief.etag}"` })
         .get()
         .badRequest(markAsExpected)
         .notFound(markAsExpected)
+        .error(412, (e) => {
+          refreshBrief(session.cid);
+          markAsExpected(e);
+        })
         .arrayBuffer((buf) => {
           currentChartVer satisfies 16; // update the code below when chart version is bumped
           const seq = msgpack.decode(buf) as Level6Play | Level15Play;
           console.log("seq.ver", seq.ver);
           if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
-            addRecent("play", cid ?? "");
+            addRecent("play", session.cid ?? "");
             updatePlayCountForReview();
             return { seq: loadChart(seq), error: undefined };
           } else {
@@ -147,14 +141,12 @@ export function InitPlay({ locale }: { locale: string }) {
         })
         .catch((e: unknown) => ({
           seq: undefined,
-          error: captureAndWrap(e, { cid, lvIndex }),
+          error: captureAndWrap(e),
         }))
         .then(({ seq, error }) => {
           setChartSeq(seq);
           setErrorMsg(error);
         });
-    } else {
-      setErrorMsg(te("noSession"));
     }
   }, [te]);
 

--- a/frontend/app/[locale]/play/clientPage.tsx
+++ b/frontend/app/[locale]/play/clientPage.tsx
@@ -154,18 +154,22 @@ export function InitPlay({ locale }: { locale: string }) {
           .then(async (res) => {
             const buf = await res.clone().arrayBuffer();
             currentChartVer satisfies 16; // update the code below when chart version is bumped
-            const seq = msgpack.decode(buf) as Level6Play | Level15Play;
-            console.log("seq.ver", seq.ver);
-            if (seq.ver === 6 || seq.ver === 15 || seq.ver === 16) {
+            const playFile = msgpack.decode(buf) as Level6Play | Level15Play;
+            console.log("playFile.ver", playFile.ver);
+            if (
+              playFile.ver === 6 ||
+              playFile.ver === 15 ||
+              playFile.ver === 16
+            ) {
               addRecent("play", session.cid ?? "");
               updatePlayCountForReview();
-              await cache?.put(url, res);
-              return { seq: loadChart(seq), error: undefined };
+              cache?.put(url, res);
+              return { seq: loadChart(playFile), error: undefined };
             } else {
-              // seq satisfies never;
+              // playFile satisfies never;
               return {
                 seq: undefined,
-                error: te("chartVersion", { ver: (seq as any)?.ver }),
+                error: te("chartVersion", { ver: (playFile as any)?.ver }),
               };
             }
           })

--- a/frontend/app/[locale]/play/queryOption.ts
+++ b/frontend/app/[locale]/play/queryOption.ts
@@ -6,9 +6,6 @@ boolean値については、 0, 空文字, 未指定 をfalse、それ以外をt
 export interface QueryOptions {
   // session idで譜面を指定
   sid?: number;
-  // sidの代わりにcidとlvIndexで譜面を指定することも可能
-  cid?: string;
-  lvIndex?: number;
 
   fps?: boolean; // fps表示
   speed?: boolean; // 音符の速度変化を表示 (ver13以降のなめらか速度変化に対応していません)
@@ -30,8 +27,6 @@ export function getQueryOptions(): QueryOptions {
   );
   return {
     sid: q.has("sid") ? Number(q.get("sid")) : undefined,
-    cid: q.get("cid") ?? undefined,
-    lvIndex: q.has("lvindex") ? Number(q.get("lvindex")) : undefined,
     fps: toBoolean(q.get("fps")),
     speed: toBoolean(q.get("speed")),
     result: toBoolean(q.get("result")),

--- a/frontend/app/[locale]/play/session.ts
+++ b/frontend/app/[locale]/play/session.ts
@@ -1,12 +1,20 @@
 import { ChartBrief, LevelPlay } from "@falling-nikochan/chart";
 
-export interface SessionData {
-  cid?: string;
-  lvIndex: number;
-  brief: ChartBrief;
-  level?: LevelPlay;
-  editing?: boolean;
-}
+export type SessionData =
+  | {
+      cid?: string;
+      lvIndex: number;
+      brief: ChartBrief;
+      level: LevelPlay;
+      editing: true;
+    }
+  | {
+      cid: string;
+      lvIndex: number;
+      brief: ChartBrief & { etag: string };
+      editing: false;
+    };
+
 // プレイボタンを押した時にlocalStorageに保存し、sessionIdを返す
 // share->play では押すたびにidを発行、edit->playでは使い回し
 // localStorageのsessionは多くても1回しか呼ばれないので、容量節約のため定期的に消す

--- a/frontend/app/[locale]/share/placeholder/clientPage.tsx
+++ b/frontend/app/[locale]/share/placeholder/clientPage.tsx
@@ -21,6 +21,7 @@ import { PCHeader2 } from "@/common/header.js";
 import { Features, PoliciesAndLinks } from "@/clientPage.js";
 import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
 import * as v from "valibot";
+import { etagContentRegex } from "@/common/briefCache.js";
 
 const dummyBrief = {
   title: "placeholder",
@@ -53,7 +54,9 @@ export default function ShareChart(props: Props) {
   const { locale } = props;
   const [cid, setCId] = useState<string>("");
   // const { res, brief } = await getBrief(cid, true);
-  const [brief, setBrief] = useState<ChartBrief | null>(null);
+  const [brief, setBrief] = useState<(ChartBrief & { etag: string }) | null>(
+    null
+  );
   const [record, setRecord] = useState<RecordGetSummary[] | Error | null>(null);
   const [sharedResult, setSharedResult] = useState<ResultParams | null>(null);
 
@@ -62,16 +65,23 @@ export default function ShareChart(props: Props) {
     setCId(cid);
     const searchParams = new URLSearchParams(window.location.search);
     let brief: ChartBrief;
+    let etag: string;
     if (process.env.NODE_ENV === "development") {
       brief = dummyBrief;
+      etag = "";
     } else {
       brief = JSON.parse(
         document
           .querySelector('meta[name="nikochanSharingBrief"]')!
           .getAttribute("content")!
       );
+      etag =
+        document
+          .querySelector('meta[name="nikochanSharingETag"]')!
+          .getAttribute("content")
+          ?.match(etagContentRegex)?.[0] ?? "";
     }
-    setBrief(brief);
+    setBrief({ ...brief, etag });
     document.title = titleShare(t, cid, brief);
     const titleUpdate = setInterval(() => {
       // Next.jsが元のタイトルに戻してしまう場合があるので、再度上書き

--- a/frontend/app/[locale]/share/placeholder/page.tsx
+++ b/frontend/app/[locale]/share/placeholder/page.tsx
@@ -14,7 +14,10 @@ export async function generateMetadata({ params }: MetadataProps) {
         "application/json+oembed": "https://placeholder_oembed/json",
         "text/xml+oembed": "https://placeholder_oembed/xml",
       },
-      custom: { nikochanSharingBrief: "PLACEHOLDER_BRIEF" },
+      custom: {
+        nikochanSharingBrief: "PLACEHOLDER_BRIEF",
+        nikochanSharingETag: "PLACEHOLDER_ETAG",
+      },
     }
   );
 }

--- a/frontend/app/[locale]/share/placeholder/playOption.tsx
+++ b/frontend/app/[locale]/share/placeholder/playOption.tsx
@@ -33,7 +33,7 @@ import { formatError } from "@/common/fetch";
 interface Props {
   locale: string;
   cid: string;
-  brief: ChartBrief;
+  brief: ChartBrief & { etag: string };
   record: RecordGetSummary[] | Error | null;
 }
 export function PlayOption(props: Props) {
@@ -156,6 +156,7 @@ export function PlayOption(props: Props) {
                 cid: props.cid,
                 lvIndex: selectedLevel,
                 brief: props.brief,
+                editing: false as const,
               });
               if (isStandalone() || isInsideFrame()) {
                 router.push(`/${props.locale}/play?sid=${sessionId}`);

--- a/frontend/app/[locale]/share/placeholder/shareBox.tsx
+++ b/frontend/app/[locale]/share/placeholder/shareBox.tsx
@@ -20,6 +20,11 @@ import { ButtonHighlight } from "@/common/button.jsx";
 import { captureAndWrap, fetchBackend } from "@/common/fetch.js";
 import * as v from "valibot";
 import { markAsExpected } from "@/common/apiError.js";
+import {
+  briefIsStale,
+  briefStaleKey,
+  fetchBrief,
+} from "@/common/briefCache.js";
 
 const YtMetaSchema = () =>
   v.object({
@@ -30,7 +35,7 @@ type YtMeta = v.InferOutput<ReturnType<typeof YtMetaSchema>>;
 
 interface Props {
   cid: string | undefined;
-  brief: ChartBrief | null;
+  brief: (ChartBrief & { etag: string }) | null;
   record: RecordGetSummary[] | Error | null;
   sharedResult?: ResultParams | null;
   locale: string;
@@ -39,7 +44,39 @@ interface Props {
 }
 export function ShareBox(props: Props) {
   const t = useTranslations("share");
-  const { cid, brief, sharedResult, locale } = props;
+  const { cid, brief: propBrief, sharedResult, locale } = props;
+
+  const [refreshedBrief, setRefreshedBrief] = useState<
+    (ChartBrief & { etag: string }) | null
+  >(null);
+  const brief = refreshedBrief ?? propBrief;
+  useEffect(() => {
+    const update = () => {
+      if (cid && briefIsStale(cid)) {
+        fetchBrief(cid, {
+          onResult: (brief) => {
+            setRefreshedBrief(brief);
+          },
+        });
+      } else {
+        setRefreshedBrief(null);
+      }
+    };
+    const storageUpdate = (e: StorageEvent) => {
+      if (cid && e.key === briefStaleKey(cid)) {
+        update();
+      }
+    };
+    update();
+    window.addEventListener("storage", storageUpdate);
+    window.addEventListener("visibilitychange", update); // 別タブからもどってきたとき
+    window.addEventListener("popstate", update); // router.push()からもどってきたとき
+    return () => {
+      window.removeEventListener("storage", storageUpdate);
+      window.removeEventListener("visibilitychange", update);
+      window.removeEventListener("popstate", update);
+    };
+  }, [cid]);
 
   const [updatedAt, setUpdatedAt] = useState<string>("");
 

--- a/frontend/app/[locale]/topDemo.tsx
+++ b/frontend/app/[locale]/topDemo.tsx
@@ -5,7 +5,6 @@ import { useFlash } from "./play/useFlash";
 import useGameLogic from "./play/gameLogic";
 import {
   ChartBrief,
-  ChartSeqData,
   currentChartVer,
   Level15Play,
   Level6Play,

--- a/frontend/app/[locale]/topDemo.tsx
+++ b/frontend/app/[locale]/topDemo.tsx
@@ -9,6 +9,7 @@ import { useColorThief } from "./common/colorThief";
 import clsx from "clsx/lite";
 import { ChartListItem } from "./main/chartList";
 import { fetchBackend } from "./common/fetch";
+import { fetchBrief } from "./common/briefCache";
 
 export interface DemoChart {
   cid: string;
@@ -129,14 +130,9 @@ export function DemoDetail(
   const [brief, setBrief] = useState<ChartBrief>();
   useEffect(() => {
     if (!brief && props.cid) {
-      fetch(process.env.BACKEND_PREFIX + `/api/brief/${props.cid}`).then(
-        (res) => {
-          if (res.ok) {
-            res.json().then((brief: ChartBrief) => setBrief(brief));
-          }
-        },
-        () => undefined
-      );
+      fetchBrief(props.cid, {
+        onResult: (brief) => setBrief(brief),
+      });
     }
   }, [brief, props.cid]);
 

--- a/frontend/app/[locale]/topDemo.tsx
+++ b/frontend/app/[locale]/topDemo.tsx
@@ -3,7 +3,14 @@ import { useRealFPS } from "./common/fpsCalculator";
 import FallingWindow from "./play/fallingWindow";
 import { useFlash } from "./play/useFlash";
 import useGameLogic from "./play/gameLogic";
-import { ChartBrief, ChartSeqData } from "@falling-nikochan/chart";
+import {
+  ChartBrief,
+  ChartSeqData,
+  currentChartVer,
+  Level15Play,
+  Level6Play,
+  loadChart,
+} from "@falling-nikochan/chart";
 import * as msgpack from "@msgpack/msgpack";
 import { useColorThief } from "./common/colorThief";
 import clsx from "clsx/lite";
@@ -77,18 +84,28 @@ export function TopDemo(
       props.offset !== undefined
     ) {
       fetchBackend()
-        .get(`/api/seqFile/${props.cid}/${props.lvIndex}`)
+        .get(`/api/playFile/${props.cid}/${props.lvIndex}`)
         .arrayBuffer((buf) => {
-          const seq = msgpack.decode(buf) as ChartSeqData;
-          resetNotesAll(
-            seq.notes.map((n) => ({
-              ...n,
-              done: 0,
-              bigDone: false,
-            })),
-            props.offset! - seq.offset
-          );
-          currentTimeSec.current = props.offset! - seq.offset;
+          currentChartVer satisfies 16; // update the code below when chart version is bumped
+          const playFile = msgpack.decode(buf) as Level6Play | Level15Play;
+          if (
+            playFile.ver === 6 ||
+            playFile.ver === 15 ||
+            playFile.ver === 16
+          ) {
+            const seq = loadChart(playFile);
+            resetNotesAll(
+              seq.notes.map((n) => ({
+                ...n,
+                done: 0,
+                bigDone: false,
+              })),
+              props.offset! - seq.offset
+            );
+            currentTimeSec.current = props.offset! - seq.offset;
+          } else {
+            // ignore
+          }
         });
     }
   }, [notesAll, resetNotesAll, props.cid, props.lvIndex, props.offset]);

--- a/i18n/en/error.js
+++ b/i18n/en/error.js
@@ -21,6 +21,8 @@ export default {
       unsupportedChartVersion: "Unsupported chart data version",
       // 410
       noLongerSupportedAPI: "This API is no longer supported",
+      // 412
+      etagMismatch: "Chart data has been updated. Please try again",
       // 413
       tooLargeFile: "File size is too large",
       tooManyEvent: "Too many events in the chart data",

--- a/i18n/ja/error.js
+++ b/i18n/ja/error.js
@@ -21,6 +21,8 @@ export default {
       unsupportedChartVersion: "サポートされていない譜面バージョンです",
       // 410
       noLongerSupportedAPI: "サポートされていない API です",
+      // 412
+      etagMismatch: "譜面データが更新されています。もう一度やり直してください",
       // 413
       tooLargeFile: "ファイルサイズが大きすぎます",
       tooManyEvent: "譜面データ内のイベント数が多すぎます",

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -35,12 +35,13 @@ const apiApp = async (config: {
   const prodCors = cors({
     origin: "*",
     credentials: false,
-    exposeHeaders: ["Retry-After"],
+    // allowHeaders は指定しなければcors middlewareが自動ですべてのヘッダーを許可する
+    exposeHeaders: ["*"],
   });
   const devCors = cors({
     origin: (origin) => origin,
     credentials: true,
-    exposeHeaders: ["Retry-After"],
+    exposeHeaders: ["*"],
   });
   const apiApp = new Hono<{
     Bindings: Bindings;

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -96,7 +96,7 @@ const apiApp = async (config: {
     )
     .use("/*", decompressMiddleware)
     .use("/*", config.dbMiddleware)
-    .route("/brief", briefApp)
+    .route("/brief", await briefApp())
     .route("/ytMeta", ytMetaApp)
     .route(
       "/chartFile",

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -24,6 +24,7 @@ import oembedApp from "./oembed.js";
 import decompressMiddleware from "./decompress.js";
 import { env } from "hono/adapter";
 import { Db } from "mongodb";
+import { etag } from "hono/etag";
 dotenv.config({ path: join(dirname(process.cwd()), ".env") });
 
 export { getBrief } from "./brief.js";
@@ -83,6 +84,7 @@ const apiApp = async (config: {
         }
       }
     })
+    .use(etag())
     .use(
       "/*",
       bodyLimit({

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -25,7 +25,6 @@ const briefApp = new Hono<{
   "/:cid",
   cache({
     cacheName: "api-brief",
-    cacheControl: `max-age=${CACHE_MAX_AGE}`,
   }),
   describeRoute({
     description: "Get brief information about the chart.",

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -87,7 +87,7 @@ const briefApp = async () =>
 
 export async function getBrief(db: Db, cid: string) {
   const entry = await getChartEntryCompressed(db, cid, null);
-  return entryToBrief(entry);
+  return { brief: entryToBrief(entry), etag: await calcETag(entry) };
 }
 
 export default briefApp;

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -1,6 +1,12 @@
 import { Hono } from "hono";
 import { cache } from "hono/cache";
-import { entryToBrief, getChartEntryCompressed } from "./chart.js";
+import {
+  calcETag,
+  entryToBrief,
+  etagHeaderDoc,
+  getChartEntryCompressed,
+  ifNoneMatchHeaderDoc,
+} from "./chart.js";
 import { Db } from "mongodb";
 import { Bindings, cacheControl } from "../env.js";
 import { env } from "hono/adapter";
@@ -28,6 +34,7 @@ const briefApp = new Hono<{
   }),
   describeRoute({
     description: "Get brief information about the chart.",
+    parameters: [ifNoneMatchHeaderDoc],
     responses: {
       200: {
         description: "Successful response",
@@ -41,7 +48,11 @@ const briefApp = new Hono<{
             description: `max-age=${CACHE_MAX_AGE}`,
             schema: { type: "string" },
           },
+          ...etagHeaderDoc,
         },
+      },
+      304: {
+        description: "No content if If-None-Match header matches",
       },
       400: {
         description: "invalid chart id",
@@ -64,8 +75,11 @@ const briefApp = new Hono<{
   validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
   async (c) => {
     const { cid } = c.req.valid("param");
-    return c.json(await getBrief(await c.get("db")(), cid), 200, {
+    const db = await c.get("db")();
+    const entry = await getChartEntryCompressed(db, cid, null);
+    return c.json(entryToBrief(entry), 200, {
       "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+      "ETag": await calcETag(entry),
     });
   }
 );

--- a/route/src/api/brief.ts
+++ b/route/src/api/brief.ts
@@ -22,67 +22,68 @@ import {
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 600;
 
-const briefApp = new Hono<{
-  Bindings: Bindings;
-  Variables: { db: () => Promise<Db> };
-}>({
-  strict: false,
-}).get(
-  "/:cid",
-  cache({
-    cacheName: "api-brief",
-  }),
-  describeRoute({
-    description: "Get brief information about the chart.",
-    parameters: [ifNoneMatchHeaderDoc],
-    responses: {
-      200: {
-        description: "Successful response",
-        content: {
-          "application/json": {
-            schema: docRefs("ChartBrief"),
+const briefApp = async () =>
+  new Hono<{
+    Bindings: Bindings;
+    Variables: { db: () => Promise<Db> };
+  }>({
+    strict: false,
+  }).get(
+    "/:cid",
+    cache({
+      cacheName: "api-brief",
+    }),
+    describeRoute({
+      description: "Get brief information about the chart.",
+      parameters: [ifNoneMatchHeaderDoc],
+      responses: {
+        200: {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: docRefs("ChartBrief"),
+            },
+          },
+          headers: {
+            "Cache-Control": {
+              description: `max-age=${CACHE_MAX_AGE}`,
+              schema: { type: "string" },
+            },
+            ...etagHeaderDoc,
           },
         },
-        headers: {
-          "Cache-Control": {
-            description: `max-age=${CACHE_MAX_AGE}`,
-            schema: { type: "string" },
-          },
-          ...etagHeaderDoc,
+        304: {
+          description: "No content if If-None-Match header matches",
         },
-      },
-      304: {
-        description: "No content if If-None-Match header matches",
-      },
-      400: {
-        description: "invalid chart id",
-        content: {
-          "application/json": {
-            schema: resolver(await validationErrorSchema()),
+        400: {
+          description: "invalid chart id",
+          content: {
+            "application/json": {
+              schema: resolver(await validationErrorSchema()),
+            },
           },
         },
-      },
-      404: {
-        description: "chart id not found",
-        content: {
-          "application/json": {
-            schema: resolver(await errorLiteral("chartIdNotFound")),
+        404: {
+          description: "chart id not found",
+          content: {
+            "application/json": {
+              schema: resolver(await errorLiteral("chartIdNotFound")),
+            },
           },
         },
       },
-    },
-  }),
-  validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
-  async (c) => {
-    const { cid } = c.req.valid("param");
-    const db = await c.get("db")();
-    const entry = await getChartEntryCompressed(db, cid, null);
-    return c.json(entryToBrief(entry), 200, {
-      "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
-      "ETag": await calcETag(entry),
-    });
-  }
-);
+    }),
+    validator("param", v.object({ cid: CidSchema() }), sValidatorHook()),
+    async (c) => {
+      const { cid } = c.req.valid("param");
+      const db = await c.get("db")();
+      const entry = await getChartEntryCompressed(db, cid, null);
+      return c.json(entryToBrief(entry), 200, {
+        "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+        "ETag": await calcETag(entry),
+      });
+    }
+  );
 
 export async function getBrief(db: Db, cid: string) {
   const entry = await getChartEntryCompressed(db, cid, null);

--- a/route/src/api/chart.ts
+++ b/route/src/api/chart.ts
@@ -31,11 +31,12 @@ import {
   BPMChangeWithLua15,
   SpeedChangeWithLua15,
   SignatureWithLua15,
+  currentChartVer,
 } from "@falling-nikochan/chart";
 import * as v from "valibot";
 import { gzip, gunzip } from "node:zlib";
 import { promisify } from "node:util";
-import { Binary, Db } from "mongodb";
+import { Binary, Db, BSON } from "mongodb";
 import { HTTPException } from "hono/http-exception";
 import { randomBytes } from "node:crypto";
 import { normalizeEntry, YTDataEntry } from "./ytData.js";
@@ -93,10 +94,14 @@ export async function getChartEntryCompressed(
     throw new HTTPException(401, { message: "badPassword" });
   }
 }
+/**
+ * ifMatchが文字列で一致しなかったら412を返す、undefinedならチェックを行わない
+ */
 export async function getChartEntry(
   db: Db,
   cid: string,
-  p: Passwd | null
+  p: Passwd | null,
+  ifMatch: string | undefined
 ): Promise<{
   entry: ChartEntry;
   chart:
@@ -110,13 +115,19 @@ export async function getChartEntry(
     | Chart13Edit
     | Chart14Edit
     | Chart15;
+  etag: string;
 }> {
   const entryCompressed = await getChartEntryCompressed(db, cid, p);
+
+  const etag = await calcETag(entryCompressed);
+  if (ifMatch && ifMatch !== etag) {
+    throw new HTTPException(412, { message: "etagMismatch" });
+  }
 
   const entry = await unzipEntry(entryCompressed);
   const chart = entryToChart(entry);
 
-  return { entry, chart };
+  return { entry, chart, etag };
 }
 
 export function getPUserHash(
@@ -259,6 +270,32 @@ export type ChartEntry = ChartEntryCompressed &
     | { ver: 14; levels: ChartLevelCore14[] }
     | { ver: 15 | 16; levels: ChartLevelCore15[] }
   );
+
+export async function calcETag(entry: ChartEntryCompressed) {
+  const bsonBuffer = BSON.serialize(entry);
+  const hashBuffer = await crypto.subtle.digest("SHA-1", bsonBuffer);
+  const hashBase64 = Buffer.from(hashBuffer).toString("base64");
+  return `"${currentChartVer}-${hashBase64}"`;
+}
+export const etagHeaderDoc = {
+  "ETag": {
+    description: `"${currentChartVer}-(hash of chart data)"`,
+    schema: { type: "string" },
+  },
+} as const;
+export const ifMatchHeaderDoc = {
+  name: "If-Match",
+  in: "header",
+  description:
+    "If strong ETag of chart data is given and does not match, it returns 412.",
+  schema: { type: "string" },
+} as const;
+export const ifNoneMatchHeaderDoc = {
+  name: "If-None-Match",
+  in: "header",
+  description: "If ETag of chart data is given and matches, it returns 304.",
+  schema: { type: "string" },
+} as const;
 
 export async function unzipEntry(
   entry: ChartEntryCompressed

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -151,6 +151,10 @@ const chartFileApp = async (config: {
                 description: "Filename with extension of .fn{ver}.mpk",
                 schema: { type: "string" },
               },
+              "Cache-Control": {
+                description: `private, no-cache`,
+                schema: { type: "string" },
+              },
             },
           },
           400: {
@@ -204,6 +208,7 @@ const chartFileApp = async (config: {
         return c.body(new Blob([msgpack.encode(chart)]).stream(), 200, {
           "Content-Type": "application/vnd.msgpack",
           "Content-Disposition": `attachment; filename="${filename}"`,
+          "Cache-Control": "private, no-cache",
         });
       }
     )

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -15,11 +15,16 @@ import {
 } from "@falling-nikochan/chart";
 import { Db } from "mongodb";
 import {
+  calcETag,
   ChartEntry,
   ChartEntryCompressed,
   chartToEntry,
   entryToChart,
+  etagHeaderDoc,
   getChartEntry,
+  getChartEntryCompressed,
+  ifMatchHeaderDoc,
+  ifNoneMatchHeaderDoc,
   zipEntry,
 } from "./chart.js";
 import { Bindings, secretSalt } from "../env.js";
@@ -67,6 +72,7 @@ interface ChartFileAppVars {
   ip: string;
   entry: ChartEntry;
   chart: ReturnType<typeof entryToChart>;
+  etag: string;
   db: () => Promise<Db>;
   pSecretSalt: string;
 }
@@ -113,18 +119,24 @@ const chartFileApp = async (config: {
           );
         }
 
-        let { entry, chart } = await getChartEntry(db, cid, {
-          bypass,
-          rawPasswd: p,
-          v9PasswdHash: ph,
-          v9UserSalt,
-          pSecretSalt,
-        });
+        const { entry, chart, etag } = await getChartEntry(
+          db,
+          cid,
+          {
+            bypass,
+            rawPasswd: p,
+            v9PasswdHash: ph,
+            v9UserSalt,
+            pSecretSalt,
+          },
+          c.req.header("If-Match")
+        );
         // 必要なデータをコンテキストに保存
         c.set("cid", cid);
         c.set("ip", ip);
         c.set("entry", entry);
         c.set("chart", chart);
+        c.set("etag", etag);
         c.set("pSecretSalt", pSecretSalt);
         await next();
       }
@@ -137,7 +149,7 @@ const chartFileApp = async (config: {
           "The chart data format can be either Chart4, Chart5, Chart6, Chart7, Chart8Edit, Chart9Edit, Chart11Edit, Chart13Edit or Chart14Edit, " +
           `while this documentation only describes Chart15 format. ` +
           `The chart editor can import chart data from the API.`,
-        parameters: [passwdHeaderDoc],
+        parameters: [passwdHeaderDoc, ifNoneMatchHeaderDoc, ifMatchHeaderDoc],
         responses: {
           200: {
             description: "Successful response",
@@ -155,7 +167,11 @@ const chartFileApp = async (config: {
                 description: `private, no-cache`,
                 schema: { type: "string" },
               },
+              ...etagHeaderDoc,
             },
+          },
+          304: {
+            description: "No content if If-None-Match header matches",
           },
           400: {
             description: "invalid chart id or parameter",
@@ -186,6 +202,14 @@ const chartFileApp = async (config: {
               },
             },
           },
+          412: {
+            description: "ETag does not match with given If-Match header",
+            content: {
+              "application/json": {
+                schema: resolver(await errorLiteral("etagMismatch")),
+              },
+            },
+          },
           429: {
             description: "Rate limited",
             content: {
@@ -209,6 +233,7 @@ const chartFileApp = async (config: {
           "Content-Type": "application/vnd.msgpack",
           "Content-Disposition": `attachment; filename="${filename}"`,
           "Cache-Control": "private, no-cache",
+          "ETag": c.get("etag"),
         });
       }
     )
@@ -217,7 +242,7 @@ const chartFileApp = async (config: {
       describeRoute({
         description:
           "Soft delete a chart. The chart will be marked as deleted and won't appear in searches or latest/popular lists. Requires a password (either p/ph query or Authorization header).",
-        parameters: [passwdHeaderDoc],
+        parameters: [passwdHeaderDoc, ifMatchHeaderDoc],
         responses: {
           204: {
             description: "No content, chart deleted successfully",
@@ -248,6 +273,14 @@ const chartFileApp = async (config: {
             content: {
               "application/json": {
                 schema: resolver(await errorLiteral("chartIdNotFound")),
+              },
+            },
+          },
+          412: {
+            description: "ETag does not match with given If-Match header",
+            content: {
+              "application/json": {
+                schema: resolver(await errorLiteral("etagMismatch")),
               },
             },
           },
@@ -301,6 +334,7 @@ const chartFileApp = async (config: {
         },
         parameters: [
           passwdHeaderDoc,
+          ifMatchHeaderDoc,
           {
             name: "Content-Encoding",
             in: "header",
@@ -311,6 +345,9 @@ const chartFileApp = async (config: {
         responses: {
           204: {
             description: "No content, chart updated successfully",
+            headers: {
+              ...etagHeaderDoc,
+            },
           },
           400: {
             description:
@@ -347,6 +384,14 @@ const chartFileApp = async (config: {
             content: {
               "application/json": {
                 schema: resolver(await errorLiteral("oldChartVersion")),
+              },
+            },
+          },
+          412: {
+            description: "ETag does not match with given If-Match header",
+            content: {
+              "application/json": {
+                schema: resolver(await errorLiteral("etagMismatch")),
               },
             },
           },
@@ -501,7 +546,10 @@ const chartFileApp = async (config: {
             ),
           }
         );
-        return c.body(null, 204);
+        const newEntry = await getChartEntryCompressed(db, cid, null);
+        return c.body(null, 204, {
+          "ETag": await calcETag(newEntry),
+        });
       }
     );
 

--- a/route/src/api/hashPasswd.ts
+++ b/route/src/api/hashPasswd.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { Bindings, cacheControl } from "../env.js";
+import { Bindings } from "../env.js";
 import { env } from "hono/adapter";
 import { getCookie, setCookie } from "hono/cookie";
 import { getChartEntryCompressed, getPUserHash } from "./chart.js";
@@ -49,6 +49,10 @@ const hashPasswdApp = new Hono<{
           "Set-Cookie": {
             description:
               "Sets the pUserSalt cookie if it was not present in the request.",
+            schema: { type: "string" },
+          },
+          "Cache-Control": {
+            description: `no-store`,
             schema: { type: "string" },
           },
         },
@@ -146,7 +150,7 @@ const hashPasswdApp = new Hono<{
     });
     if (entry.pServerHash) {
       return c.text(await getPUserHash(entry.pServerHash, pUserSalt), 200, {
-        "cache-control": cacheControl(env(c), null),
+        "cache-control": "no-store",
       });
     } else {
       throw new HTTPException(400, { message: "noPasswd" });

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -12,7 +12,14 @@ import {
 } from "@falling-nikochan/chart";
 import { getIp, updateIp } from "./dbRateLimit.js";
 import { Db } from "mongodb";
-import { ChartEntryCompressed, chartToEntry, zipEntry } from "./chart.js";
+import {
+  calcETag,
+  ChartEntryCompressed,
+  chartToEntry,
+  etagHeaderDoc,
+  getChartEntryCompressed,
+  zipEntry,
+} from "./chart.js";
 import { Context, Hono } from "hono";
 import { Bindings, secretSalt } from "../env.js";
 import { env } from "hono/adapter";
@@ -64,6 +71,9 @@ const newChartFileApp = async (config: {
             "application/json": {
               schema: resolver(v.object({ cid: CidSchema() })),
             },
+          },
+          headers: {
+            ...etagHeaderDoc,
           },
         },
         400: {
@@ -209,7 +219,10 @@ const newChartFileApp = async (config: {
           )
         );
 
-      return c.json({ cid: cid });
+      const newEntry = await getChartEntryCompressed(db, cid, null);
+      return c.json({ cid: cid }, 200, {
+        "ETag": await calcETag(newEntry),
+      });
     }
   );
 

--- a/route/src/api/oembed.ts
+++ b/route/src/api/oembed.ts
@@ -52,7 +52,6 @@ const oembedApp = new Hono<{
   "/",
   cache({
     cacheName: "api-oembed",
-    cacheControl: `max-age=${CACHE_MAX_AGE}`,
   }),
   describeRoute({
     hide: true,

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -1,6 +1,11 @@
 import * as msgpack from "@msgpack/msgpack";
 import { Db } from "mongodb";
-import { getChartEntry } from "./chart.js";
+import {
+  etagHeaderDoc,
+  getChartEntry,
+  ifMatchHeaderDoc,
+  ifNoneMatchHeaderDoc,
+} from "./chart.js";
 import { Bindings } from "../env.js";
 import { Hono } from "hono";
 import {
@@ -33,6 +38,7 @@ const playFileApp = new Hono<{
       "Gets level data in MessagePack format, which is only used for playing the chart, not for editing. " +
       "Note that the level data is either in Level6Play or Level15Play format, " +
       `while this documentation only describes Level15Play format. `,
+    parameters: [ifNoneMatchHeaderDoc, ifMatchHeaderDoc],
     responses: {
       200: {
         description: "chart file in MessagePack format.",
@@ -50,7 +56,11 @@ const playFileApp = new Hono<{
             description: `no-cache`,
             schema: { type: "string" },
           },
+          ...etagHeaderDoc,
         },
+      },
+      304: {
+        description: "No content if If-None-Match header matches",
       },
       400: {
         description: "invalid chart id",
@@ -70,6 +80,14 @@ const playFileApp = new Hono<{
           },
         },
       },
+      412: {
+        description: "ETag does not match with given If-Match header",
+        content: {
+          "application/json": {
+            schema: resolver(await errorLiteral("etagMismatch")),
+          },
+        },
+      },
     },
   }),
   validator(
@@ -84,7 +102,12 @@ const playFileApp = new Hono<{
     const { cid, lvIndex } = c.req.valid("param");
 
     const db = await c.get("db")();
-    let { chart } = await getChartEntry(db, cid, null);
+    let { chart, etag } = await getChartEntry(
+      db,
+      cid,
+      null,
+      c.req.header("If-Match")
+    );
 
     let level: Level6Play | Level15Play;
     switch (chart.ver) {
@@ -144,6 +167,7 @@ const playFileApp = new Hono<{
       "Content-Type": "application/vnd.msgpack",
       "Content-Disposition": `attachment; filename="${filename}"`,
       "Cache-Control": "no-cache",
+      "ETag": etag,
     });
   }
 );

--- a/route/src/api/playFile.ts
+++ b/route/src/api/playFile.ts
@@ -46,6 +46,10 @@ const playFileApp = new Hono<{
             description: "Filename with extension of .fn{ver}p.mpk",
             schema: { type: "string" },
           },
+          "Cache-Control": {
+            description: `no-cache`,
+            schema: { type: "string" },
+          },
         },
       },
       400: {
@@ -139,6 +143,7 @@ const playFileApp = new Hono<{
     return c.body(new Blob([msgpack.encode(level)]).stream(), 200, {
       "Content-Type": "application/vnd.msgpack",
       "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-cache",
     });
   }
 );

--- a/route/src/api/record.ts
+++ b/route/src/api/record.ts
@@ -47,7 +47,6 @@ const recordApp = async (config: {
       "/:cid",
       cache({
         cacheName: "api-record",
-        cacheControl: `max-age=${CACHE_MAX_AGE}`,
       }),
       describeRoute({
         description: "Get play record summary for the chart.",

--- a/route/src/api/search.ts
+++ b/route/src/api/search.ts
@@ -62,7 +62,6 @@ const searchApp = new Hono<{
   "/",
   cache({
     cacheName: "api-search",
-    cacheControl: `max-age=${CACHE_MAX_AGE}`,
   }),
   describeRoute({
     description:

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -1,6 +1,11 @@
 import * as msgpack from "@msgpack/msgpack";
 import { Db } from "mongodb";
-import { getChartEntry } from "./chart.js";
+import {
+  etagHeaderDoc,
+  getChartEntry,
+  ifMatchHeaderDoc,
+  ifNoneMatchHeaderDoc,
+} from "./chart.js";
 import { Bindings } from "../env.js";
 import { Hono } from "hono";
 import {
@@ -31,6 +36,7 @@ const seqFileApp = new Hono<{
   describeRoute({
     description:
       "Gets chart sequence data in MessagePack format, which is used for playing the chart.",
+    parameters: [ifNoneMatchHeaderDoc, ifMatchHeaderDoc],
     responses: {
       200: {
         description: "chart sequence data in MessagePack format.",
@@ -48,7 +54,11 @@ const seqFileApp = new Hono<{
             description: `no-cache`,
             schema: { type: "string" },
           },
+          ...etagHeaderDoc,
         },
+      },
+      304: {
+        description: "No content if If-None-Match header matches",
       },
       400: {
         description: "invalid chart id",
@@ -68,6 +78,14 @@ const seqFileApp = new Hono<{
           },
         },
       },
+      412: {
+        description: "ETag does not match with given If-Match header",
+        content: {
+          "application/json": {
+            schema: resolver(await errorLiteral("etagMismatch")),
+          },
+        },
+      },
     },
   }),
   validator(
@@ -82,7 +100,12 @@ const seqFileApp = new Hono<{
     const { cid, lvIndex } = c.req.valid("param");
 
     const db = await c.get("db")();
-    let { chart } = await getChartEntry(db, cid, null);
+    let { chart, etag } = await getChartEntry(
+      db,
+      cid,
+      null,
+      c.req.header("If-Match")
+    );
 
     let seqData: ChartSeqData;
     switch (chart.ver) {
@@ -142,6 +165,7 @@ const seqFileApp = new Hono<{
       "Content-Type": "application/vnd.msgpack",
       "Content-Disposition": `attachment; filename="${filename}"`,
       "Cache-Control": "no-cache",
+      "ETag": etag,
     });
   }
 );

--- a/route/src/api/seqFile.ts
+++ b/route/src/api/seqFile.ts
@@ -44,6 +44,10 @@ const seqFileApp = new Hono<{
             description: "Filename with extension of .fnseq.mpk",
             schema: { type: "string" },
           },
+          "Cache-Control": {
+            description: `no-cache`,
+            schema: { type: "string" },
+          },
         },
       },
       400: {
@@ -137,6 +141,7 @@ const seqFileApp = new Hono<{
     return c.body(new Blob([msgpack.encode(seqData)]).stream(), 200, {
       "Content-Type": "application/vnd.msgpack",
       "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-cache",
     });
   }
 );

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -26,7 +26,6 @@ const ytMetaApp = new Hono<{
   "/:cid",
   cache({
     cacheName: "api-ytMeta",
-    cacheControl: `max-age=${CACHE_MAX_AGE}`,
   }),
   describeRoute({
     description: "Get YouTube metadata about the chart.",

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -40,8 +40,10 @@ export function secretSalt(e: Bindings) {
   }
 }
 
-export function cacheControl(e: Bindings, age: number) {
-  if (e.API_CACHE_EDGE) {
+export function cacheControl(e: Bindings, age: number, private_?: boolean) {
+  if (private_) {
+    return `private, max-age=${age}, must-revalidate`;
+  } else if (e.API_CACHE_EDGE) {
     return `max-age=${age}, s-maxage=${age}, must-revalidate`;
   } else {
     return `max-age=${age}, must-revalidate`;

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -40,15 +40,11 @@ export function secretSalt(e: Bindings) {
   }
 }
 
-export function cacheControl(e: Bindings, age: number | null) {
-  if (age) {
-    if (e.API_CACHE_EDGE) {
-      return `max-age=${age}, s-maxage=${age}`;
-    } else {
-      return `max-age=${age}`;
-    }
+export function cacheControl(e: Bindings, age: number) {
+  if (e.API_CACHE_EDGE) {
+    return `max-age=${age}, s-maxage=${age}, must-revalidate`;
   } else {
-    return "no-store";
+    return `max-age=${age}, must-revalidate`;
   }
 }
 

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -42,7 +42,7 @@ const ChartBriefMinArraySchema = v.tuple([
 
 const ogApp = (config: {
   ImageResponse: any;
-  fetchBrief: (e: Bindings, cid: string) => Promise<ChartBrief>;
+  fetchBrief: (e: Bindings, cid: string) => Promise<{ brief: ChartBrief }>;
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
@@ -61,7 +61,7 @@ const ogApp = (config: {
       // /og/share/cid?brief=表示する全情報 で生成した画像を永久にキャッシュ
       // (vパラメータは /share でも追加されるけど)
       if (!c.req.query("brief")) {
-        const brief = await config.fetchBrief(env(c), cid);
+        const { brief } = await config.fetchBrief(env(c), cid);
         const lvType = levelTypes.indexOf(
           brief.levels.filter((l) => !l.unlisted).at(0)?.type || ""
         );

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -19,6 +19,9 @@ import { getColor } from "colorthief";
 import { adjustColor } from "./style.js";
 import * as v from "valibot";
 import { fetchError } from "../error.js";
+import { cache } from "hono/cache";
+
+const CACHE_MAX_AGE = 315360000;
 
 export interface ChartBriefMin {
   ytId: string;
@@ -43,6 +46,13 @@ const ogApp = (config: {
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
     .use("/*", cors({ origin: "*" }))
+    .use(
+      "/*",
+      cache({
+        cacheName: "og",
+        cacheControl: `max-age=${CACHE_MAX_AGE}`,
+      })
+    )
     .get("/:type/:cid", async (c) => {
       const cid = c.req.param("cid");
 
@@ -263,7 +273,7 @@ const ogApp = (config: {
       }) as Response;
       return c.body(imRes.body!, imRes.status as 200, {
         "Content-Type": imRes.headers.get("Content-Type") || "",
-        "Cache-Control": cacheControl(env(c), 315360000),
+        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
       });
     })
     .get("/:cid{[0-9]+}", (c) =>

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -50,7 +50,6 @@ const ogApp = (config: {
       "/*",
       cache({
         cacheName: "og",
-        cacheControl: `max-age=${CACHE_MAX_AGE}`,
       })
     )
     .get("/:type/:cid", async (c) => {

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -20,6 +20,7 @@ import { adjustColor } from "./style.js";
 import * as v from "valibot";
 import { fetchError } from "../error.js";
 import { cache } from "hono/cache";
+import { etag } from "hono/etag";
 
 const CACHE_MAX_AGE = 315360000;
 
@@ -46,6 +47,7 @@ const ogApp = (config: {
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
     .use("/*", cors({ origin: "*" }))
+    .use(etag())
     .use(
       "/*",
       cache({

--- a/route/src/rss.ts
+++ b/route/src/rss.ts
@@ -5,6 +5,7 @@ import { ChartEntryCompressed } from "./api/chart.js";
 import xmlbuilder2 from "xmlbuilder2";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import { Db } from "mongodb";
+import { cache } from "hono/cache";
 
 // Cache duration for RSS feed (in seconds) - 30 minutes
 const CACHE_MAX_AGE = 1800;
@@ -14,106 +15,114 @@ const RSS_ITEM_LIMIT = 25;
 const rssApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
   new Hono<{ Bindings: Bindings; Variables: { db: () => Promise<Db> } }>({
     strict: false,
-  }).get("/", config.dbMiddleware, async (c) => {
-    const t = await getTranslations("en", "share");
+  }).get(
+    "/",
+    cache({
+      cacheName: "rss",
+      cacheControl: `max-age=${CACHE_MAX_AGE}`,
+    }),
+    config.dbMiddleware,
+    async (c) => {
+      const t = await getTranslations("en", "share");
 
-    const db = await c.get("db")();
-    const charts = await db
-      .collection<ChartEntryCompressed>("chart")
-      .find({ published: true, deleted: false })
-      .sort({ updatedAt: -1 })
-      .limit(RSS_ITEM_LIMIT)
-      .project<{
-        cid: string;
-        title: string;
-        composer: string;
-        chartCreator: string;
-        updatedAt: number;
-      }>({
-        _id: 0,
-        cid: 1,
-        title: 1,
-        composer: 1,
-        chartCreator: 1,
-        updatedAt: 1,
-      })
-      .toArray();
+      const db = await c.get("db")();
+      const charts = await db
+        .collection<ChartEntryCompressed>("chart")
+        .find({ published: true, deleted: false })
+        .sort({ updatedAt: -1 })
+        .limit(RSS_ITEM_LIMIT)
+        .project<{
+          cid: string;
+          title: string;
+          composer: string;
+          chartCreator: string;
+          updatedAt: number;
+        }>({
+          _id: 0,
+          cid: 1,
+          title: 1,
+          composer: 1,
+          chartCreator: 1,
+          updatedAt: 1,
+        })
+        .toArray();
 
-    // xmlbuilder2でRSS XMLを構築
-    const doc = xmlbuilder2
-      .create({ version: "1.0", encoding: "UTF-8" })
-      .ele("rss", {
-        version: "2.0",
-        "xmlns:atom": "http://www.w3.org/2005/Atom",
-      })
-      .ele("channel");
+      // xmlbuilder2でRSS XMLを構築
+      const doc = xmlbuilder2
+        .create({ version: "1.0", encoding: "UTF-8" })
+        .ele("rss", {
+          version: "2.0",
+          "xmlns:atom": "http://www.w3.org/2005/Atom",
+        })
+        .ele("channel");
 
-    doc.ele("title").txt("Falling Nikochan - Latest Charts").up();
-    doc.ele("link").txt(backendOrigin(c)).up();
-    doc
-      .ele("description")
-      .txt(
-        "Simple and cute rhythm game, where anyone can create and share charts."
-      )
-      .up();
+      doc.ele("title").txt("Falling Nikochan - Latest Charts").up();
+      doc.ele("link").txt(backendOrigin(c)).up();
+      doc
+        .ele("description")
+        .txt(
+          "Simple and cute rhythm game, where anyone can create and share charts."
+        )
+        .up();
 
-    const images = doc.ele("image");
-    images
-      .ele("url")
-      .txt(`${backendOrigin(c)}/assets/icon.png`)
-      .up();
-    images.ele("title").txt("Falling Nikochan").up();
-    images.ele("link").txt(backendOrigin(c)).up();
-    images.up();
+      const images = doc.ele("image");
+      images
+        .ele("url")
+        .txt(`${backendOrigin(c)}/assets/icon.png`)
+        .up();
+      images.ele("title").txt("Falling Nikochan").up();
+      images.ele("link").txt(backendOrigin(c)).up();
+      images.up();
 
-    // <atom:link ... />
-    doc
-      .ele("atom:link", {
-        href: `${backendOrigin(c)}/rss.xml`,
-        rel: "self",
-        type: "application/rss+xml",
-      })
-      .up();
+      // <atom:link ... />
+      doc
+        .ele("atom:link", {
+          href: `${backendOrigin(c)}/rss.xml`,
+          rel: "self",
+          type: "application/rss+xml",
+        })
+        .up();
 
-    // <item>群
-    for (const chart of charts) {
-      const item = doc.ele("item");
-      const newTitle = chart.composer
-        ? t("titleWithComposer", {
-            title: chart.title,
-            composer: chart.composer,
-            cid: chart.cid,
-          })
-        : t("title", {
-            title: chart.title,
-            cid: chart.cid,
-          });
-      const newDescription = t("description", {
-        chartCreator: chart.chartCreator || t("chartCreatorEmpty"),
-        title: chart.title,
+      // <item>群
+      for (const chart of charts) {
+        const item = doc.ele("item");
+        const newTitle = chart.composer
+          ? t("titleWithComposer", {
+              title: chart.title,
+              composer: chart.composer,
+              cid: chart.cid,
+            })
+          : t("title", {
+              title: chart.title,
+              cid: chart.cid,
+            });
+        const newDescription = t("description", {
+          chartCreator: chart.chartCreator || t("chartCreatorEmpty"),
+          title: chart.title,
+        });
+
+        item.ele("title").txt(newTitle).up();
+        item
+          .ele("link")
+          .txt(`${backendOrigin(c)}/share/${chart.cid}`)
+          .up();
+        item
+          .ele("guid", { isPermaLink: "true" })
+          .txt(`${backendOrigin(c)}/share/${chart.cid}`)
+          .up();
+        item.ele("pubDate").txt(new Date(chart.updatedAt).toUTCString()).up();
+        item.ele("description").txt(newDescription).up();
+        item.up(); // </item>
+      }
+
+      // channelまで上がってからXML化
+      const rssXml = doc.up().up().end({ prettyPrint: true });
+
+      return c.body(rssXml, 200, {
+        "Content-Type": "application/rss+xml; charset=utf-8",
+        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
       });
-
-      item.ele("title").txt(newTitle).up();
-      item
-        .ele("link")
-        .txt(`${backendOrigin(c)}/share/${chart.cid}`)
-        .up();
-      item
-        .ele("guid", { isPermaLink: "true" })
-        .txt(`${backendOrigin(c)}/share/${chart.cid}`)
-        .up();
-      item.ele("pubDate").txt(new Date(chart.updatedAt).toUTCString()).up();
-      item.ele("description").txt(newDescription).up();
-      item.up(); // </item>
     }
-
-    // channelまで上がってからXML化
-    const rssXml = doc.up().up().end({ prettyPrint: true });
-
-    return c.body(rssXml, 200, {
-      "Content-Type": "application/rss+xml; charset=utf-8",
-      "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
-    });
-  });
+  );
 
 export default rssApp;

--- a/route/src/rss.ts
+++ b/route/src/rss.ts
@@ -6,6 +6,7 @@ import xmlbuilder2 from "xmlbuilder2";
 import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import { Db } from "mongodb";
 import { cache } from "hono/cache";
+import { etag } from "hono/etag";
 
 // Cache duration for RSS feed (in seconds) - 30 minutes
 const CACHE_MAX_AGE = 1800;
@@ -17,6 +18,7 @@ const rssApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
     strict: false,
   }).get(
     "/",
+    etag(),
     cache({
       cacheName: "rss",
     }),

--- a/route/src/rss.ts
+++ b/route/src/rss.ts
@@ -19,7 +19,6 @@ const rssApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
     "/",
     cache({
       cacheName: "rss",
-      cacheControl: `max-age=${CACHE_MAX_AGE}`,
     }),
     config.dbMiddleware,
     async (c) => {

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -38,7 +38,6 @@ const shareApp = (config: {
     .use(
       cache({
         cacheName: "share",
-        cacheControl: `max-age=${CACHE_MAX_AGE}`,
       })
     )
     .get("/:cid{[0-9]+}", async (c) => {

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -28,8 +28,14 @@ bodyを無理やり書き換える。
 
 const CACHE_MAX_AGE = 600;
 
+// w/や引用符を除いた部分
+export const etagContentRegex = /\d+-[a-zA-Z0-9+/]+=*/;
+
 const shareApp = (config: {
-  fetchBrief: (e: Bindings, cid: string) => Promise<ChartBrief>;
+  fetchBrief: (
+    e: Bindings,
+    cid: string
+  ) => Promise<{ brief: ChartBrief; etag: string }>;
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
   languageDetector?: (c: Context, next: () => Promise<void>) => Promise<void>;
 }) =>
@@ -64,7 +70,7 @@ const shareApp = (config: {
       //   );
       // }
       const pRes = config.fetchStatic(env(c), placeholderUrl);
-      const brief = await pBriefRes;
+      const { brief, etag } = await pBriefRes;
       const res = await pRes;
       let newTitle = brief.composer
         ? t("titleWithComposer", {
@@ -155,6 +161,8 @@ const shareApp = (config: {
         .replaceAll("PLACEHOLDER_DESCRIPTION", escapeHtml(newDescription))
         .replaceAll('\\"PLACEHOLDER_BRIEF', '\\"' + escapeJs(briefStr))
         .replaceAll("PLACEHOLDER_BRIEF", escapeHtml(briefStr))
+        // 引用符やw/がついている場合ここで除外するので、fetchBrief()が返すetagはなんでもよい
+        .replaceAll("PLACEHOLDER_ETAG", etag.match(etagContentRegex)?.[0] ?? "")
         .replaceAll("https://placeholder_oembed/json", oembedJsonURL.toString())
         .replaceAll("https://placeholder_oembed/xml", oembedXmlURL.toString());
       if (c.req.path.startsWith("/share") && lang !== qLang) {

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -18,12 +18,15 @@ import {
 import packageJson from "../package.json" with { type: "json" };
 import { env } from "hono/adapter";
 import { Context, Hono } from "hono";
+import { cache } from "hono/cache";
 
 /*
 OGPの見た目を優先するため、shareページではクエリのlangを優先する。
 クエリのlangとaccept-languageが異なる場合、クライアントサイドでリダイレクトするように
 bodyを無理やり書き換える。
 */
+
+const CACHE_MAX_AGE = 600;
 
 const shareApp = (config: {
   fetchBrief: (e: Bindings, cid: string) => Promise<ChartBrief>;
@@ -32,6 +35,12 @@ const shareApp = (config: {
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
     .use(config.languageDetector || languageDetector())
+    .use(
+      cache({
+        cacheName: "share",
+        cacheControl: `max-age=${CACHE_MAX_AGE}`,
+      })
+    )
     .get("/:cid{[0-9]+}", async (c) => {
       const lang = c.get("language");
       const qLang = c.req.query("lang") || lang;
@@ -165,7 +174,7 @@ const shareApp = (config: {
 
       return c.text(replacedBody, 200, {
         "Content-Type": res.headers.get("Content-Type") || "text/plain",
-        "Cache-Control": cacheControl(env(c), null),
+        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
         /*
           Linkヘッダーかmetaタグのどちらかがあればいいはずだが、
           Linkタグは例えばdiscordで動作しないらしい?: https://github.com/discord/discord-api-docs/issues/7370

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -18,7 +18,7 @@ import {
 import packageJson from "../package.json" with { type: "json" };
 import { env } from "hono/adapter";
 import { Context, Hono } from "hono";
-import { cache } from "hono/cache";
+import { etag } from "hono/etag";
 
 /*
 OGPの見た目を優先するため、shareページではクエリのlangを優先する。
@@ -35,11 +35,8 @@ const shareApp = (config: {
 }) =>
   new Hono<{ Bindings: Bindings }>({ strict: false })
     .use(config.languageDetector || languageDetector())
-    .use(
-      cache({
-        cacheName: "share",
-      })
-    )
+    .use(etag())
+    // CookieとAccept-Languageでレスポンスが変わるためprivate指定しcache middlewareは使わない
     .get("/:cid{[0-9]+}", async (c) => {
       const lang = c.get("language");
       const qLang = c.req.query("lang") || lang;
@@ -173,7 +170,7 @@ const shareApp = (config: {
 
       return c.text(replacedBody, 200, {
         "Content-Type": res.headers.get("Content-Type") || "text/plain",
-        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
+        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE, true),
         /*
           Linkヘッダーかmetaタグのどちらかがあればいいはずだが、
           Linkタグは例えばdiscordで動作しないらしい?: https://github.com/discord/discord-api-docs/issues/7370

--- a/route/src/sitemap.ts
+++ b/route/src/sitemap.ts
@@ -7,6 +7,7 @@ import { ChartEntryCompressed } from "./api/chart.js";
 import { text } from "node:stream/consumers";
 import { Db } from "mongodb";
 import { cache } from "hono/cache";
+import { etag } from "hono/etag";
 
 const CACHE_MAX_AGE = 86400;
 
@@ -29,6 +30,7 @@ const sitemapApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
     strict: false,
   }).get(
     "/",
+    etag(),
     cache({
       cacheName: "sitemap",
     }),

--- a/route/src/sitemap.ts
+++ b/route/src/sitemap.ts
@@ -31,7 +31,6 @@ const sitemapApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
     "/",
     cache({
       cacheName: "sitemap",
-      cacheControl: `max-age=${CACHE_MAX_AGE}`,
     }),
     config.dbMiddleware,
     async (c) => {

--- a/route/src/sitemap.ts
+++ b/route/src/sitemap.ts
@@ -6,6 +6,9 @@ import { env } from "hono/adapter";
 import { ChartEntryCompressed } from "./api/chart.js";
 import { text } from "node:stream/consumers";
 import { Db } from "mongodb";
+import { cache } from "hono/cache";
+
+const CACHE_MAX_AGE = 86400;
 
 const staticSitemapItems: SitemapItemLoose[] = [
   { url: "/", priority: 1 },
@@ -24,33 +27,41 @@ const staticSitemapItems: SitemapItemLoose[] = [
 const sitemapApp = async (config: { dbMiddleware: MiddlewareHandler }) =>
   new Hono<{ Bindings: Bindings; Variables: { db: () => Promise<Db> } }>({
     strict: false,
-  }).get("/", config.dbMiddleware, async (c) => {
-    let allCharts: SitemapItemLoose[];
-    const db = await c.get("db")();
-    allCharts = (
-      await db
-        .collection<ChartEntryCompressed>("chart")
-        .find({ published: true })
-        .project<{
-          cid: string;
-          updatedAt: number;
-        }>({ _id: 0, cid: 1, updatedAt: 1 })
-        .toArray()
-    ).map((c) => ({
-      url: `/share/${c.cid}`,
-      priority: 0.8,
-      lastmod: new Date(c.updatedAt).toISOString(),
-    }));
+  }).get(
+    "/",
+    cache({
+      cacheName: "sitemap",
+      cacheControl: `max-age=${CACHE_MAX_AGE}`,
+    }),
+    config.dbMiddleware,
+    async (c) => {
+      let allCharts: SitemapItemLoose[];
+      const db = await c.get("db")();
+      allCharts = (
+        await db
+          .collection<ChartEntryCompressed>("chart")
+          .find({ published: true })
+          .project<{
+            cid: string;
+            updatedAt: number;
+          }>({ _id: 0, cid: 1, updatedAt: 1 })
+          .toArray()
+      ).map((c) => ({
+        url: `/share/${c.cid}`,
+        priority: 0.8,
+        lastmod: new Date(c.updatedAt).toISOString(),
+      }));
 
-    const smStream = new SitemapStream({
-      hostname: "https://nikochan.utcode.net/",
-    });
-    Readable.from(staticSitemapItems.concat(allCharts)).pipe(smStream);
-    // smStream.end();
-    return c.body(await text(smStream), 200, {
-      "Content-Type": "application/xml",
-      "Cache-Control": cacheControl(env(c), 86400),
-    });
-  });
+      const smStream = new SitemapStream({
+        hostname: "https://nikochan.utcode.net/",
+      });
+      Readable.from(staticSitemapItems.concat(allCharts)).pipe(smStream);
+      // smStream.end();
+      return c.body(await text(smStream), 200, {
+        "Content-Type": "application/xml",
+        "Cache-Control": cacheControl(env(c), CACHE_MAX_AGE),
+      });
+    }
+  );
 
 export default sitemapApp;

--- a/route/tests/api/brief.spec.ts
+++ b/route/tests/api/brief.spec.ts
@@ -2,6 +2,11 @@ import { test, describe } from "node:test";
 import { expect } from "chai";
 import { app, dummyChart, dummyDate, initDb } from "./init";
 import { ChartBrief, hashLevel } from "@falling-nikochan/chart";
+import {
+  calcETag,
+  getChartEntryCompressed,
+} from "@falling-nikochan/route/src/api/chart";
+import { MongoClient } from "mongodb";
 
 describe("GET /api/brief/:cid", () => {
   test("should return a brief entry", async () => {
@@ -31,6 +36,32 @@ describe("GET /api/brief/:cid", () => {
         },
       ],
     });
+  });
+  test("should return ETag calculated by calcETag()", async () => {
+    await initDb();
+    const res = await app.request("/api/brief/100000");
+    expect(res.status).to.equal(200);
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const entry = await getChartEntryCompressed(db, "100000", null);
+      expect(res.headers.get("etag")).to.equal(await calcETag(entry));
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/brief/100000");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/brief/100000", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).to.equal(304);
   });
   test("should return 404 for nonexistent cid", async () => {
     await initDb();

--- a/route/tests/api/chartFile.get.spec.ts
+++ b/route/tests/api/chartFile.get.spec.ts
@@ -120,15 +120,8 @@ describe("GET /api/chartFile/:cid", () => {
       headers: { Authorization: basicAuth("p") },
     });
     expect(res.status).to.equal(200);
-    const client = new MongoClient(process.env.MONGODB_URI!);
-    try {
-      await client.connect();
-      const db = client.db("nikochan");
-      const entry = await getChartEntryCompressed(db, "100000", null);
-      expect(res.headers.get("etag")).to.equal(await calcETag(entry));
-    } finally {
-      await client.close();
-    }
+    const entry = await getChartEntryCompressed(db, "100000", null);
+    expect(res.headers.get("etag")).to.equal(await calcETag(entry));
   });
   test("should return 304 for matching If-None-Match", async () => {
     await initDb();
@@ -143,6 +136,7 @@ describe("GET /api/chartFile/:cid", () => {
       headers: {
         Authorization: basicAuth("p"),
         "If-None-Match": etag!,
+        "x-forwarded-for": "123",
       },
     });
     expect(res2.status).to.equal(304);
@@ -160,6 +154,7 @@ describe("GET /api/chartFile/:cid", () => {
       headers: {
         Authorization: basicAuth("p"),
         "If-Match": etag!,
+        "x-forwarded-for": "123",
       },
     });
     expect(res2.status).to.equal(200);

--- a/route/tests/api/chartFile.get.spec.ts
+++ b/route/tests/api/chartFile.get.spec.ts
@@ -31,7 +31,11 @@ import {
   hash,
 } from "@falling-nikochan/chart";
 import * as msgpack from "@msgpack/msgpack";
-import { ChartEntryCompressed } from "@falling-nikochan/route/src/api/chart";
+import {
+  calcETag,
+  ChartEntryCompressed,
+  getChartEntryCompressed,
+} from "@falling-nikochan/route/src/api/chart";
 
 const encodeBase64Utf8 = (value: string) =>
   btoa(
@@ -109,6 +113,67 @@ describe("GET /api/chartFile/:cid", () => {
       }
     );
     expect(res.status).to.equal(200);
+  });
+  test("should return ETag calculated by calcETag()", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000", {
+      headers: { Authorization: basicAuth("p") },
+    });
+    expect(res.status).to.equal(200);
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const entry = await getChartEntryCompressed(db, "100000", null);
+      expect(res.headers.get("etag")).to.equal(await calcETag(entry));
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/chartFile/100000", {
+      headers: { Authorization: basicAuth("p") },
+    });
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/chartFile/100000", {
+      headers: {
+        Authorization: basicAuth("p"),
+        "If-None-Match": etag!,
+      },
+    });
+    expect(res2.status).to.equal(304);
+  });
+  test("should return 200 for matching If-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/chartFile/100000", {
+      headers: { Authorization: basicAuth("p") },
+    });
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/chartFile/100000", {
+      headers: {
+        Authorization: basicAuth("p"),
+        "If-Match": etag!,
+      },
+    });
+    expect(res2.status).to.equal(200);
+  });
+  test("should return 412 for mismatching If-Match", async () => {
+    await initDb();
+    const res = await app.request("/api/chartFile/100000", {
+      headers: {
+        Authorization: basicAuth("p"),
+        "If-Match": '"invalid-etag"',
+      },
+    });
+    expect(res.status).to.equal(412);
+    expect(await res.json()).to.deep.equal({ message: "etagMismatch" });
   });
   currentChartVer satisfies 16; // edit tests below when chart version is bumped
   test("should return Chart15 if chart version is 15", async () => {

--- a/route/tests/api/playFile.spec.ts
+++ b/route/tests/api/playFile.spec.ts
@@ -7,6 +7,11 @@ import {
   Level6Play,
 } from "@falling-nikochan/chart";
 import * as msgpack from "@msgpack/msgpack";
+import {
+  calcETag,
+  getChartEntryCompressed,
+} from "@falling-nikochan/route/src/api/chart";
+import { MongoClient } from "mongodb";
 
 describe("GET /api/playFile/:cid/:lvIndex", () => {
   test("should return LevelPlay", async () => {
@@ -15,6 +20,52 @@ describe("GET /api/playFile/:cid/:lvIndex", () => {
     expect(res.status).to.equal(200);
     const level = msgpack.decode(await res.arrayBuffer()) as Level15Play;
     expect(level).to.deep.equal(dummyLevel15());
+  });
+  test("should return ETag calculated by calcETag()", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100000/0");
+    expect(res.status).to.equal(200);
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const entry = await getChartEntryCompressed(db, "100000", null);
+      expect(res.headers.get("etag")).to.equal(await calcETag(entry));
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/playFile/100000/0");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/playFile/100000/0", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).to.equal(304);
+  });
+  test("should return 200 for matching If-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/playFile/100000/0");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/playFile/100000/0", {
+      headers: { "If-Match": etag! },
+    });
+    expect(res2.status).to.equal(200);
+  });
+  test("should return 412 for mismatching If-Match", async () => {
+    await initDb();
+    const res = await app.request("/api/playFile/100000/0", {
+      headers: { "If-Match": '"invalid-etag"' },
+    });
+    expect(res.status).to.equal(412);
+    expect(await res.json()).to.deep.equal({ message: "etagMismatch" });
   });
   currentChartVer satisfies 16; // edit tests below when chart version is bumped
   test("should return Level15Play if chart version is 15", async () => {

--- a/route/tests/api/record.get.spec.ts
+++ b/route/tests/api/record.get.spec.ts
@@ -34,4 +34,16 @@ describe("GET /api/record/:cid", () => {
       },
     ]);
   });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/record/100000");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/record/100000", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).to.equal(304);
+  });
 });

--- a/route/tests/api/search.spec.ts
+++ b/route/tests/api/search.spec.ts
@@ -88,4 +88,16 @@ describe("GET /api/search", () => {
       expect(body).to.be.an("array");
     }
   });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/search?q=テスト");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/search?q=テスト", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).to.equal(304);
+  });
 });

--- a/route/tests/api/seqFile.spec.ts
+++ b/route/tests/api/seqFile.spec.ts
@@ -3,6 +3,11 @@ import { expect } from "chai";
 import { app, dummyLevel15, dummyLevel6, initDb } from "./init";
 import { ChartSeqData, loadChart } from "@falling-nikochan/chart";
 import msgpack from "@msgpack/msgpack";
+import {
+  calcETag,
+  getChartEntryCompressed,
+} from "@falling-nikochan/route/src/api/chart";
+import { MongoClient } from "mongodb";
 
 describe("GET /api/seqFile/:cid/:lvIndex", () => {
   test("should return ChartSeqData", async () => {
@@ -11,6 +16,52 @@ describe("GET /api/seqFile/:cid/:lvIndex", () => {
     expect(res.status).to.equal(200);
     const seqData = msgpack.decode(await res.arrayBuffer()) as ChartSeqData;
     expect(seqData.notes).to.deep.equal(loadChart(dummyLevel15()).notes);
+  });
+  test("should return ETag calculated by calcETag()", async () => {
+    await initDb();
+    const res = await app.request("/api/seqFile/100000/0");
+    expect(res.status).to.equal(200);
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const entry = await getChartEntryCompressed(db, "100000", null);
+      expect(res.headers.get("etag")).to.equal(await calcETag(entry));
+    } finally {
+      await client.close();
+    }
+  });
+  test("should return 304 for matching If-None-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/seqFile/100000/0");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/seqFile/100000/0", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(res2.status).to.equal(304);
+  });
+  test("should return 200 for matching If-Match", async () => {
+    await initDb();
+    const res1 = await app.request("/api/seqFile/100000/0");
+    expect(res1.status).to.equal(200);
+    const etag = res1.headers.get("etag");
+    expect(etag).to.be.a("string");
+
+    const res2 = await app.request("/api/seqFile/100000/0", {
+      headers: { "If-Match": etag! },
+    });
+    expect(res2.status).to.equal(200);
+  });
+  test("should return 412 for mismatching If-Match", async () => {
+    await initDb();
+    const res = await app.request("/api/seqFile/100000/0", {
+      headers: { "If-Match": '"invalid-etag"' },
+    });
+    expect(res.status).to.equal(412);
+    expect(await res.json()).to.deep.equal({ message: "etagMismatch" });
   });
   test("should return ChartSeqData without upgrading to latest ChartPlay if chart version is 6", async () => {
     await initDb();

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -464,7 +464,10 @@ const app = new Hono({ strict: false })
       fetchBrief: async (_e, cid) => {
         const res = await fetchAPI(self.origin + `/api/brief/${cid}`);
         if (res.ok) {
-          return await res.json();
+          return {
+            brief: await res.json(),
+            etag: res.headers.get("ETag") ?? "",
+          };
         } else {
           throw new Error(`failed to fetch /api/brief/${cid} (${res.status})`, {
             cause: res,

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -77,7 +77,8 @@ async function clearOldCaches() {
           (k) =>
             // pwaInstall.tsxにもキャッシュを削除する処理があるので、ここを編集する場合はそちらも確認
             ![mainCacheName, tmpCacheName, configCacheName].includes(k) &&
-            !k.startsWith("brief") // used in @/common/briefCache
+            !k.startsWith("brief") &&
+            !k.startsWith("play") // used in @/common/briefCache
         )
         .map((k) => caches.delete(k))
     )


### PR DESCRIPTION
close #1148

- [x] etag middlewareをデフォルト設定で/api,/og,/share,/rss,/sitemapに追加
  - If-None-Matchヘッダーとマッチしたら304を返す処理はここで自動的に行われる
- [x] oembed, record, search, ytMeta, /rss.xml, /sitemap.xml: cache-controlはすでにmax-age指定なのでそのまま、cache middlewareを追加
- [x] /share/:cid: cache-controlは現在no-storeになっていたが、 briefとおなじ10分に
  - ただしCookieとAccept-Languageでレスポンスが変わるので、private指定でcache middlewareなし
- [x] getChartEntry() において、entryCompressedのハッシュの計算を追加
- [x] brief, playFile, seqFile, chartFile, newChartFile で手動でEtagレスポンスヘッダーを設定
  - `${currentChartVer}-${entryCompressedで計算したハッシュ}` を共通のETagとする
- [x] chartFile, playFile, seqFile のcache-controlを no-cache に
  - briefは今までどおり10分cache
- [x] chartFile, playFile, seqFile リクエストにIf-Matchヘッダーが含まれていた場合、ETagが一致しなかったら412を返す
- [x] test
- [x] フロントエンドの実装
  - 412の場合にはフロントエンドはbriefをクエリパラメータを付与して再fetchしキャッシュをバイパスする必要がある
