### PR TITLE
Service Worker でフォントをプレキャッシュしない

### DIFF
--- a/frontend/app/[locale]/common/apiError.ts
+++ b/frontend/app/[locale]/common/apiError.ts
@@ -33,7 +33,7 @@ export class APIError extends Error {
     this.stack = stack;
     this.body = body;
     this.fingerprint = [
-      this.name,
+      `APIError-${status}`,
       this.message,
       // url内のパラメータ部分を消す (cid, lvIndex など)
       // TODO: 数値以外がパラメータになるAPIが今後作られた場合ロジックを変更する必要がある

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -191,6 +191,35 @@ export function useSafariDetector() {
   return isSafari;
 }
 
+function isLowSpeed(): boolean {
+  const connection =
+    (navigator as any).connection ||
+    (navigator as any).mozConnection ||
+    (navigator as any).webkitConnection;
+  if (!connection) {
+    return false;
+  }
+  if (connection.saveData) {
+    console.warn(
+      "skipping service worker update because of connection.saveData"
+    );
+    return true;
+  }
+  if (connection.type && ["ethernet", "wifi"].includes(connection.type)) {
+    return false;
+  }
+  if (
+    connection.effectiveType &&
+    ["slow-2g", "2g", "3g"].includes(connection.effectiveType)
+  ) {
+    console.warn(
+      `skipping service worker update because of connection.effectiveType=${connection.effectiveType} and type=${connection.type}`
+    );
+    return true;
+  }
+  return false;
+}
+
 interface InitAssetsState {
   type?: "initAssets";
   state: InitAssetsResult;
@@ -268,21 +297,26 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
               clearTimeout(updateFetching.current);
             }
             const checkUpdate = () =>
-              fetch("/worker/checkUpdate").then(
-                (res) => {
-                  // okの場合、messageイベントで受け取るのでここでは何もしない
-                  if (!res.ok) {
-                    if (isStandalone()) {
-                      setWorkerUpdate({ state: "failed" });
+              !isStandalone() && isLowSpeed()
+                ? // アセットの更新を行わず、完了したことにする
+                  setWorkerUpdate((prev) =>
+                    prev?.state === "updating" ? { state: "done" } : prev
+                  )
+                : fetch("/worker/checkUpdate").then(
+                    (res) => {
+                      // okの場合、messageイベントで受け取るのでここでは何もしない
+                      if (!res.ok) {
+                        if (isStandalone()) {
+                          setWorkerUpdate({ state: "failed" });
+                        }
+                      }
+                    },
+                    () => {
+                      if (isStandalone()) {
+                        setWorkerUpdate({ state: "failed" });
+                      }
                     }
-                  }
-                },
-                () => {
-                  if (isStandalone()) {
-                    setWorkerUpdate({ state: "failed" });
-                  }
-                }
-              );
+                  );
             updateFetching.current = setTimeout(checkUpdate, 1000);
             reg.addEventListener("updatefound", () => {
               if (isStandalone()) {
@@ -295,7 +329,6 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
               newWorker?.addEventListener("statechange", () => {
                 console.log("sw statechange:", newWorker?.state);
                 if (newWorker?.state === "activated") {
-                  // setWorkerUpdate({ state: "done" });
                   updateFetching.current = setTimeout(checkUpdate, 1000);
                 }
               });

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -296,27 +296,34 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
             if (updateFetching.current !== null) {
               clearTimeout(updateFetching.current);
             }
-            const checkUpdate = () =>
-              !isStandalone() && isLowSpeed()
-                ? // アセットの更新を行わず、完了したことにする
-                  setWorkerUpdate((prev) =>
-                    prev?.state === "updating" ? { state: "done" } : prev
-                  )
-                : fetch("/worker/checkUpdate").then(
-                    (res) => {
-                      // okの場合、messageイベントで受け取るのでここでは何もしない
-                      if (!res.ok) {
-                        if (isStandalone()) {
-                          setWorkerUpdate({ state: "failed" });
-                        }
-                      }
-                    },
-                    () => {
+            const checkUpdate = () => {
+              if (isStandalone()) {
+                // standaloneの場合、ネットワークの状態に関わらず更新を行う (良いのか?)
+                // もともとこのSWはv10.0でPWAが絶対にエラーページを出さないようにという意図で実装したものなので、そっちの意図を優先している
+                fetch("/worker/checkUpdate").then(
+                  (res) => {
+                    // okの場合、messageイベントで受け取るのでここでは何もしない
+                    if (!res.ok) {
                       if (isStandalone()) {
                         setWorkerUpdate({ state: "failed" });
                       }
                     }
-                  );
+                  },
+                  () => {
+                    if (isStandalone()) {
+                      setWorkerUpdate({ state: "failed" });
+                    }
+                  }
+                );
+              } else {
+                if (isLowSpeed()) {
+                  // standaloneでなく、かつ低速の場合、アセットの更新を行わない
+                } else {
+                  // 更新を行うが、結果が何であってもなにもしない
+                  fetch("/worker/checkUpdate").catch(() => undefined);
+                }
+              }
+            };
             updateFetching.current = setTimeout(checkUpdate, 1000);
             reg.addEventListener("updatefound", () => {
               if (isStandalone()) {

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -287,9 +287,6 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
       process.env.NODE_ENV !== "development" &&
       "serviceWorker" in navigator
     ) {
-      navigator.serviceWorker.addEventListener("message", (e) => {
-        console.warn("sw:", e.data);
-      });
       if (SW_ALLOWED_ORIGINS.includes(window.location.origin)) {
         navigator.serviceWorker.register("/sw.js", { scope: "/" }).then(
           (reg) => {
@@ -369,34 +366,37 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
       navigator.serviceWorker.addEventListener("message", (event) => {
         if (
           typeof event.data === "object" &&
-          event.data.type === "initAssets" &&
-          isStandalone()
+          event.data.type === "initAssets"
         ) {
-          const state = (event.data as InitAssetsState).state;
-          switch (state) {
-            case "done":
-            case "failed":
-            case "updating":
-              setWorkerUpdate(event.data);
-              break;
-            case "noUpdate":
-              setWorkerUpdate((current) => {
-                if (current?.state === "updating") {
-                  // serviceworkerのinstallのためにupdatingになり、その後assetの更新はない場合
-                  return { state: "done" };
-                }
-                return null;
-              });
-              break;
-            case "inProgress":
-              // ignore
-              break;
-            default:
-              state satisfies never;
-              throw new Error(
-                `Unknown worker update state: ${event.data.state}`
-              );
+          if (isStandalone()) {
+            const state = (event.data as InitAssetsState).state;
+            switch (state) {
+              case "done":
+              case "failed":
+              case "updating":
+                setWorkerUpdate(event.data);
+                break;
+              case "noUpdate":
+                setWorkerUpdate((current) => {
+                  if (current?.state === "updating") {
+                    // serviceworkerのinstallのためにupdatingになり、その後assetの更新はない場合
+                    return { state: "done" };
+                  }
+                  return null;
+                });
+                break;
+              case "inProgress":
+                // ignore
+                break;
+              default:
+                state satisfies never;
+                throw new Error(
+                  `Unknown worker update state: ${event.data.state}`
+                );
+            }
           }
+        } else {
+          console.warn("sw:", event.data);
         }
       });
     }

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -289,10 +289,14 @@ async function initAssetsCache(config: {
         .split("\n")
         .map((file) => file.replaceAll("[", "%5B").replaceAll("]", "%5D"));
       // パス名にハッシュが入っているので既にキャッシュ済みのものはスキップ
+      // フォントはスキップ (必要なときにダウンロードすればいい)
       const toFetch = (
         await Promise.all(
           nextFiles.map(async (pathname) =>
-            (await cache.match(pathname)) || (await tmp.match(pathname))
+            pathname.endsWith(".woff") ||
+            pathname.endsWith(".woff2") ||
+            (await cache.match(pathname)) ||
+            (await tmp.match(pathname))
               ? null
               : pathname
           )

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -97,7 +97,7 @@ async function fetchStatic(_e: any, url: URL): Promise<Response> {
     return res;
   } else {
     // 通常は全部cacheに入っているはずなのでここに来ることはほぼない
-    console.warn(`${url} is not in cache`);
+    // console.warn(`${url} is not in cache`);
     const res = await fetch(
       (process.env.ASSET_PREFIX || self.origin) + url.pathname
     ).catch(fetchError(e));
@@ -325,11 +325,11 @@ async function initAssetsCache(config: {
               progressSize += size;
               sendInitState("updating", progressNum, totalNum, progressSize);
             } else {
-              console.error(`failed to fetch ${pathname}: ${res.status}`);
+              // console.error(`failed to fetch ${pathname}: ${res.status}`);
               failed = true;
             }
-          } catch (err) {
-            console.error(`failed to fetch ${pathname}: ${err}`);
+          } catch {
+            // console.error(`failed to fetch ${pathname}: ${err}`);
             failed = true;
           }
         })
@@ -347,8 +347,8 @@ async function initAssetsCache(config: {
         downloadNextAssets(),
       ]);
       allPathnames = [...tarPathnames, ...nextPathnames];
-    } catch (err) {
-      console.error(err);
+    } catch {
+      // console.error(err);
       return sendInitState("failed");
     }
 
@@ -357,7 +357,7 @@ async function initAssetsCache(config: {
       await Promise.all(
         keys.map(async (req) => {
           if (!allPathnames.includes(new URL(req.url).pathname)) {
-            console.warn(`delete ${req.url}`);
+            // console.warn(`delete ${req.url}`);
             await cache.delete(req);
           }
         })

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -11,6 +11,7 @@ import {
 import { locales } from "@falling-nikochan/i18n/staticMin.js";
 import { TarFileType, TarReader } from "@gera2ld/tarjs";
 import cfBeaconHtml from "./beacon.html?raw";
+import { getMimeType, mimes } from "hono/utils/mime";
 
 const e: Bindings = {
   MONGODB_URI: "",
@@ -131,27 +132,13 @@ function getContentType(pathname: string): string {
   } else {
     ext = pathname.split(".").pop()?.toLowerCase();
   }
-  const types: Record<string, string> = {
-    html: "text/html; charset=utf-8",
-    css: "text/css; charset=utf-8",
-    js: "application/javascript; charset=utf-8",
-    mjs: "application/javascript; charset=utf-8",
-    json: "application/json; charset=utf-8",
-    txt: "text/plain; charset=utf-8",
-    svg: "image/svg+xml",
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    webp: "image/webp",
-    ico: "image/x-icon",
-    woff: "font/woff",
-    woff2: "font/woff2",
-    wasm: "application/wasm",
-    xml: "application/xml",
-    gz: "application/gzip",
-  };
-  if (ext && ext in types) {
-    return types[ext];
+  const type = getMimeType("." + ext, {
+    ...mimes,
+    wav: "audio/wav",
+    md: "text/markdown; charset=utf-8",
+  });
+  if (type) {
+    return type;
   } else {
     console.error(`Unknown extension ${ext} for path ${pathname}`);
     return "application/octet-stream";


### PR DESCRIPTION
* Service Worker でフォントをプレキャッシュしない
  * なくても表示は可能なので、必要になったときのfetchで十分
* navigator.connection を見て低速だった場合はアセットの更新(プレキャッシュ)を呼び出さない
  * (standalone時は今までどおり強制的に更新する)
* ついでにmimetypeの判定にhono/utils/mimeを使うよう変更