### PR TITLE
トップページと譜面編集の読み込み高速化

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,10 @@
+## ver. 16.18 - 2025/06/13 [#1205](https://github.com/na-trium-144/falling-nikochan/pull/1205)
+
+* 画像の遅延読み込み
+* mathjsの遅延読み込み
+* テーマの読み込みをインラインscriptタグに移動
+* next/bundle-analyzerを追加、環境変数でいつでも有効化できる
+
 ## ver. 16.17 - 2025/06/13
 
 * ETagとIf-Matchの利用 [#1190](https://github.com/na-trium-144/falling-nikochan/pull/1190)

--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,9 +1,10 @@
 ## ver. 16.18 - 2025/06/13 [#1205](https://github.com/na-trium-144/falling-nikochan/pull/1205)
 
 * 画像の遅延読み込み
-* mathjsの遅延読み込み
+* mathjs,yaml,wasmoonの遅延読み込み
 * テーマの読み込みをインラインscriptタグに移動
 * next/bundle-analyzerを追加、環境変数でいつでも有効化できる
+* workerをeditページ起動時に非同期に初期化し、エラーが出たらページ全体を止める
 
 ## ver. 16.17 - 2025/06/13
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,7 @@ The service worker ([`worker/entry.ts`](worker/entry.ts), bundled into `/sw.js`)
 
 | Variable | GitHub Action | Build time | Backend runtime | Description |
 |---|---|---|---|---|
+| `ANALYZE` | | optional | | Enables next/bundle-analyzer |
 | `MONGODB_URI` | | | required | `mongodb://...` |
 | `API_ENV` |  |  | DO NOT SET | if set to `development`, development-specific behaviors such as password bypass will be enabled |
 | `API_NO_RATELIMIT` |  |  | DO NOT SET | |

--- a/chart/src/luaExec/exec.ts
+++ b/chart/src/luaExec/exec.ts
@@ -1,4 +1,3 @@
-import { LuaFactory } from "wasmoon";
 import { Step, StepSchema, stepZero } from "../step.js";
 import { LevelFreeze } from "../chart.js";
 import * as v from "valibot";
@@ -22,6 +21,7 @@ export async function luaExec(
     isChartFile?: boolean;
   }
 ): Promise<LuaExecResult> {
+  const { LuaFactory } = await import("wasmoon");
   const factory = new LuaFactory(wasmPath);
   await factory.mountFile(
     "/usr/local/share/lua/5.4/fn-commands.lua",

--- a/frontend/app/[locale]/clientPage.tsx
+++ b/frontend/app/[locale]/clientPage.tsx
@@ -24,6 +24,7 @@ import { IrasutoyaLikeGrass } from "./common/irasutoyaLike.js";
 import { useDisplayMode } from "./scale.js";
 import { DemoChart, demoCharts, DemoDetail, TopDemo } from "./topDemo.js";
 import { Box } from "./common/box.js";
+import { LazyImg } from "./common/lazyImage.js";
 
 interface Props {
   locale: string;
@@ -375,24 +376,22 @@ export function Features({ locale }: { locale: string }) {
           </div>
         </div>
         <Box>
-          <div className="relative w-full aspect-[1.6] overflow-hidden">
-            <img
-              src={
-                process.env.ASSET_PREFIX +
-                "/assets/lp-play.jpg" +
-                process.env.ASSET_LP
-              }
-              className="absolute bottom-[10%] left-[-1%] w-[70%]"
-            />
-            <img
-              src={
-                process.env.ASSET_PREFIX +
-                "/assets/lp-play-mobile.jpg" +
-                process.env.ASSET_LP
-              }
-              className="absolute right-[-4%] top-0 h-[105%] rotate-3 origin-top-right"
-            />
-          </div>
+          <LazyImg
+            src={
+              process.env.ASSET_PREFIX +
+              "/assets/lp-play.jpg" +
+              process.env.ASSET_LP
+            }
+            className="absolute bottom-[10%] left-[-1%] w-[70%]"
+          />
+          <LazyImg
+            src={
+              process.env.ASSET_PREFIX +
+              "/assets/lp-play-mobile.jpg" +
+              process.env.ASSET_LP
+            }
+            className="absolute right-[-4%] top-0 h-[105%] rotate-3 origin-top-right"
+          />
         </Box>
       </section>
 
@@ -435,13 +434,13 @@ export function Features({ locale }: { locale: string }) {
           </Link>
         </div>
         <Box>
-          <img
+          <LazyImg
             src={
               process.env.ASSET_PREFIX +
               "/assets/lp-edit.jpg" +
               process.env.ASSET_LP
             }
-            className="w-full"
+            className="absolute inset-0 w-full h-auto my-auto!"
           />
         </Box>
       </section>

--- a/frontend/app/[locale]/common/lazyImage.tsx
+++ b/frontend/app/[locale]/common/lazyImage.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  src: string;
+  className: string;
+}
+export function LazyImg(props: Props) {
+  const [loadImages, setLoadImages] = useState(false);
+  useEffect(() => {
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => setLoadImages(true))
+    );
+  }, []);
+
+  if (loadImages) {
+    return (
+      <img
+        loading="lazy"
+        decoding="async"
+        fetchPriority="low"
+        className={props.className}
+        src={props.src}
+      />
+    );
+  }
+  return null;
+}

--- a/frontend/app/[locale]/common/mathInput.tsx
+++ b/frontend/app/[locale]/common/mathInput.tsx
@@ -1,9 +1,15 @@
-import { evaluate } from "mathjs";
+"use client";
+
+import { useEffect } from "react";
 import Input from "./input";
+
+// import { evaluate } from "mathjs";
+// lazy load mathjs because it's heavy
+let evaluate: null | typeof import("mathjs").evaluate = null;
 
 function evalMath(value: string): number {
   try {
-    const result = evaluate(value);
+    const result = evaluate?.(value);
     if (typeof result === "number" && isFinite(result)) return result;
     return NaN;
   } catch {
@@ -19,6 +25,14 @@ interface MathInputProps {
   disabled?: boolean;
 }
 export default function MathInput(props: MathInputProps) {
+  useEffect(() => {
+    (async () => {
+      if (!evaluate) {
+        evaluate = (await import("mathjs")).evaluate;
+      }
+    })();
+  }, []);
+
   const mathIsValid = (raw: string): boolean => {
     const evaluated = evalMath(raw);
     if (isNaN(evaluated)) return false;

--- a/frontend/app/[locale]/common/mathInput.tsx
+++ b/frontend/app/[locale]/common/mathInput.tsx
@@ -1,21 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Input from "./input";
 
 // import { evaluate } from "mathjs";
 // lazy load mathjs because it's heavy
-let evaluate: null | typeof import("mathjs").evaluate = null;
-
-function evalMath(value: string): number {
-  try {
-    const result = evaluate?.(value);
-    if (typeof result === "number" && isFinite(result)) return result;
-    return NaN;
-  } catch {
-    return NaN;
-  }
-}
 
 interface MathInputProps {
   className?: string;
@@ -25,34 +14,58 @@ interface MathInputProps {
   disabled?: boolean;
 }
 export default function MathInput(props: MathInputProps) {
+  const [evaluate, setEvaluate] = useState<
+    null | typeof import("mathjs").evaluate
+  >(null);
   useEffect(() => {
     (async () => {
-      if (!evaluate) {
-        evaluate = (await import("mathjs")).evaluate;
-      }
+      const { evaluate } = await import("mathjs");
+      setEvaluate(() => evaluate);
     })();
   }, []);
 
-  const mathIsValid = (raw: string): boolean => {
-    const evaluated = evalMath(raw);
-    if (isNaN(evaluated)) return false;
-    return props.isValid(evaluated.toString());
-  };
+  if (evaluate) {
+    const evalMath = (value: string): number => {
+      try {
+        const result = evaluate(value);
+        if (typeof result === "number" && isFinite(result)) return result;
+        return NaN;
+      } catch {
+        return NaN;
+      }
+    };
 
-  const mathUpdateValue = (raw: string): void => {
-    const evaluated = evalMath(raw);
-    if (!isNaN(evaluated)) {
-      props.updateValue(evaluated.toString());
-    }
-  };
+    const mathIsValid = (raw: string): boolean => {
+      const evaluated = evalMath(raw);
+      if (isNaN(evaluated)) return false;
+      return props.isValid(evaluated.toString());
+    };
 
-  return (
-    <Input
-      className={props.className}
-      actualValue={props.actualValue}
-      updateValue={mathUpdateValue}
-      isValid={mathIsValid}
-      disabled={props.disabled}
-    />
-  );
+    const mathUpdateValue = (raw: string): void => {
+      const evaluated = evalMath(raw);
+      if (!isNaN(evaluated)) {
+        props.updateValue(evaluated.toString());
+      }
+    };
+
+    return (
+      <Input
+        className={props.className}
+        actualValue={props.actualValue}
+        updateValue={mathUpdateValue}
+        isValid={mathIsValid}
+        disabled={props.disabled}
+      />
+    );
+  } else {
+    // mathjsの読み込みが完了するまでの間は、一旦disabled
+    return (
+      <Input
+        className={props.className}
+        actualValue={props.actualValue}
+        updateValue={() => undefined}
+        disabled={true}
+      />
+    );
+  }
 }

--- a/frontend/app/[locale]/common/theme.tsx
+++ b/frontend/app/[locale]/common/theme.tsx
@@ -79,6 +79,7 @@ export function ThemeProvider(props: { children: ReactNode }) {
       }}
     >
       <script
+        suppressHydrationWarning
         dangerouslySetInnerHTML={{
           __html: themeInitScript.replace(/\s+/g, " "),
         }}

--- a/frontend/app/[locale]/common/theme.tsx
+++ b/frontend/app/[locale]/common/theme.tsx
@@ -10,12 +10,18 @@ import {
   useState,
 } from "react";
 import { useTranslations } from "next-intl";
-import { themeColorDark, themeColorLight } from "@/metadata.js";
 import DropDown from "./dropdown";
 import { IrasutoyaLikeBg } from "./irasutoyaLike.jsx";
 import Moon from "@icon-park/react/lib/icons/Moon";
 import Sun from "@icon-park/react/lib/icons/Sun";
 import DownOne from "@icon-park/react/lib/icons/DownOne";
+import themeInitScript from "./themeInit.js?raw";
+
+declare global {
+  var fnGetCurrentTheme: () => "dark" | "light" | null;
+  var fnCurrentThemeIsDark: () => boolean;
+  var fnApplyTheme: () => void;
+}
 
 export interface ThemeState {
   theme: "dark" | "light" | null;
@@ -29,60 +35,14 @@ const ThemeContext = createContext<ThemeState>({
 });
 export const useTheme = () => useContext(ThemeContext);
 
-function getCurrentTheme(): "dark" | "light" | null {
-  const theme = localStorage?.getItem("theme");
-  return theme === "dark" || theme === "light" ? theme : null;
-}
-function currentThemeIsDark() {
-  switch (getCurrentTheme()) {
-    case "dark":
-      return true;
-    case "light":
-      return false;
-    default:
-      return (
-        window?.matchMedia("(prefers-color-scheme: dark)").matches || false
-      );
-  }
-}
-const applyTheme = () => {
-  if (typeof document !== "undefined") {
-    document.body.classList.add("fn-csr-ready");
-    if (currentThemeIsDark()) {
-      /* ダークテーマの時 */
-      document.body.classList.add("dark");
-    } else {
-      /* ライトテーマの時 */
-      document.body.classList.remove("dark");
-    }
-    const metaThemeColor = document.querySelectorAll("meta[name=theme-color]");
-    switch (getCurrentTheme()) {
-      case "dark":
-        metaThemeColor.forEach((e) => {
-          e.setAttribute("content", themeColorDark);
-        });
-        break;
-      case "light":
-        metaThemeColor.forEach((e) => {
-          e.setAttribute("content", themeColorLight);
-        });
-        break;
-      default:
-        metaThemeColor[0].setAttribute("content", themeColorLight);
-        metaThemeColor[1].setAttribute("content", themeColorDark);
-        break;
-    }
-  }
-};
-
 export function ThemeProvider(props: { children: ReactNode }) {
   const [theme, setTheme] = useState<"dark" | "light" | null>(null);
   const [isDark, setIsDark] = useState<boolean>(false);
   const updateTheme = useCallback(() => {
-    setTheme(getCurrentTheme());
-    const isDark = currentThemeIsDark();
+    setTheme(window.fnGetCurrentTheme());
+    const isDark = window.fnCurrentThemeIsDark();
     setIsDark(isDark);
-    applyTheme();
+    window.fnApplyTheme();
   }, []);
   useLayoutEffect(() => {
     updateTheme();
@@ -118,6 +78,11 @@ export function ThemeProvider(props: { children: ReactNode }) {
         },
       }}
     >
+      <script
+        dangerouslySetInnerHTML={{
+          __html: themeInitScript.replace(/\s+/g, " "),
+        }}
+      />
       <div className="fn-fallback-bg" />
       <IrasutoyaLikeBg />
       {props.children}

--- a/frontend/app/[locale]/common/themeInit.js
+++ b/frontend/app/[locale]/common/themeInit.js
@@ -1,0 +1,46 @@
+const themeColorLight = "#b8e6fe";
+const themeColorDark = "#20100a";
+
+window.fnGetCurrentTheme = () => {
+  const theme = localStorage.getItem("theme");
+  return theme === "dark" || theme === "light" ? theme : null;
+};
+window.fnCurrentThemeIsDark = () => {
+  switch (window.fnGetCurrentTheme()) {
+    case "dark":
+      return true;
+    case "light":
+      return false;
+    default:
+      return (
+        window?.matchMedia("(prefers-color-scheme: dark)").matches || false
+      );
+  }
+};
+window.fnApplyTheme = () => {
+  document.body.classList.add("fn-csr-ready");
+  if (window.fnCurrentThemeIsDark()) {
+    document.body.classList.add("dark");
+  } else {
+    document.body.classList.remove("dark");
+  }
+  const metaThemeColor = document.querySelectorAll("meta[name=theme-color]");
+  switch (window.fnGetCurrentTheme()) {
+    case "dark":
+      metaThemeColor.forEach((e) => {
+        e.setAttribute("content", themeColorDark);
+      });
+      break;
+    case "light":
+      metaThemeColor.forEach((e) => {
+        e.setAttribute("content", themeColorLight);
+      });
+      break;
+    default:
+      metaThemeColor[0].setAttribute("content", themeColorLight);
+      metaThemeColor[1].setAttribute("content", themeColorDark);
+      break;
+  }
+};
+
+window.fnApplyTheme();

--- a/frontend/app/[locale]/dev/clientPage.tsx
+++ b/frontend/app/[locale]/dev/clientPage.tsx
@@ -8,7 +8,6 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "@/common/theme";
 import { useDisplayMode } from "@/scale";
-import YAML from "yaml";
 import ArrowLeft from "@icon-park/react/lib/icons/ArrowLeft";
 import Right from "@icon-park/react/lib/icons/Right";
 import Down from "@icon-park/react/lib/icons/Down";
@@ -129,9 +128,10 @@ function StorageEditor(props: EProps) {
     }
   }, [props.storage]);
   const setCode = useCallback(
-    (code: string) => {
+    async (code: string) => {
       setCode_(code);
       if (props.storage) {
+        const YAML = await import("yaml");
         try {
           const newObj = YAML.parse(code || "{}");
           const newKeys = Object.keys(newObj);

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -28,7 +28,6 @@ import * as msgpack from "@msgpack/msgpack";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import saveAs from "file-saver";
-import YAML from "yaml";
 import { luaExec } from "@falling-nikochan/chart/dist/luaExec";
 import { isInsideFrame, isStandalone } from "@/common/pwaInstall";
 import * as v from "valibot";
@@ -486,6 +485,7 @@ export function useChartState(props: Props) {
         }
       };
       let result: Awaited<ReturnType<typeof validateAndExec>> | null = null;
+      const YAML = await import("yaml");
       try {
         result = await validateAndExec(
           YAML.parse(new TextDecoder().decode(buffer))

--- a/frontend/app/[locale]/edit/luaExecWorker.ts
+++ b/frontend/app/[locale]/edit/luaExecWorker.ts
@@ -42,3 +42,5 @@ worker.addEventListener(
     worker.postMessage(result);
   }
 );
+
+worker.postMessage("initDone");

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -56,6 +56,8 @@ if (typeof window !== "undefined") {
 }
 
 export function useLuaExecutor(): LuaExecutor {
+  const initDoneRef = useRef(false);
+  const [initError, setInitError] = useState<Error>();
   const [stdout, setStdout] = useState<string[]>([]);
   const [err, setErr] = useState<string[]>([]);
   const [errLine, setErrLine] = useState<number | null>(null);
@@ -67,6 +69,61 @@ export function useLuaExecutor(): LuaExecutor {
   const workerResolver = useRef<((result: LevelFreeze | null) => void) | null>(
     null
   );
+
+  const initWorker = useCallback(() => {
+    if (worker.current === null) {
+      worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
+      worker.current.addEventListener("error", (e) => {
+        console.error(e);
+        if (!initDoneRef.current) {
+          let err = e.error ?? e.message;
+          if (!(err instanceof Error)) {
+            err = new Error(String(err));
+          }
+          if (!(err as Error).stack) {
+            (err as Error).stack = new Error().stack;
+          }
+          setInitError(err);
+        }
+        if (workerResolver.current) {
+          setRunning(false);
+          setStdout([]);
+          // e.messageが空の場合がある
+          setErr([e.message || "Unknown error"]);
+          setErrLine(-1);
+          workerResolver.current(null);
+          workerResolver.current = null;
+        }
+      });
+      worker.current.addEventListener(
+        "message",
+        ({ data }: { data: LuaExecResult | "initDone" }) => {
+          if (typeof data === "string") {
+            initDoneRef.current = true;
+          } else {
+            if (workerResolver.current) {
+              setRunning(false);
+              setStdout(data.stdout);
+              setErr(data.err);
+              setErrLine(data.errorLine);
+              if (data.err.length === 0) {
+                workerResolver.current(data.levelFreezed);
+              } else {
+                workerResolver.current(null);
+              }
+              workerResolver.current = null;
+            } else {
+              console.error("luaExecWorker finished but resolver is null");
+            }
+          }
+        }
+      );
+    }
+  }, []);
+  useEffect(initWorker, [initWorker]);
+  if (initError) {
+    throw initError;
+  }
 
   const abortExec = useCallback(() => {
     if (workerResolver.current !== null) {
@@ -84,51 +141,26 @@ export function useLuaExecutor(): LuaExecutor {
   }, []);
   const exec = useCallback(
     (code: string) => {
-      if (workerResolver.current !== null) {
-        abortExec();
-      }
+      abortExec();
+      initWorker();
       setRunning(true);
       const p = new Promise<LevelFreeze | null>((resolve) => {
         workerResolver.current = resolve;
       });
-      if (worker.current === null) {
-        worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
-        worker.current.addEventListener("error", (e) => {
-          console.error(e);
-          setRunning(false);
-          setStdout([]);
-          // e.messageが空の場合がある
-          setErr([e.message || "Unknown error"]);
-          setErrLine(-1);
-          workerResolver.current?.(null);
-          workerResolver.current = null;
-        });
-        worker.current.addEventListener(
-          "message",
-          ({ data }: { data: LuaExecResult }) => {
-            if (workerResolver.current) {
-              setRunning(false);
-              setStdout(data.stdout);
-              setErr(data.err);
-              setErrLine(data.errorLine);
-              if (data.err.length === 0) {
-                workerResolver.current(data.levelFreezed);
-              } else {
-                workerResolver.current(null);
-              }
-              workerResolver.current = null;
-            } else {
-              console.error("luaExecWorker finished but resolver is null");
-            }
-          }
-        );
-      }
-      worker.current.postMessage({ code } satisfies WorkerInput);
+      worker.current!.postMessage({ code } satisfies WorkerInput);
       return p;
     },
-    [abortExec]
+    [abortExec, initWorker]
   );
-  return { stdout, err, errLine, running, exec, abortExec };
+
+  return {
+    stdout,
+    err,
+    errLine,
+    running,
+    exec,
+    abortExec,
+  };
 }
 
 // Aceはposition:fixedがviewportに対する絶対座標であることを想定しているが

--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
   const ChangeLog = await importChangeLogMDX(locale);
   return (
     <html lang={locale}>
-      <body className="fn-body">
+      <body className="fn-body" suppressHydrationWarning>
         <ThemeProvider>
           <IntlProvider locale={locale}>
             <ChangeLogProvider changeLog={<ChangeLog />}>

--- a/frontend/app/[locale]/main/chartList.tsx
+++ b/frontend/app/[locale]/main/chartList.tsx
@@ -700,6 +700,9 @@ function ChartListItemChildren(props: CProps) {
       )}
       {props.brief?.ytId ? (
         <img
+          loading="lazy"
+          decoding="async"
+          fetchPriority="low"
           className="fn-thumbnail"
           src={`https://i.ytimg.com/vi/${props.brief?.ytId}/${props.big ? "mqdefault" : "default"}.jpg`}
         />

--- a/frontend/app/[locale]/metadata.ts
+++ b/frontend/app/[locale]/metadata.ts
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { getTranslations, locales } from "@falling-nikochan/i18n/dynamic";
 import { titleWithoutSiteName, titleWithSiteName } from "./common/title.js";
 
+// @common/themeInit.js にも同じものがある。
 export const backgroundColorLight = "#f0f9ff"; // sky-50
 export const themeColorLight = "#b8e6fe"; // sky-200
 export const backgroundColorDark = "#441306"; // orange-950

--- a/frontend/app/[locale]/styles/main.css
+++ b/frontend/app/[locale]/styles/main.css
@@ -184,8 +184,9 @@
     }
     > :last-child {
       @apply w-full main-wide:w-3/7 main-wide:ml-0 main-wide:-mr-3;
+      @apply p-4.5;
       > .fn-box-inner {
-        @apply p-4.5;
+        @apply relative w-full aspect-[1.6] overflow-hidden;
       }
     }
     &.fn-reverse > :last-child {

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { CenterBox } from "@/common/box";
 import { ErrorMessage } from "@/common/errorPageComponent";
-import clsx from "clsx/lite";
+import themeInitScript from "@/common/themeInit.js?raw";
 
 // Error boundaries must be Client Components
 
@@ -21,13 +21,13 @@ export default function Error(props: ErrorProps) {
   // ボタンとかは置いても無駄でしょう
   return (
     <html>
-      <body
-        className={clsx(
-          "fn-body",
-          // ThemeProviderのimportも避けて直接書いている。
-          "fn-csr-ready"
-        )}
-      >
+      <body className="fn-body" suppressHydrationWarning>
+        <script
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{
+            __html: themeInitScript.replace(/\s+/g, " "),
+          }}
+        />
         <div className="fn-fallback-bg" />
         <CenterBox classNameInner="flex flex-col items-center">
           <h4 className="fn-heading-box">An error has occurred 😢</h4>

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -13,7 +13,7 @@ export default async function NotFoundPage() {
   const t = await getTranslations("en", "error");
   return (
     <html>
-      <body className="fn-body">
+      <body className="fn-body" suppressHydrationWarning>
         <ThemeProvider>
           <CenterBox classNameInner="flex flex-col items-center">
             <h4 className="fn-heading-box">Error 404</h4>

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -9,6 +9,7 @@ import {
   unlinkSync,
 } from "node:fs";
 import createMDX from "@next/mdx";
+import createBundleAnalyzer from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 import packageJson from "./package.json" with { type: "json" };
 import parentPackageJson from "../package.json" with { type: "json" };
@@ -203,6 +204,11 @@ nextConfig = withLicense(nextConfig, {
         dirname(fileURLToPath(import.meta.resolve(`${pkg}/package.json`)))
     ),
 });
+
+const withBundleAnalyzer = createBundleAnalyzer({
+  enabled: !!process.env.ANALYZE,
+});
+nextConfig = withBundleAnalyzer(nextConfig);
 
 export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "16.17.0",
+  "version": "16.18.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@icon-park/svg": "^1.4.2",
+    "@next/bundle-analyzer": "16.1.7",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/file-saver": "^2.0.7",
     "@types/mdx": "^2.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 5.106.2(webpack-cli@7.0.2)
       webpack-cli:
         specifier: ^7.0.2
-        version: 7.0.2(webpack@5.106.2)
+        version: 7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)
       webpack-license-plugin:
         specifier: ^4.5.1
         version: 4.5.1(webpack@5.106.2)
@@ -165,7 +165,7 @@ importers:
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mdx-js/loader':
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+        version: 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -174,13 +174,13 @@ importers:
         version: 3.1.3
       '@next/mdx':
         specifier: 16.1.7
-        version: 16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))
+        version: 16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))
       '@sentry/browser':
         specifier: ^10.52.0
         version: 10.52.0
       '@sentry/nextjs':
         specifier: ^10.52.0
-        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+        version: 10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       ace-builds:
         specifier: ^1.43.5
         version: 1.43.6
@@ -213,7 +213,7 @@ importers:
         version: 4.12.0(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(typescript@5.9.3)
       next-license-list:
         specifier: ^1.0.1
-        version: 1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+        version: 1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       pretty-checkbox:
         specifier: ^3.0.3
         version: 3.0.3
@@ -254,6 +254,9 @@ importers:
       '@icon-park/svg':
         specifier: ^1.4.2
         version: 1.4.2
+      '@next/bundle-analyzer':
+        specifier: 16.1.7
+        version: 16.1.7
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -942,6 +945,10 @@ packages:
     resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
     engines: {node: '>=16.11.0'}
 
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
+
   '@discoveryjs/json-ext@1.0.0':
     resolution: {integrity: sha512-dDlz3W405VMFO4w5kIP9DOmELBcvFQGmLoKSdIRstBDubKFYwaNHV1NnlzMCQpXQFGWVALmeMORAuiLx18AvZQ==}
     engines: {node: '>=14.17.0'}
@@ -1423,6 +1430,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@next/bundle-analyzer@16.1.7':
+    resolution: {integrity: sha512-RlMe5kKnTBtn7l1svgz5BgMZZue+Bymvbvo7aTlzd2un4EMV94fSOvf26Z3NgzhZYv7xf3K2TV7SGPQ5NYHocA==}
+
   '@next/env@16.1.7':
     resolution: {integrity: sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==}
 
@@ -1777,6 +1787,9 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -2841,6 +2854,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -3136,6 +3153,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -3220,6 +3241,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -3299,6 +3323,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -3743,6 +3770,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3807,6 +3838,9 @@ packages:
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -3957,6 +3991,10 @@ packages:
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-reference@1.2.1:
@@ -4429,6 +4467,10 @@ packages:
       socks:
         optional: true
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4579,6 +4621,10 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4994,6 +5040,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+
   sitemap@9.0.1:
     resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
@@ -5193,6 +5243,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -5380,6 +5434,11 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+
   webpack-cli@7.0.2:
     resolution: {integrity: sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==}
     engines: {node: '>=20.9.0'}
@@ -5459,6 +5518,18 @@ packages:
   wretch@3.0.8:
     resolution: {integrity: sha512-HDDFvyELFUVZFiw4hb/QfMkuh+xwHwJoRjCCTDO+E9ik3TrRJSVI7MmzSKQemimeDH9EwIRmQuh4HTgEcVcYVw==}
     engines: {node: '>=22'}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
@@ -6234,6 +6305,8 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@discoveryjs/json-ext@0.5.7': {}
+
   '@discoveryjs/json-ext@1.0.0': {}
 
   '@emnapi/core@1.9.2':
@@ -6577,12 +6650,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
+  '@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -6635,17 +6708,24 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@next/bundle-analyzer@16.1.7':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@next/env@16.1.7': {}
 
   '@next/eslint-plugin-next@16.1.7':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/mdx@16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))':
+  '@next/mdx@16.1.7(@mdx-js/loader@3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      '@mdx-js/loader': 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+      '@mdx-js/loader': 3.1.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.6)
 
   '@next/swc-darwin-arm64@16.1.7':
@@ -6989,6 +7069,8 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -7268,7 +7350,7 @@ snapshots:
       '@sentry/cloudflare': 10.56.0
       '@sentry/node': 10.56.0
 
-  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
+  '@sentry/nextjs@10.52.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0))(react@19.2.6)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -7280,7 +7362,7 @@ snapshots:
       '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/react': 10.52.0(react@19.2.6)
       '@sentry/vercel-edge': 10.52.0
-      '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+      '@sentry/webpack-plugin': 5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       next: 16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.98.0)
       rollup: 4.60.3
       stacktrace-parser: 0.1.11
@@ -7399,10 +7481,10 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.52.0
 
-  '@sentry/webpack-plugin@5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))':
+  '@sentry/webpack-plugin@5.2.0(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.2.0
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7963,6 +8045,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -8245,6 +8331,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@7.2.0: {}
+
   commondir@1.0.1: {}
 
   complex.js@2.4.3: {}
@@ -8328,6 +8416,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debounce@1.2.1: {}
 
   debug@3.2.7:
     dependencies:
@@ -8417,6 +8507,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer@0.1.2: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -9048,6 +9140,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -9134,6 +9230,8 @@ snapshots:
       hono: 4.12.23
 
   hono@4.12.23: {}
+
+  html-escaper@2.0.2: {}
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -9295,6 +9393,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@5.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -9896,6 +9996,8 @@ snapshots:
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -9934,9 +10036,9 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-license-list@1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
+  next-license-list@1.0.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))):
     dependencies:
-      webpack-license-plugin: 4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+      webpack-license-plugin: 4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
     transitivePeerDependencies:
       - webpack
 
@@ -10048,6 +10150,8 @@ snapshots:
       mimic-fn: 2.1.0
 
   openapi-types@12.1.3: {}
+
+  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -10592,6 +10696,12 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sitemap@9.0.1:
     dependencies:
       '@types/node': 24.10.9
@@ -10744,13 +10854,13 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
+  terser-webpack-plugin@5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))
     optionalDependencies:
       postcss: 8.5.14
 
@@ -10781,6 +10891,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 
@@ -11018,7 +11130,26 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-cli@7.0.2(webpack@5.106.2):
+  webpack-bundle-analyzer@4.10.1:
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2):
     dependencies:
       '@discoveryjs/json-ext': 1.0.0
       commander: 14.0.3
@@ -11030,14 +11161,16 @@ snapshots:
       rechoir: 0.8.0
       webpack: 5.106.2(webpack-cli@7.0.2)
       webpack-merge: 6.0.1
+    optionalDependencies:
+      webpack-bundle-analyzer: 4.10.1
 
-  webpack-license-plugin@4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))):
+  webpack-license-plugin@4.5.1(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))):
     dependencies:
       chalk: 5.6.2
       lodash: 4.18.1
       needle: 3.3.1
       spdx-expression-validate: 2.0.0
-      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2))
+      webpack: 5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2))
       webpack-sources: 3.4.1
 
   webpack-license-plugin@4.5.1(webpack@5.106.2):
@@ -11057,7 +11190,7 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)):
+  webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -11080,11 +11213,11 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack@5.106.2)))
+      terser-webpack-plugin: 5.6.0(postcss@8.5.14)(webpack@5.106.2(postcss@8.5.14)(webpack-cli@7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 7.0.2(webpack@5.106.2)
+      webpack-cli: 7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -11126,7 +11259,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:
-      webpack-cli: 7.0.2(webpack@5.106.2)
+      webpack-cli: 7.0.2(webpack-bundle-analyzer@4.10.1)(webpack@5.106.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -11205,6 +11338,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wretch@3.0.8: {}
+
+  ws@7.5.11: {}
 
   ws@8.20.1: {}
 

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "16.17.0",
+  "version": "16.18.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
- 画像の遅延読み込み
- mathjs, yaml, wasmoonの遅延読み込み
- テーマの読み込みをインラインscriptタグに移動
- bundle-analyzerを常時インストールしておく
- workerをeditページ起動時に非同期に初期化し、エラーが出たらページ全体を止める
