### PR TITLE
フロントエンドのfetchエラー処理改善

### DIFF
--- a/frontend/app/[locale]/common/fetch.ts
+++ b/frontend/app/[locale]/common/fetch.ts
@@ -63,19 +63,12 @@ export function fetchAsset() {
           if (!response) {
             // network error, do not report
           } else {
-            let message: string;
-            try {
-              message = await response.text();
-            } catch {
-              message = response.statusText;
-            }
-            const we = new wretch.WretchError(message);
-            we.cause = referenceError;
-            // we.stack += "\nCAUSE: " + referenceError.stack;
-            we.response = response;
-            we.status = response.status;
-            we.url = url;
-            Sentry.captureException(we);
+            const e = await APIErrorTransformer(referenceError)(
+              null,
+              response,
+              { _url: url }
+            );
+            Sentry.captureException(e);
           }
           return {};
         },
@@ -101,7 +94,7 @@ export function fetchAsset() {
 
 function APIErrorTransformer(referenceError: Error) {
   return async (
-    we: WretchError,
+    _we: WretchError | null,
     res: Response,
     req: { _url: string }
   ): Promise<APIError> => {
@@ -130,7 +123,7 @@ function APIErrorTransformer(referenceError: Error) {
     }
     return new APIError(
       req._url,
-      we.status,
+      res.status,
       message,
       referenceError.stack,
       body

--- a/frontend/app/[locale]/common/fetch.ts
+++ b/frontend/app/[locale]/common/fetch.ts
@@ -4,6 +4,7 @@ import AbortAddon from "wretch/addons/abort";
 import { dedupe, retry } from "wretch/middlewares";
 import * as Sentry from "@sentry/nextjs";
 import { APIError, FETCH_ERROR_STATUS } from "./apiError";
+import { rateLimit } from "@falling-nikochan/chart";
 
 const dedupeMiddleware = dedupe();
 
@@ -33,7 +34,21 @@ export function fetchBackend() {
   return wretch(process.env.BACKEND_PREFIX || window.location.origin)
     .addon(QueryStringAddon)
     .addon(AbortAddon())
-    .middlewares([dedupeMiddleware])
+    .middlewares([
+      dedupeMiddleware,
+      retry({
+        delayTimer: rateLimit.chartFile * 1000 + 500,
+        delayRamp: (delay) => delay,
+        maxAttempts: 3,
+        until: (response) => !!response && response.status !== 429,
+        resolveWithLatestResponse: true,
+      }),
+      retry({
+        maxAttempts: 1,
+        until: (response) => !!response,
+        retryOnNetworkError: true,
+      }),
+    ])
     .customError(APIErrorTransformer(referenceError))
     .resolve((r) =>
       r.fetchError((e, w) => {

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -22,7 +22,6 @@ import {
   convertToLatest,
   updateBpmTimeSec,
   updateBarNum,
-  rateLimit,
 } from "@falling-nikochan/chart";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as msgpack from "@msgpack/msgpack";
@@ -37,7 +36,6 @@ import fnCommandsLib from "fn-commands?raw";
 import fnCommandsPackageJson from "fn-commands/package.json";
 import { isInsideFrame } from "@/scale";
 import { captureAndWrap, fetchBackend } from "@/common/fetch";
-import { retry } from "wretch/middlewares";
 import { markAsExpected } from "@/common/apiError";
 
 interface Props {
@@ -83,16 +81,6 @@ export interface FetchChartOptions {
   bypass?: boolean;
   editPasswd: string;
   savePasswd: boolean;
-}
-
-function chartFileRetryMiddleware() {
-  return retry({
-    delayTimer: rateLimit.chartFile * 1000 + 500,
-    delayRamp: (delay) => delay,
-    maxAttempts: 3,
-    until: (response) => !response || response.status !== 429,
-    resolveWithLatestResponse: true,
-  });
 }
 
 async function compressBodyIfSupported(body: Uint8Array<ArrayBuffer>) {
@@ -178,7 +166,6 @@ export function useChartState(props: Props) {
             process.env.NODE_ENV === "development" ? "include" : "same-origin",
         })
         .auth(chartAuthorization(initialPasswd) ?? "")
-        .middlewares([chartFileRetryMiddleware()])
         .get()
         // passwdPrompt has unique handler for 401 and 429 messages
         .unauthorized(
@@ -344,7 +331,6 @@ export function useChartState(props: Props) {
                 : "same-origin",
           })
           .auth(chartAuthorization(chartState.chart.currentPasswd) ?? "")
-          .middlewares([chartFileRetryMiddleware()])
           .post()
           .unauthorized(markAsExpected)
           .notFound(markAsExpected)
@@ -388,7 +374,6 @@ export function useChartState(props: Props) {
             process.env.NODE_ENV === "development" ? "include" : "same-origin",
         })
         .auth(chartAuthorization(chartState.chart.currentPasswd) ?? "")
-        .middlewares([chartFileRetryMiddleware()])
         .delete()
         .unauthorized(() => undefined)
         .notFound(() => undefined)

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -231,7 +231,15 @@ export function ChartList(props: Props) {
                 }
                 return briefs;
               }),
-            onError: (e) => setBriefs(e),
+            onError: () =>
+              setBriefs((briefs) => {
+                if (Array.isArray(briefs) && briefs.at(i)?.cid === b.cid) {
+                  briefs = briefs.slice();
+                  briefs[i]!.fetched = true;
+                  // briefs[i]!.brief = undefined;
+                }
+                return briefs;
+              }),
           });
         }
       }


### PR DESCRIPTION
- **fetchAssetのリトライ時のエラーハンドリングを修正**
- **429リトライとネットワークエラー時リトライをfetchBackend側に常時入れる**
- **briefの取得に失敗してもリスト全体をエラー表示にしない**
close #1194
