### PR TITLE
undo/redo

### DIFF
--- a/chart/src/editing/chart.ts
+++ b/chart/src/editing/chart.ts
@@ -25,7 +25,7 @@ export class ChartEditing extends EventEmitter<EventType> {
     composer: string;
     chartCreator: string;
   };
-  #levels: LevelEditing[];
+  #levels: LevelEditing[] = []; // 変更時にはindexの再設定が必要なので、直接アクセスせずsetterを使うこと
   #currentLevelIndex: number | undefined; // 範囲外にはせず、levelsが空の場合undefined
   #copyBuffer: CopyBuffer;
   #zoom: number;
@@ -73,21 +73,23 @@ export class ChartEditing extends EventEmitter<EventType> {
       composer: obj.composer,
       chartCreator: obj.chartCreator,
     };
-    this.#levels = obj.levelsMeta.map(
-      (_, i) =>
-        new LevelEditing(
-          obj.levelsMeta[i],
-          obj.levelsFreeze[i],
-          obj.lua[i],
-          (type) => this.emit(type),
-          () => this.#offset,
-          this.#luaExecutorRef
-        )
+    this.#setLevels(
+      obj.levelsMeta.map(
+        (_, i) =>
+          new LevelEditing(
+            obj.levelsMeta[i],
+            obj.levelsFreeze[i],
+            obj.lua[i],
+            (type) => this.emit(type),
+            () => this.#offset,
+            this.#luaExecutorRef
+          )
+      )
     );
     this.#copyBuffer = { ...obj.copyBuffer };
     this.#zoom = obj.zoom;
     this.#currentLevelIndex =
-      options.currentLevelIndex ?? (this.#levels.length >= 1 ? 0 : undefined);
+      options.currentLevelIndex ?? (this.levels.length >= 1 ? 0 : undefined);
 
     this.#hasChange = options.hasChange ?? false;
     this.#numEvents = numEvents(this.toObject());
@@ -111,9 +113,9 @@ export class ChartEditing extends EventEmitter<EventType> {
       offset: this.#offset,
       locale: this.#locale,
       ...this.#meta,
-      levelsMeta: this.#levels.map((l) => l.meta),
-      lua: this.#levels.map((l) => [...l.lua]),
-      levelsFreeze: this.#levels.map((l) => ({
+      levelsMeta: this.levels.map((l) => l.meta),
+      lua: this.levels.map((l) => [...l.lua]),
+      levelsFreeze: this.levels.map((l) => ({
         ...l.freeze,
         bpmChanges: l.freeze.bpmChanges.map((c) => ({
           step: c.step,
@@ -146,11 +148,15 @@ export class ChartEditing extends EventEmitter<EventType> {
     return this.#numEvents;
   }
   get levels() {
-    return [...this.#levels] as const;
+    return this.#levels as readonly LevelEditing[];
+  }
+  #setLevels(levels: LevelEditing[]) {
+    this.#levels = levels;
+    this.#levels.forEach((l, i) => (l.index = i));
   }
   get currentLevel() {
     if (this.#currentLevelIndex !== undefined) {
-      return this.#levels[this.#currentLevelIndex];
+      return this.levels[this.#currentLevelIndex];
     } else {
       return undefined;
     }
@@ -161,13 +167,12 @@ export class ChartEditing extends EventEmitter<EventType> {
     freeze: Readonly<LevelFreeze>;
   }) {
     if (this.#currentLevelIndex === undefined) {
-      this.#currentLevelIndex = this.#levels.length;
+      this.#currentLevelIndex = this.levels.length;
     } else {
       this.#currentLevelIndex = this.#currentLevelIndex + 1;
     }
-    this.#levels.splice(
-      this.#currentLevelIndex,
-      0,
+    this.#setLevels([
+      ...this.levels.slice(0, this.#currentLevelIndex),
       new LevelEditing(
         level.min,
         level.freeze,
@@ -175,19 +180,23 @@ export class ChartEditing extends EventEmitter<EventType> {
         (type) => this.emit(type),
         () => this.#offset,
         this.#luaExecutorRef
-      )
-    );
+      ),
+      ...this.levels.slice(this.#currentLevelIndex),
+    ]);
     this.emit("rerender");
     this.emit("change");
     this.emit("levelIndex");
   }
   deleteLevel() {
-    if (this.#currentLevelIndex !== undefined && this.#levels.length > 0) {
-      this.#levels.splice(this.#currentLevelIndex, 1);
-      if (this.#levels.length === 0) {
+    if (this.#currentLevelIndex !== undefined && this.levels.length > 0) {
+      this.#setLevels([
+        ...this.levels.slice(0, this.#currentLevelIndex),
+        ...this.levels.slice(this.#currentLevelIndex + 1),
+      ]);
+      if (this.levels.length === 0) {
         this.#currentLevelIndex = undefined;
-      } else if (this.#currentLevelIndex >= this.#levels.length) {
-        this.#currentLevelIndex = this.#levels.length - 1;
+      } else if (this.#currentLevelIndex >= this.levels.length) {
+        this.#currentLevelIndex = this.levels.length - 1;
       }
       this.emit("rerender");
       this.emit("change");
@@ -197,9 +206,12 @@ export class ChartEditing extends EventEmitter<EventType> {
   moveLevelUp() {
     if (this.#currentLevelIndex !== undefined && this.#currentLevelIndex > 0) {
       const idx = this.#currentLevelIndex;
-      const tmp = this.#levels[idx];
-      this.#levels[idx] = this.#levels[idx - 1];
-      this.#levels[idx - 1] = tmp;
+      this.#setLevels([
+        ...this.levels.slice(0, idx - 1),
+        this.levels[idx],
+        this.levels[idx - 1],
+        ...this.levels.slice(idx),
+      ]);
       this.#currentLevelIndex = idx - 1;
       this.emit("rerender");
       this.emit("change");
@@ -209,12 +221,15 @@ export class ChartEditing extends EventEmitter<EventType> {
   moveLevelDown() {
     if (
       this.#currentLevelIndex !== undefined &&
-      this.#currentLevelIndex < this.#levels.length - 1
+      this.#currentLevelIndex < this.levels.length - 1
     ) {
       const idx = this.#currentLevelIndex;
-      const tmp = this.#levels[idx];
-      this.#levels[idx] = this.#levels[idx + 1];
-      this.#levels[idx + 1] = tmp;
+      this.#setLevels([
+        ...this.levels.slice(0, idx),
+        this.levels[idx + 1],
+        this.levels[idx],
+        ...this.levels.slice(idx + 1),
+      ]);
       this.#currentLevelIndex = idx + 1;
       this.emit("rerender");
       this.emit("change");
@@ -225,7 +240,7 @@ export class ChartEditing extends EventEmitter<EventType> {
     return this.#currentLevelIndex;
   }
   setCurrentLevelIndex(index: number) {
-    if (index >= 0 && index < this.#levels.length) {
+    if (index >= 0 && index < this.levels.length) {
       this.#currentLevelIndex = index;
       this.emit("rerender");
       this.emit("levelIndex");
@@ -262,19 +277,19 @@ export class ChartEditing extends EventEmitter<EventType> {
   setOffset(ofs: number) {
     const oldOffset = this.#offset;
     this.#offset = ofs;
-    for (const level of this.#levels) {
+    for (const level of this.levels) {
       level.setCurrentTimeWithoutOffset(level.current.timeSec + oldOffset);
     }
     this.emit("rerender");
     this.emit("change");
   }
   setCurrentTimeWithoutOffset(timeSecWithoutOffset: number) {
-    for (const level of this.#levels) {
+    for (const level of this.levels) {
       level.setCurrentTimeWithoutOffset(timeSecWithoutOffset);
     }
   }
   setYTDuration(duration: number) {
-    for (const level of this.#levels) {
+    for (const level of this.levels) {
       level.setYTDuration(duration);
     }
   }

--- a/chart/src/editing/chart.ts
+++ b/chart/src/editing/chart.ts
@@ -51,6 +51,7 @@ export class ChartEditing extends EventEmitter<EventType> {
       convertedFrom?: number;
       currentLevelIndex?: number;
       hasChange?: boolean;
+      undoManager?: unknown[];
     }
   ) {
     super();
@@ -86,6 +87,12 @@ export class ChartEditing extends EventEmitter<EventType> {
           )
       )
     );
+    this.#levels.forEach((l, i) => {
+      if (typeof options.undoManager?.[i] === "object") {
+        l.luaEditorInitialUndoManager = options.undoManager[i];
+      }
+    });
+
     this.#copyBuffer = { ...obj.copyBuffer };
     this.#zoom = obj.zoom;
     this.#currentLevelIndex =

--- a/chart/src/editing/level.ts
+++ b/chart/src/editing/level.ts
@@ -170,7 +170,7 @@ export class LevelEditing extends EventEmitter<EventType> {
     this.#lua = lua;
     if (!fromLuaEditor) {
       this.#luaEditorValue = lua.join("\n");
-      this.emit("luaEditor");
+      this.emit("rerender");
     }
     this.#luaExecutorRef.current.abortExec();
     const levelFreezed = await this.#luaExecutorRef.current.exec(
@@ -188,23 +188,29 @@ export class LevelEditing extends EventEmitter<EventType> {
       }
     }
   }
-  _manualLuaUpdateForTesting(lua: string[]){
+  _manualLuaUpdateForTesting(lua: string[]) {
     this.#lua = lua;
   }
 
   get luaEditorValue() {
     return this.#luaEditorValue;
   }
-  setLuaEditorValue(lua: string) {
+  setLuaEditorValue(lua: string, inCodeEditor: boolean) {
     if (this.#luaEditorValue !== lua) {
       this.#luaEditorValue = lua;
       if (this.#luaEditorDebounceTimeout !== null) {
         clearTimeout(this.#luaEditorDebounceTimeout);
       }
-      this.#luaEditorDebounceTimeout = setTimeout(() => {
+      // これが呼ばれるのは、ユーザーが直接コードを編集した場合だけでなく、undoボタンを押した時なども含まれる。
+      // コードエディター以外でundoボタンを押した場合には、他の編集機能と同様、即時コードを実行して反映する。
+      if (inCodeEditor) {
+        this.#luaEditorDebounceTimeout = setTimeout(() => {
+          this.updateLua(lua.split("\n"), true);
+        }, 500);
+      } else {
         this.updateLua(lua.split("\n"), true);
-      }, 500);
-      this.emit("luaEditor");
+      }
+      this.emit("rerender");
     }
   }
 

--- a/chart/src/editing/level.ts
+++ b/chart/src/editing/level.ts
@@ -55,6 +55,10 @@ export class LevelEditing extends EventEmitter<EventType> {
     signature: SignatureWithBarNum[];
   };
 
+  #lastValidLua: string[];
+  #luaEditorValue: string;
+  #luaEditorDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
+
   constructor(
     min: Readonly<LevelMin>,
     freeze: Readonly<LevelFreeze>,
@@ -72,6 +76,8 @@ export class LevelEditing extends EventEmitter<EventType> {
 
     this.#meta = JSON.parse(JSON.stringify(min));
     this.#lua = [...lua];
+    this.#lastValidLua = [...lua];
+    this.#luaEditorValue = lua.join("\n");
     this.#freeze = JSON.parse(JSON.stringify(freeze));
     const { bpm, speed } = updateBpmTimeSec(
       this.#freeze.bpmChanges,
@@ -160,23 +166,45 @@ export class LevelEditing extends EventEmitter<EventType> {
     this.emit("rerender");
     this.emit("change");
   }
-  async updateLua(lua: string[]) {
-    const prevLua = this.#lua;
+  async updateLua(lua: string[], fromLuaEditor: boolean = false) {
     this.#lua = lua;
+    if (!fromLuaEditor) {
+      this.#luaEditorValue = lua.join("\n");
+      this.emit("luaEditor");
+    }
     this.#luaExecutorRef.current.abortExec();
     const levelFreezed = await this.#luaExecutorRef.current.exec(
       lua.join("\n")
     );
     if (levelFreezed) {
-      this.#lua = lua;
+      this.#lastValidLua = lua;
       this.updateFreeze(levelFreezed);
     } else {
       if (this.#lua === lua) {
         // 変更をrevert
-        this.#lua = prevLua;
+        this.#lua = this.#lastValidLua;
       } else {
-        // すでに別のコードでupdateLuaが呼ばれているので、気にしなくて良い
+        // abortされ、すでに別のコードでupdateLuaが呼ばれている場合、何もしない
       }
+    }
+  }
+  _manualLuaUpdateForTesting(lua: string[]){
+    this.#lua = lua;
+  }
+
+  get luaEditorValue() {
+    return this.#luaEditorValue;
+  }
+  setLuaEditorValue(lua: string) {
+    if (this.#luaEditorValue !== lua) {
+      this.#luaEditorValue = lua;
+      if (this.#luaEditorDebounceTimeout !== null) {
+        clearTimeout(this.#luaEditorDebounceTimeout);
+      }
+      this.#luaEditorDebounceTimeout = setTimeout(() => {
+        this.updateLua(lua.split("\n"), true);
+      }, 500);
+      this.emit("luaEditor");
     }
   }
 

--- a/chart/src/editing/level.ts
+++ b/chart/src/editing/level.ts
@@ -44,6 +44,11 @@ export class LevelEditing extends EventEmitter<EventType> {
   // これは親のChartEditingと同期
   #offset: () => number;
   index: number = null!;
+
+  // エディタ内でlevelを一意に識別するid (Reactのkeyに使う)
+  static #localCount = 0;
+  localId: number;
+
   #luaExecutorRef: LuaExecutorRef;
   // 以下の編集には updateMeta(), updateFreeze(), updateLua() を使う
   #meta: LevelMin;
@@ -59,6 +64,8 @@ export class LevelEditing extends EventEmitter<EventType> {
   #lastValidLua: string[];
   #luaEditorValue: string;
   #luaEditorDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
+  // chartState.tsでsessionからの復元時にセットし、luaEditorの初期化に使う
+  luaEditorInitialUndoManager: object | null = null;
 
   constructor(
     min: Readonly<LevelMin>,
@@ -72,6 +79,7 @@ export class LevelEditing extends EventEmitter<EventType> {
     for (const type of eventTypes) {
       this.on(type, () => parentEmit(type));
     }
+    this.localId = ++LevelEditing.#localCount;
     this.#offset = offset;
     this.#luaExecutorRef = luaExecutorRef;
 

--- a/chart/src/editing/level.ts
+++ b/chart/src/editing/level.ts
@@ -43,6 +43,7 @@ import {
 export class LevelEditing extends EventEmitter<EventType> {
   // これは親のChartEditingと同期
   #offset: () => number;
+  index: number = null!;
   #luaExecutorRef: LuaExecutorRef;
   // 以下の編集には updateMeta(), updateFreeze(), updateLua() を使う
   #meta: LevelMin;
@@ -174,7 +175,8 @@ export class LevelEditing extends EventEmitter<EventType> {
     }
     this.#luaExecutorRef.current.abortExec();
     const levelFreezed = await this.#luaExecutorRef.current.exec(
-      lua.join("\n")
+      lua.join("\n"),
+      this.index
     );
     if (levelFreezed) {
       this.#lastValidLua = lua;

--- a/chart/src/editing/types.ts
+++ b/chart/src/editing/types.ts
@@ -4,6 +4,7 @@ export const eventTypes = [
   "rerender", // 再render用
   "change", // toObject()で出力するデータに変化があるとき (session管理 & hasChange で使う)
   "levelIndex", // currentLevelIndexが変化したとき
+  "luaEditor",
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 

--- a/chart/src/editing/types.ts
+++ b/chart/src/editing/types.ts
@@ -16,6 +16,7 @@ export interface LuaExecutorLastResult {
 export interface LuaExecutor {
   result: LuaExecutorLastResult | null;
   running: boolean;
+  clearResult: () => void;
   exec: (code: string, levelIndex: number) => Promise<LevelFreeze | null>;
   abortExec: () => void;
 }

--- a/chart/src/editing/types.ts
+++ b/chart/src/editing/types.ts
@@ -4,7 +4,6 @@ export const eventTypes = [
   "rerender", // 再render用
   "change", // toObject()で出力するデータに変化があるとき (session管理 & hasChange で使う)
   "levelIndex", // currentLevelIndexが変化したとき
-  "luaEditor",
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 

--- a/chart/src/editing/types.ts
+++ b/chart/src/editing/types.ts
@@ -7,12 +7,16 @@ export const eventTypes = [
 ] as const;
 export type EventType = (typeof eventTypes)[number];
 
-export interface LuaExecutor {
+export interface LuaExecutorLastResult {
   stdout: string[];
   err: string[];
   errLine: number | null;
+  levelIndex: number;
+}
+export interface LuaExecutor {
+  result: LuaExecutorLastResult | null;
   running: boolean;
-  exec: (code: string) => Promise<LevelFreeze | null>;
+  exec: (code: string, levelIndex: number) => Promise<LevelFreeze | null>;
   abortExec: () => void;
 }
 export type LuaExecutorRef = { current: LuaExecutor };

--- a/chart/tests/editing/dummy.ts
+++ b/chart/tests/editing/dummy.ts
@@ -15,9 +15,7 @@ export function dummyLuaExecutor(
 ): { current: LuaExecutor } {
   return {
     current: {
-      stdout: [],
-      err: [],
-      errLine: null,
+      result: null,
       running: false,
       exec,
       abortExec,

--- a/chart/tests/editing/level.spec.ts
+++ b/chart/tests/editing/level.spec.ts
@@ -252,88 +252,323 @@ describe("LevelEditing", () => {
     });
   });
   describe("updateLua", () => {
-    test("should abort current execution", () => {
-      let aborted = false;
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(
-          async () => null,
-          () => {
-            aborted = true;
+    [false, true].forEach((fromLuaEditor) =>
+      describe(
+        fromLuaEditor ? "from lua editor" : "not from lua editor",
+        () => {
+          test("should abort current execution", () => {
+            let aborted = false;
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(
+                async () => null,
+                () => {
+                  aborted = true;
+                }
+              )
+            );
+            level.updateLua([...level.lua, "print('new line')"], fromLuaEditor);
+            expect(aborted).to.equal(true);
+          });
+          test("should try to execute new lua", async () => {
+            let executedCode = "";
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async (code: string) => {
+                executedCode = code;
+                return null;
+              })
+            );
+            await level.updateLua(
+              ["print('new line')", "print('new line 2')"],
+              fromLuaEditor
+            );
+            expect(executedCode).to.equal(
+              "print('new line')\nprint('new line 2')"
+            );
+          });
+          test("should update lua immediately", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            const p = level.updateLua(newLua, fromLuaEditor);
+            expect(level.lua).to.deep.equal(newLua);
+            await p;
+            expect(level.lua).to.deep.equal(newLua);
+          });
+          test("should update freeze data after successful execution", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => ({
+                notes: [
+                  ...dummyChartData.levelsFreeze[0].notes,
+                  {
+                    step: { fourth: 5, numerator: 0, denominator: 1 },
+                    big: false,
+                    hitX: -1,
+                    hitVX: 1,
+                    hitVY: 3,
+                    fall: true,
+                    luaLine: null,
+                  },
+                ],
+                rest: dummyChartData.levelsFreeze[0].rest,
+                bpmChanges: dummyChartData.levelsFreeze[0].bpmChanges,
+                speedChanges: dummyChartData.levelsFreeze[0].speedChanges,
+                signature: dummyChartData.levelsFreeze[0].signature,
+              }))
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            await level.updateLua(newLua, fromLuaEditor);
+            expect(level.freeze.notes).to.have.lengthOf(
+              dummyChartData.levelsFreeze[0].notes.length + 1
+            );
+          });
+          test("should revert lua if execution returns null", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => null)
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            const p = level.updateLua(newLua, fromLuaEditor);
+            expect(level.lua).to.deep.equal(newLua);
+            await p;
+            expect(level.lua).to.deep.equal(dummyChartData.lua[0]);
+          });
+          test("should not revert lua if another execution started and lua updated", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => null)
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            const p = level.updateLua(newLua, fromLuaEditor);
+            const newLua2 = [...level.lua, "print('new line 2')"];
+            // const p2 = level.updateLua(newLua2, fromLuaEditor);
+            level._manualLuaUpdateForTesting(newLua2); // updateLuaは一瞬で終了して意図したテストができないので、手動上書き
+            await p;
+            expect(level.lua).to.deep.equal(newLua2);
+          });
+          test("should revert lua to last valid value eventually", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => null)
+            );
+            const oldLua = level.lua;
+            const newLua = [...level.lua, "print('new line')"];
+            const p = level.updateLua(newLua, fromLuaEditor);
+            const newLua2 = [...level.lua, "print('new line 2')"];
+            const p2 = level.updateLua(newLua2, fromLuaEditor);
+            await p;
+            await p2;
+            expect(level.lua).to.deep.equal(oldLua);
+          });
+
+          if (fromLuaEditor) {
+            test("should never update luaEditorValue", async () => {
+              // ユーザーが編集した場合、またはundo/redoされた場合が考えられる。
+              const level = new LevelEditing(
+                dummyChartData.levelsMeta[0],
+                dummyChartData.levelsFreeze[0],
+                dummyChartData.lua[0],
+                () => {},
+                () => dummyChartData.offset,
+                dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+              );
+              const oldLua = level.lua;
+              expect(level.luaEditorValue).to.equal(oldLua.join("\n"));
+              const newLua = [...level.lua, "print('new line')"];
+              const p = level.updateLua(newLua, fromLuaEditor);
+              expect(level.luaEditorValue).to.equal(oldLua.join("\n"));
+              await p;
+              expect(level.luaEditorValue).to.equal(oldLua.join("\n"));
+            });
+            test("should never trigger luaEditor event", async () => {
+              const level = new LevelEditing(
+                dummyChartData.levelsMeta[0],
+                dummyChartData.levelsFreeze[0],
+                dummyChartData.lua[0],
+                () => {},
+                () => dummyChartData.offset,
+                dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+              );
+              let luaUpdated = false;
+              level.on("luaEditor", () => {
+                luaUpdated = true;
+              });
+              const newLua = [...level.lua, "print('new line')"];
+              const p = level.updateLua(newLua, fromLuaEditor);
+              expect(luaUpdated).to.equal(false);
+              await p;
+              expect(luaUpdated).to.equal(false);
+            });
+          } else {
+            test("should update luaEditorValue immediately", async () => {
+              const level = new LevelEditing(
+                dummyChartData.levelsMeta[0],
+                dummyChartData.levelsFreeze[0],
+                dummyChartData.lua[0],
+                () => {},
+                () => dummyChartData.offset,
+                dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+              );
+              expect(level.luaEditorValue).to.equal(level.lua.join("\n"));
+              const newLua = [...level.lua, "print('new line')"];
+              const p = level.updateLua(newLua, fromLuaEditor);
+              expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+              await p;
+              expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+            });
+            test("should trigger luaEditor event immediately", async () => {
+              const level = new LevelEditing(
+                dummyChartData.levelsMeta[0],
+                dummyChartData.levelsFreeze[0],
+                dummyChartData.lua[0],
+                () => {},
+                () => dummyChartData.offset,
+                dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+              );
+              let luaUpdated = false;
+              level.on("luaEditor", () => {
+                luaUpdated = true;
+              });
+              const newLua = [...level.lua, "print('new line')"];
+              const p = level.updateLua(newLua, fromLuaEditor);
+              expect(luaUpdated).to.equal(true);
+              luaUpdated = false;
+              await p;
+              expect(luaUpdated).to.equal(false);
+            });
           }
-        )
-      );
-      level.updateLua([...level.lua, "print('new line')"]);
-      expect(aborted).to.equal(true);
-    });
-    test("should try to execute new lua", async () => {
-      let executedCode = "";
+          test("should not revert luaEditorValue if execution returns null", async () => {
+            // これは not fromLuaEditor の場合正直どちらでも良いかもしれない
+            // fromLuaEditorの場合はrevertすると履歴が消えてしまうのでしてはいけない。
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => null)
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            const p = level.updateLua(newLua, fromLuaEditor);
+            const updatedLuaEditorValue = level.luaEditorValue;
+            let luaUpdated = false;
+            level.on("luaEditor", () => {
+              luaUpdated = true;
+            });
+            await p;
+            expect(luaUpdated).to.equal(false);
+            expect(level.luaEditorValue).to.equal(updatedLuaEditorValue);
+          });
+        }
+      )
+    );
+  });
+  describe("setLuaEditorValue", () => {
+    test("should update luaEditorValue immediately", async () => {
       const level = new LevelEditing(
         dummyChartData.levelsMeta[0],
         dummyChartData.levelsFreeze[0],
         dummyChartData.lua[0],
         () => {},
         () => dummyChartData.offset,
-        dummyLuaExecutor(async (code: string) => {
-          executedCode = code;
-          return null;
-        })
-      );
-      await level.updateLua(["print('new line')", "print('new line 2')"]);
-      expect(executedCode).to.equal("print('new line')\nprint('new line 2')");
-    });
-    test("should update lua and freeze data", async () => {
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(async () => ({
-          notes: [
-            ...dummyChartData.levelsFreeze[0].notes,
-            {
-              step: { fourth: 5, numerator: 0, denominator: 1 },
-              big: false,
-              hitX: -1,
-              hitVX: 1,
-              hitVY: 3,
-              fall: true,
-              luaLine: null,
-            },
-          ],
-          rest: dummyChartData.levelsFreeze[0].rest,
-          bpmChanges: dummyChartData.levelsFreeze[0].bpmChanges,
-          speedChanges: dummyChartData.levelsFreeze[0].speedChanges,
-          signature: dummyChartData.levelsFreeze[0].signature,
-        }))
+        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
       );
       const newLua = [...level.lua, "print('new line')"];
-      await level.updateLua(newLua);
+      level.setLuaEditorValue(newLua.join("\n"));
+      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+    });
+    test("should trigger luaEditor event immediately", async () => {
+      const level = new LevelEditing(
+        dummyChartData.levelsMeta[0],
+        dummyChartData.levelsFreeze[0],
+        dummyChartData.lua[0],
+        () => {},
+        () => dummyChartData.offset,
+        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+      );
+      let luaUpdated = false;
+      level.on("luaEditor", () => {
+        luaUpdated = true;
+      });
+      const newLua = [...level.lua, "print('new line')"];
+      level.setLuaEditorValue(newLua.join("\n"));
+      expect(luaUpdated).to.equal(true);
+    });
+    test("should update lua after 500 ms", async () => {
+      const level = new LevelEditing(
+        dummyChartData.levelsMeta[0],
+        dummyChartData.levelsFreeze[0],
+        dummyChartData.lua[0],
+        () => {},
+        () => dummyChartData.offset,
+        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+      );
+      const oldLua = level.lua;
+      const newLua = [...level.lua, "print('new line')"];
+      level.setLuaEditorValue(newLua.join("\n"));
+      expect(level.lua).to.deep.equal(oldLua);
+      await new Promise<void>((r) => setTimeout(r, 600));
       expect(level.lua).to.deep.equal(newLua);
-      expect(level.freeze.notes).to.have.lengthOf(
-        dummyChartData.levelsFreeze[0].notes.length + 1
-      );
     });
-    test("should not update lua and freeze data if execution returns null", async () => {
+    test("should reset timer on another update", async () => {
       const level = new LevelEditing(
         dummyChartData.levelsMeta[0],
         dummyChartData.levelsFreeze[0],
         dummyChartData.lua[0],
         () => {},
         () => dummyChartData.offset,
-        dummyLuaExecutor(async () => null)
+        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
       );
+      const oldLua = level.lua;
       const newLua = [...level.lua, "print('new line')"];
-      await level.updateLua(newLua);
-      expect(level.lua).to.deep.equal(dummyChartData.lua[0]);
-      expect(level.freeze.notes).to.have.lengthOf(
-        dummyChartData.levelsFreeze[0].notes.length
-      );
+      level.setLuaEditorValue(newLua.join("\n"));
+      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+      expect(level.lua).to.deep.equal(oldLua);
+      await new Promise<void>((r) => setTimeout(r, 400));
+      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+      expect(level.lua).to.deep.equal(oldLua);
+      const newLua2 = [...level.lua, "print('new line 2')"];
+      level.setLuaEditorValue(newLua2.join("\n"));
+      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+      expect(level.lua).to.deep.equal(oldLua);
+      await new Promise<void>((r) => setTimeout(r, 400));
+      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+      expect(level.lua).to.deep.equal(oldLua);
+      await new Promise<void>((r) => setTimeout(r, 200));
+      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+      expect(level.lua).to.deep.equal(newLua2);
     });
   });
 

--- a/chart/tests/editing/level.spec.ts
+++ b/chart/tests/editing/level.spec.ts
@@ -412,25 +412,6 @@ describe("LevelEditing", () => {
               await p;
               expect(level.luaEditorValue).to.equal(oldLua.join("\n"));
             });
-            test("should never trigger luaEditor event", async () => {
-              const level = new LevelEditing(
-                dummyChartData.levelsMeta[0],
-                dummyChartData.levelsFreeze[0],
-                dummyChartData.lua[0],
-                () => {},
-                () => dummyChartData.offset,
-                dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
-              );
-              let luaUpdated = false;
-              level.on("luaEditor", () => {
-                luaUpdated = true;
-              });
-              const newLua = [...level.lua, "print('new line')"];
-              const p = level.updateLua(newLua, fromLuaEditor);
-              expect(luaUpdated).to.equal(false);
-              await p;
-              expect(luaUpdated).to.equal(false);
-            });
           } else {
             test("should update luaEditorValue immediately", async () => {
               const level = new LevelEditing(
@@ -448,7 +429,7 @@ describe("LevelEditing", () => {
               await p;
               expect(level.luaEditorValue).to.equal(newLua.join("\n"));
             });
-            test("should trigger luaEditor event immediately", async () => {
+            test("should trigger rerender event immediately", async () => {
               const level = new LevelEditing(
                 dummyChartData.levelsMeta[0],
                 dummyChartData.levelsFreeze[0],
@@ -458,15 +439,12 @@ describe("LevelEditing", () => {
                 dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
               );
               let luaUpdated = false;
-              level.on("luaEditor", () => {
+              level.on("rerender", () => {
                 luaUpdated = true;
               });
               const newLua = [...level.lua, "print('new line')"];
-              const p = level.updateLua(newLua, fromLuaEditor);
+              level.updateLua(newLua, fromLuaEditor);
               expect(luaUpdated).to.equal(true);
-              luaUpdated = false;
-              await p;
-              expect(luaUpdated).to.equal(false);
             });
           }
           test("should not revert luaEditorValue if execution returns null", async () => {
@@ -484,7 +462,7 @@ describe("LevelEditing", () => {
             const p = level.updateLua(newLua, fromLuaEditor);
             const updatedLuaEditorValue = level.luaEditorValue;
             let luaUpdated = false;
-            level.on("luaEditor", () => {
+            level.on("rerender", () => {
               luaUpdated = true;
             });
             await p;
@@ -496,80 +474,101 @@ describe("LevelEditing", () => {
     );
   });
   describe("setLuaEditorValue", () => {
-    test("should update luaEditorValue immediately", async () => {
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
-      );
-      const newLua = [...level.lua, "print('new line')"];
-      level.setLuaEditorValue(newLua.join("\n"));
-      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
-    });
-    test("should trigger luaEditor event immediately", async () => {
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
-      );
-      let luaUpdated = false;
-      level.on("luaEditor", () => {
-        luaUpdated = true;
-      });
-      const newLua = [...level.lua, "print('new line')"];
-      level.setLuaEditorValue(newLua.join("\n"));
-      expect(luaUpdated).to.equal(true);
-    });
-    test("should update lua after 500 ms", async () => {
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
-      );
-      const oldLua = level.lua;
-      const newLua = [...level.lua, "print('new line')"];
-      level.setLuaEditorValue(newLua.join("\n"));
-      expect(level.lua).to.deep.equal(oldLua);
-      await new Promise<void>((r) => setTimeout(r, 600));
-      expect(level.lua).to.deep.equal(newLua);
-    });
-    test("should reset timer on another update", async () => {
-      const level = new LevelEditing(
-        dummyChartData.levelsMeta[0],
-        dummyChartData.levelsFreeze[0],
-        dummyChartData.lua[0],
-        () => {},
-        () => dummyChartData.offset,
-        dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
-      );
-      const oldLua = level.lua;
-      const newLua = [...level.lua, "print('new line')"];
-      level.setLuaEditorValue(newLua.join("\n"));
-      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
-      expect(level.lua).to.deep.equal(oldLua);
-      await new Promise<void>((r) => setTimeout(r, 400));
-      expect(level.luaEditorValue).to.equal(newLua.join("\n"));
-      expect(level.lua).to.deep.equal(oldLua);
-      const newLua2 = [...level.lua, "print('new line 2')"];
-      level.setLuaEditorValue(newLua2.join("\n"));
-      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
-      expect(level.lua).to.deep.equal(oldLua);
-      await new Promise<void>((r) => setTimeout(r, 400));
-      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
-      expect(level.lua).to.deep.equal(oldLua);
-      await new Promise<void>((r) => setTimeout(r, 200));
-      expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
-      expect(level.lua).to.deep.equal(newLua2);
-    });
+    [false, true].forEach((inLuaEditor) =>
+      describe(inLuaEditor ? "in lua editor" : "not in lua editor", () => {
+        test("should update luaEditorValue immediately", async () => {
+          const level = new LevelEditing(
+            dummyChartData.levelsMeta[0],
+            dummyChartData.levelsFreeze[0],
+            dummyChartData.lua[0],
+            () => {},
+            () => dummyChartData.offset,
+            dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+          );
+          const newLua = [...level.lua, "print('new line')"];
+          level.setLuaEditorValue(newLua.join("\n"), inLuaEditor);
+          expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+        });
+        test("should trigger rerender event immediately", async () => {
+          const level = new LevelEditing(
+            dummyChartData.levelsMeta[0],
+            dummyChartData.levelsFreeze[0],
+            dummyChartData.lua[0],
+            () => {},
+            () => dummyChartData.offset,
+            dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+          );
+          let luaUpdated = false;
+          level.on("rerender", () => {
+            luaUpdated = true;
+          });
+          const newLua = [...level.lua, "print('new line')"];
+          level.setLuaEditorValue(newLua.join("\n"), inLuaEditor);
+          expect(luaUpdated).to.equal(true);
+        });
+        if (inLuaEditor) {
+          test("should update lua after 500 ms", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+            );
+            const oldLua = level.lua;
+            const newLua = [...level.lua, "print('new line')"];
+            level.setLuaEditorValue(newLua.join("\n"), inLuaEditor);
+            expect(level.lua).to.deep.equal(oldLua);
+            await new Promise<void>((r) => setTimeout(r, 600));
+            expect(level.lua).to.deep.equal(newLua);
+          });
+          test("should reset timer on another update", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+            );
+            const oldLua = level.lua;
+            const newLua = [...level.lua, "print('new line')"];
+            level.setLuaEditorValue(newLua.join("\n"), inLuaEditor);
+            expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+            expect(level.lua).to.deep.equal(oldLua);
+            await new Promise<void>((r) => setTimeout(r, 400));
+            expect(level.luaEditorValue).to.equal(newLua.join("\n"));
+            expect(level.lua).to.deep.equal(oldLua);
+            const newLua2 = [...level.lua, "print('new line 2')"];
+            level.setLuaEditorValue(newLua2.join("\n"), inLuaEditor);
+            expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+            expect(level.lua).to.deep.equal(oldLua);
+            await new Promise<void>((r) => setTimeout(r, 400));
+            expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+            expect(level.lua).to.deep.equal(oldLua);
+            await new Promise<void>((r) => setTimeout(r, 200));
+            expect(level.luaEditorValue).to.equal(newLua2.join("\n"));
+            expect(level.lua).to.deep.equal(newLua2);
+          });
+        } else {
+          test("should update lua immediately", async () => {
+            const level = new LevelEditing(
+              dummyChartData.levelsMeta[0],
+              dummyChartData.levelsFreeze[0],
+              dummyChartData.lua[0],
+              () => {},
+              () => dummyChartData.offset,
+              dummyLuaExecutor(async () => dummyChartData.levelsFreeze[0])
+            );
+            const newLua = [...level.lua, "print('new line')"];
+            level.setLuaEditorValue(newLua.join("\n"), inLuaEditor);
+            await new Promise<void>((r) => setTimeout(r, 1));
+            expect(level.lua).to.deep.equal(newLua);
+          });
+        }
+      })
+    );
   });
 
   describe("setYTDuration", () => {

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -37,6 +37,7 @@ import fnCommandsPackageJson from "fn-commands/package.json";
 import { captureAndWrap, fetchBackend } from "@/common/fetch";
 import { markAsExpected } from "@/common/apiError";
 import { removeRecent } from "@/common/recent";
+import type Ace from "ace-builds";
 
 interface Props {
   onLoad: (cid: string) => void;
@@ -141,6 +142,8 @@ export function useChartState(props: Props) {
       };
     }
   }, [chartState, rerender]);
+
+  const aceSessionRef = useRef<(Ace.EditSession | null)[]>([]);
 
   const t = useTranslations("edit");
   const router = useRouter();
@@ -670,5 +673,6 @@ export function useChartState(props: Props) {
     localSave,
     localLoadState,
     localLoad,
+    aceSessionRef,
   };
 }

--- a/frontend/app/[locale]/edit/chartState.ts
+++ b/frontend/app/[locale]/edit/chartState.ts
@@ -70,16 +70,17 @@ export type LocalLoadState = undefined | "loading" | "ok" | LocalLoadError;
 export type SaveState = undefined | "saving" | "ok" | Error;
 const EditSessionSchema = () =>
   v.object({
-    cid: v.undefinedable(v.string()),
+    cid: v.optional(v.string()),
     currentPasswd: v.object({
       ph: v.nullable(v.string()),
       pbypass: v.nullable(v.string()),
     }),
     chart: ChartSchema15(),
     convertedFrom: v.number(),
-    currentLevelIndex: v.undefinedable(v.number()),
+    currentLevelIndex: v.optional(v.number()),
     hasChange: v.boolean(),
     savePasswd: v.boolean(),
+    undoManager: v.array(v.unknown()),
   });
 type EditSession = v.InferOutput<ReturnType<typeof EditSessionSchema>>;
 export interface FetchChartOptions {
@@ -570,7 +571,10 @@ export function useChartState(props: Props) {
   );
 
   useEffect(() => {
-    if (chartState.state === undefined) {
+    if (chartState.state !== undefined) {
+      // setChartStateと同時に削除するとreactのstrict modeの2回実行によりset前に消えてしまう
+      sessionStorage.removeItem("editSession");
+    } else {
       const params = new URLSearchParams(window.location.search);
       const cid = params.get("cid");
       if (sessionStorage.getItem("editSession")) {
@@ -579,7 +583,6 @@ export function useChartState(props: Props) {
             EditSessionSchema(),
             JSON.parse(sessionStorage.getItem("editSession")!)
           );
-          sessionStorage.removeItem("editSession");
           if (data.cid === cid || (data.cid === undefined && cid === "new")) {
             setChartState({
               chart: new ChartEditing(data.chart, {
@@ -590,6 +593,7 @@ export function useChartState(props: Props) {
                 currentLevelIndex: data.currentLevelIndex,
                 hasChange: data.hasChange,
                 locale,
+                undoManager: data.undoManager,
               }),
               state: "ok",
             });
@@ -640,6 +644,9 @@ export function useChartState(props: Props) {
           currentLevelIndex: chartState.chart.currentLevelIndex,
           hasChange: chartState.chart.hasChange,
           savePasswd: !!savePasswd,
+          undoManager: aceSessionRef.current.map((s) =>
+            s?.getUndoManager().toJSON()
+          ),
         } satisfies EditSession)
       );
     }

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -618,8 +618,7 @@ export default function Edit(props: {
         chart={chart}
         currentStepStr={cur?.currentStepStr || null}
         seekStepAbs={seekStepAbs}
-        errLine={luaExecutor.running ? null : luaExecutor.errLine}
-        err={luaExecutor.err}
+        result={luaExecutor.running ? null : luaExecutor.result}
         aceSessionRef={aceSessionRef}
       >
         <div
@@ -1003,8 +1002,11 @@ export default function Edit(props: {
                 "bg-gray-500/25",
                 !(
                   luaExecutor.running ||
-                  luaExecutor.stdout.length > 0 ||
-                  luaExecutor.err.length > 0
+                  (luaExecutor.result &&
+                    luaExecutor.result.levelIndex ===
+                      chart?.currentLevelIndex &&
+                    (luaExecutor.result.stdout.length > 0 ||
+                      luaExecutor.result.err.length > 0))
                 ) && "edit-wide:hidden"
               )}
               classNameInner="h-24 max-h-24 edit-wide:h-auto"
@@ -1027,12 +1029,12 @@ export default function Edit(props: {
                 </>
               ) : (
                 <>
-                  {luaExecutor.stdout.map((s, i) => (
+                  {luaExecutor.result?.stdout.map((s, i) => (
                     <p className="text-sm" key={i}>
                       {s}
                     </p>
                   ))}
-                  {luaExecutor.err.map((e, i) => (
+                  {luaExecutor.result?.err.map((e, i) => (
                     <p
                       className="text-sm text-red-600 dark:text-red-400 "
                       key={i}

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -44,6 +44,7 @@ import { useColorThief } from "@/common/colorThief.js";
 import ArrowLeft from "@icon-park/react/lib/icons/ArrowLeft.js";
 import { useDisplayMode } from "@/scale.js";
 import { useResizeDetector } from "react-resize-detector";
+import Close from "@icon-park/react/lib/icons/Close.js";
 
 export default function Edit(props: {
   locale: string;
@@ -998,7 +999,7 @@ export default function Edit(props: {
             </Box>
             <Box
               classNameOuter={clsx(
-                "mt-2",
+                "fixed inset-1.5 ml-auto mt-auto w-max h-max shadow-modal z-edit-error",
                 "bg-gray-500/25",
                 !(
                   luaExecutor.running ||
@@ -1007,41 +1008,57 @@ export default function Edit(props: {
                       chart?.currentLevelIndex &&
                     (luaExecutor.result.stdout.length > 0 ||
                       luaExecutor.result.err.length > 0))
-                ) && "edit-wide:hidden"
+                ) && "hidden"
               )}
-              classNameInner="h-24 max-h-24 edit-wide:h-auto"
+              classNameInner={clsx(
+                // min-h: キャンセルボタンの高さ(8) + padding
+                "min-h-14 max-h-[20vh]",
+                // min-w: スクリプトを実行中...[キャンセル] が収まるサイズ
+                "edit-wide:min-w-85 edit-wide:max-w-[min(50rem,66vw)]",
+                "flex flex-col justify-center"
+              )}
               scrollableX
               scrollableY
               padding={3}
             >
               {luaExecutor.running ? (
-                <>
+                <div>
                   <span className="inline-block ">
                     <SlimeSVG />
                     {t("running")}
                   </span>
                   <Button
-                    className="ml-2"
+                    className="ml-2 my-0"
                     small
                     onClick={luaExecutor.abortExec}
                     text={t("cancel")}
                   />
-                </>
+                </div>
               ) : (
                 <>
+                  {/* mr-11: 閉じるボタンの分のスペース */}
                   {luaExecutor.result?.stdout.map((s, i) => (
-                    <p className="text-sm" key={i}>
+                    <p className="text-sm mr-11" key={i}>
                       {s}
                     </p>
                   ))}
                   {luaExecutor.result?.err.map((e, i) => (
                     <p
-                      className="text-sm text-red-600 dark:text-red-400 "
+                      className="text-sm text-red-600 dark:text-red-400 mr-11"
                       key={i}
                     >
                       {e}
                     </p>
                   ))}
+                  <button
+                    className="fn-icon-button inline-block absolute top-3 right-3"
+                    onClick={() => {
+                      luaExecutor.clearResult();
+                    }}
+                  >
+                    <ButtonHighlight />
+                    <Close />
+                  </button>
                 </>
               )}
             </Box>

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -73,6 +73,7 @@ export default function Edit(props: {
     localSave,
     localLoadState,
     localLoad,
+    aceSessionRef,
   } = useChartState({
     luaExecutor,
     onLoad: (cid) => {
@@ -606,6 +607,7 @@ export default function Edit(props: {
         seekStepAbs={seekStepAbs}
         errLine={luaExecutor.running ? null : luaExecutor.errLine}
         err={luaExecutor.err}
+        aceSessionRef={aceSessionRef}
       >
         <div
           className={clsx(
@@ -893,6 +895,54 @@ export default function Edit(props: {
               <HelpIcon className="self-center">
                 {t.rich("stepUnitHelp", { br: () => <br /> })}
               </HelpIcon>
+              <Button
+                small
+                text={`Undo (${
+                  chart?.currentLevelIndex !== undefined &&
+                  aceSessionRef.current[
+                    chart.currentLevelIndex
+                  ]?.getUndoManager()?.$undoStack.length
+                })`}
+                onClick={() => {
+                  if (chart?.currentLevelIndex !== undefined) {
+                    const session =
+                      aceSessionRef.current[chart.currentLevelIndex];
+                    session?.getUndoManager().undo(session);
+                  }
+                }}
+                disabled={
+                  !(
+                    chart?.currentLevelIndex !== undefined &&
+                    aceSessionRef.current[chart.currentLevelIndex]
+                      ?.getUndoManager()
+                      .canUndo()
+                  )
+                }
+              />
+              <Button
+                small
+                text={`Redo (${
+                  chart?.currentLevelIndex !== undefined &&
+                  aceSessionRef.current[
+                    chart.currentLevelIndex
+                  ]?.getUndoManager()?.$redoStack.length
+                })`}
+                onClick={() => {
+                  if (chart?.currentLevelIndex !== undefined) {
+                    const session =
+                      aceSessionRef.current[chart.currentLevelIndex];
+                    session?.getUndoManager().redo(session);
+                  }
+                }}
+                disabled={
+                  !(
+                    chart?.currentLevelIndex !== undefined &&
+                    aceSessionRef.current[chart.currentLevelIndex]
+                      ?.getUndoManager()
+                      .canRedo()
+                  )
+                }
+              />
               <div className="flex-1" />
               <span className="mr-1">{t("zoom")}</span>
               <Button

--- a/frontend/app/[locale]/edit/clientPage.tsx
+++ b/frontend/app/[locale]/edit/clientPage.tsx
@@ -478,6 +478,18 @@ export default function Edit(props: {
           }
         } else if (e.key === "Shift") {
           setDragMode("v");
+        } else if (e.key === "z") {
+          const session =
+            chart?.currentLevelIndex !== undefined
+              ? aceSessionRef.current[chart.currentLevelIndex]
+              : undefined;
+          session?.getUndoManager().undo(session);
+        } else if (e.key === "y") {
+          const session =
+            chart?.currentLevelIndex !== undefined
+              ? aceSessionRef.current[chart.currentLevelIndex]
+              : undefined;
+          session?.getUndoManager().redo(session);
         } else {
           //
         }
@@ -499,6 +511,7 @@ export default function Edit(props: {
     seekStepRel,
     seekSec,
     currentLevel,
+    aceSessionRef,
   ]);
   return (
     <main
@@ -895,54 +908,6 @@ export default function Edit(props: {
               <HelpIcon className="self-center">
                 {t.rich("stepUnitHelp", { br: () => <br /> })}
               </HelpIcon>
-              <Button
-                small
-                text={`Undo (${
-                  chart?.currentLevelIndex !== undefined &&
-                  aceSessionRef.current[
-                    chart.currentLevelIndex
-                  ]?.getUndoManager()?.$undoStack.length
-                })`}
-                onClick={() => {
-                  if (chart?.currentLevelIndex !== undefined) {
-                    const session =
-                      aceSessionRef.current[chart.currentLevelIndex];
-                    session?.getUndoManager().undo(session);
-                  }
-                }}
-                disabled={
-                  !(
-                    chart?.currentLevelIndex !== undefined &&
-                    aceSessionRef.current[chart.currentLevelIndex]
-                      ?.getUndoManager()
-                      .canUndo()
-                  )
-                }
-              />
-              <Button
-                small
-                text={`Redo (${
-                  chart?.currentLevelIndex !== undefined &&
-                  aceSessionRef.current[
-                    chart.currentLevelIndex
-                  ]?.getUndoManager()?.$redoStack.length
-                })`}
-                onClick={() => {
-                  if (chart?.currentLevelIndex !== undefined) {
-                    const session =
-                      aceSessionRef.current[chart.currentLevelIndex];
-                    session?.getUndoManager().redo(session);
-                  }
-                }}
-                disabled={
-                  !(
-                    chart?.currentLevelIndex !== undefined &&
-                    aceSessionRef.current[chart.currentLevelIndex]
-                      ?.getUndoManager()
-                      .canRedo()
-                  )
-                }
-              />
               <div className="flex-1" />
               <span className="mr-1">{t("zoom")}</span>
               <Button
@@ -1028,7 +993,7 @@ export default function Edit(props: {
               ) : tab === 2 ? (
                 <LevelTab chart={chart} />
               ) : tab === 3 ? (
-                <NoteTab chart={chart} />
+                <NoteTab chart={chart} aceSessionRef={aceSessionRef} />
               ) : null}
               <LuaTabPlaceholder parentContainer={ref.current} />
             </Box>

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -220,7 +220,7 @@ export function LuaTabProvider(props: Props) {
       {props.children}
       {chart?.levels.map((l, i) => (
         <div
-          key={i}
+          key={l.localId.toString()}
           className={clsx(
             "absolute rounded-sq-box isolate",
             (visible && i === chart?.currentLevelIndex) || "hidden"
@@ -271,6 +271,11 @@ function AceEditorInstance(props: IProps) {
     <AceEditor
       onLoad={(editor) => {
         editorRef.current = editor;
+        if (level.luaEditorInitialUndoManager) {
+          editor.session
+            .getUndoManager()
+            .fromJSON(level.luaEditorInitialUndoManager);
+        }
       }}
       mode="lua"
       theme={themeState.isDark ? "tomorrow_night" : "tomorrow"}

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -18,6 +18,7 @@ import {
   LevelEditing,
   LevelFreeze,
   LuaExecutor,
+  LuaExecutorLastResult,
 } from "@falling-nikochan/chart";
 import { Step } from "@falling-nikochan/chart";
 import { findStepFromLua } from "@falling-nikochan/chart";
@@ -59,19 +60,27 @@ if (typeof window !== "undefined") {
 }
 
 export function useLuaExecutor(): LuaExecutor {
+  // 1回目のworker起動時に出たエラーのみレンダリング時に再throwし、エラーページの表示にする
   const initDoneRef = useRef(false);
   const [initError, setInitError] = useState<Error>();
-  const [stdout, setStdout] = useState<string[]>([]);
-  const [err, setErr] = useState<string[]>([]);
-  const [errLine, setErrLine] = useState<number | null>(null);
+
+  // 表示用途のみのstate
+  const [result, setResult] = useState<LuaExecutorLastResult | null>(null);
   const [running, setRunning] = useState<boolean>(false);
+
   // workerは一度立てたら使いまわす。
   const worker = useRef<Worker | null>(null);
-  // コードが実行中の場合、結果を返すpromiseのresolverを保持する。
+  // コードが実行中の場合、promiseに結果を返し上2つのstateを更新するコールバックを保持する。
   // 実行が完了したらresolverを呼び出した後これをnullにする。
-  const workerResolver = useRef<((result: LevelFreeze | null) => void) | null>(
-    null
-  );
+  const workerResolver = useRef<
+    | ((
+        stdout: string[],
+        err: string[],
+        errLine: number | null,
+        freeze: LevelFreeze | null
+      ) => void)
+    | null
+  >(null);
 
   const initWorker = useCallback(() => {
     if (worker.current === null) {
@@ -88,15 +97,14 @@ export function useLuaExecutor(): LuaExecutor {
           }
           setInitError(err);
         }
-        if (workerResolver.current) {
-          setRunning(false);
-          setStdout([]);
+        workerResolver.current?.(
+          [],
           // e.messageが空の場合がある
-          setErr([e.message || "Unknown error"]);
-          setErrLine(-1);
-          workerResolver.current(null);
-          workerResolver.current = null;
-        }
+          [e.message || "Unknown error"],
+          null,
+          null
+        );
+        workerResolver.current = null;
       });
       worker.current.addEventListener(
         "message",
@@ -104,20 +112,13 @@ export function useLuaExecutor(): LuaExecutor {
           if (typeof data === "string") {
             initDoneRef.current = true;
           } else {
-            if (workerResolver.current) {
-              setRunning(false);
-              setStdout(data.stdout);
-              setErr(data.err);
-              setErrLine(data.errorLine);
-              if (data.err.length === 0) {
-                workerResolver.current(data.levelFreezed);
-              } else {
-                workerResolver.current(null);
-              }
-              workerResolver.current = null;
-            } else {
-              console.error("luaExecWorker finished but resolver is null");
-            }
+            workerResolver.current?.(
+              data.stdout,
+              data.err,
+              data.errorLine,
+              data.err.length === 0 ? data.levelFreezed : null
+            );
+            workerResolver.current = null;
           }
         }
       );
@@ -134,21 +135,21 @@ export function useLuaExecutor(): LuaExecutor {
         worker.current.terminate();
         worker.current = null;
       }
-      setRunning(false);
-      setStdout([]);
-      setErr(["terminated"]);
-      setErrLine(-1);
-      workerResolver.current(null);
+      workerResolver.current?.([], ["terminated"], null, null);
       workerResolver.current = null;
     }
   }, []);
   const exec = useCallback(
-    (code: string) => {
+    (code: string, levelIndex: number) => {
       abortExec();
       initWorker();
       setRunning(true);
       const p = new Promise<LevelFreeze | null>((resolve) => {
-        workerResolver.current = resolve;
+        workerResolver.current = (stdout, err, errLine, freeze) => {
+          setRunning(false);
+          setResult({ stdout, err, errLine, levelIndex });
+          resolve(freeze);
+        };
       });
       worker.current!.postMessage({ code } satisfies WorkerInput);
       return p;
@@ -157,9 +158,7 @@ export function useLuaExecutor(): LuaExecutor {
   );
 
   return {
-    stdout,
-    err,
-    errLine,
+    result,
     running,
     exec,
     abortExec,
@@ -174,8 +173,7 @@ interface Props {
   chart?: ChartEditing;
   currentStepStr: string | null;
   seekStepAbs: (s: Step) => void;
-  errLine: number | null;
-  err: string[];
+  result: LuaExecutorLastResult | null;
   children: ReactNode;
   aceSessionRef: RefObject<(Ace.EditSession | null)[]>;
 }
@@ -200,15 +198,8 @@ export function LuaTabProvider(props: Props) {
   });
 
   const { top, left, width, height } = data;
-  const {
-    visible,
-    chart,
-    currentStepStr,
-    seekStepAbs,
-    errLine,
-    err,
-    aceSessionRef,
-  } = props;
+  const { visible, chart, currentStepStr, seekStepAbs, result, aceSessionRef } =
+    props;
 
   return (
     <LuaPositionContext.Provider value={{ data, setData }}>
@@ -226,8 +217,7 @@ export function LuaTabProvider(props: Props) {
             level={l}
             currentStepStr={currentStepStr}
             seekStepAbs={seekStepAbs}
-            errLine={chart.currentLevelIndex === i ? errLine : null}
-            err={chart.currentLevelIndex === i ? err : []}
+            result={result?.levelIndex === i ? result : null}
             setAceSession={(session) => {
               aceSessionRef.current[i] = session;
             }}
@@ -243,22 +233,14 @@ interface IProps {
   level: LevelEditing;
   currentStepStr: string | null;
   seekStepAbs: (s: Step) => void;
-  errLine: number | null;
-  err: string[];
+  result: LuaExecutorLastResult | null;
   setAceSession: (session: Ace.EditSession | null) => void;
   visible: boolean;
 }
 function AceEditorInstance(props: IProps) {
   const themeState = useTheme();
-  const {
-    level,
-    currentStepStr,
-    seekStepAbs,
-    errLine,
-    err,
-    setAceSession,
-    visible,
-  } = props;
+  const { level, currentStepStr, seekStepAbs, result, setAceSession, visible } =
+    props;
   const cur = level.current;
   const { rem } = useDisplayMode();
   const t = useTranslations("edit.code");
@@ -299,16 +281,16 @@ function AceEditorInstance(props: IProps) {
           type: "warning",
         },
         {
-          row: errLine === null ? -1 : errLine,
+          row: result?.errLine == null ? -1 : result.errLine,
           column: 1,
-          text: err[0],
+          text: result?.err[0] ?? "",
           type: "error",
         },
       ]}
       markers={[
         {
-          startRow: errLine === null ? -1 : errLine,
-          endRow: errLine === null ? -1 : errLine,
+          startRow: result?.errLine == null ? -1 : result.errLine,
+          endRow: result?.errLine == null ? -1 : result.errLine,
           startCol: 0,
           endCol: 1,
           type: "fullLine" as const,

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -271,6 +271,9 @@ function AceEditorInstance(props: IProps) {
     <AceEditor
       onLoad={(editor) => {
         editorRef.current = editor;
+        // 無制限にするとsessionStorageにおさまらなくなってしまうため、適当に上限を設定している
+        // @ts-expect-error accessing private property $undoDepth
+        editor.session.getUndoManager().$undoDepth = 20;
         if (level.luaEditorInitialUndoManager) {
           editor.session
             .getUndoManager()

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -86,8 +86,9 @@ export function useLuaExecutor(): LuaExecutor {
 
   const initWorker = useCallback(() => {
     if (worker.current === null) {
-      worker.current = new Worker(new URL("luaExecWorker", import.meta.url));
-      worker.current.addEventListener("error", (e) => {
+      const thisWorker = new Worker(new URL("luaExecWorker", import.meta.url));
+      worker.current = thisWorker;
+      thisWorker.addEventListener("error", (e) => {
         console.error(e);
         if (!initDoneRef.current) {
           let err = e.error ?? e.message;
@@ -99,28 +100,38 @@ export function useLuaExecutor(): LuaExecutor {
           }
           setInitError(err);
         }
-        workerResolver.current?.(
-          [],
-          // e.messageが空の場合がある
-          [e.message || "Unknown error"],
-          null,
-          null
-        );
-        workerResolver.current = null;
+        if (worker.current !== thisWorker) {
+          // すでに別のworkerが動き始めているので、無視
+          return;
+        } else {
+          workerResolver.current?.(
+            [],
+            // e.messageが空の場合がある
+            [e.message || "Unknown error"],
+            null,
+            null
+          );
+          workerResolver.current = null;
+        }
       });
-      worker.current.addEventListener(
+      thisWorker.addEventListener(
         "message",
         ({ data }: { data: LuaExecResult | "initDone" }) => {
           if (typeof data === "string") {
             initDoneRef.current = true;
           } else {
-            workerResolver.current?.(
-              data.stdout,
-              data.err,
-              data.errorLine,
-              data.err.length === 0 ? data.levelFreezed : null
-            );
-            workerResolver.current = null;
+            if (worker.current !== thisWorker) {
+              // すでに別のworkerが動き始めているので、無視
+              return;
+            } else {
+              workerResolver.current?.(
+                data.stdout,
+                data.err,
+                data.errorLine,
+                data.err.length === 0 ? data.levelFreezed : null
+              );
+              workerResolver.current = null;
+            }
           }
         }
       );

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx/lite";
 import {
   createContext,
   ReactNode,
+  RefObject,
   useCallback,
   useContext,
   useEffect,
@@ -39,6 +40,7 @@ const AceEditor = dynamic(
 );
 import type { Selection } from "ace-builds-internal/selection";
 import type { WorkerInput } from "./luaExecWorker";
+import type Ace from "ace-builds";
 
 // https://github.com/vercel/next.js/discussions/29415
 // import "remote-web-worker";
@@ -174,6 +176,8 @@ interface Props {
   seekStepAbs: (s: Step) => void;
   errLine: number | null;
   err: string[];
+  children: ReactNode;
+  aceSessionRef: RefObject<(Ace.EditSession | null)[]>;
 }
 interface LuaPositionData {
   top: number;
@@ -187,10 +191,7 @@ interface LuaPositionContext {
 }
 const LuaPositionContext = createContext<LuaPositionContext>(null!);
 
-interface PProps {
-  children: ReactNode;
-}
-export function LuaTabProvider(props: Props & PProps) {
+export function LuaTabProvider(props: Props) {
   const [data, setData] = useState<LuaPositionData>({
     top: 0,
     left: 0,
@@ -199,7 +200,15 @@ export function LuaTabProvider(props: Props & PProps) {
   });
 
   const { top, left, width, height } = data;
-  const { visible, chart, currentStepStr, seekStepAbs, errLine, err } = props;
+  const {
+    visible,
+    chart,
+    currentStepStr,
+    seekStepAbs,
+    errLine,
+    err,
+    aceSessionRef,
+  } = props;
 
   return (
     <LuaPositionContext.Provider value={{ data, setData }}>
@@ -219,6 +228,10 @@ export function LuaTabProvider(props: Props & PProps) {
             seekStepAbs={seekStepAbs}
             errLine={chart.currentLevelIndex === i ? errLine : null}
             err={chart.currentLevelIndex === i ? err : []}
+            setAceSession={(session) => {
+              aceSessionRef.current[i] = session;
+            }}
+            visible={visible && chart.currentLevelIndex === i}
           />
         </div>
       ))}
@@ -232,26 +245,37 @@ interface IProps {
   seekStepAbs: (s: Step) => void;
   errLine: number | null;
   err: string[];
+  setAceSession: (session: Ace.EditSession | null) => void;
+  visible: boolean;
 }
 function AceEditorInstance(props: IProps) {
   const themeState = useTheme();
-  const { level, currentStepStr, seekStepAbs, errLine, err } = props;
+  const {
+    level,
+    currentStepStr,
+    seekStepAbs,
+    errLine,
+    err,
+    setAceSession,
+    visible,
+  } = props;
   const cur = level.current;
   const { rem } = useDisplayMode();
   const t = useTranslations("edit.code");
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_rerenderIndex, setRerenderIndex] = useState<number>(0);
-  const rerender = useCallback(() => setRerenderIndex((i) => i + 1), []);
+  const editorRef = useRef<Ace.Editor | null>(null);
   useEffect(() => {
-    level.on("luaEditor", rerender);
+    setAceSession(editorRef.current?.session ?? null);
     return () => {
-      level.off("luaEditor", rerender);
+      setAceSession(null);
     };
-  }, [level, rerender]);
+  }, [setAceSession]);
 
   return (
     <AceEditor
+      onLoad={(editor) => {
+        editorRef.current = editor;
+      }}
       mode="lua"
       theme={themeState.isDark ? "tomorrow_night" : "tomorrow"}
       width="100%"
@@ -317,10 +341,10 @@ function AceEditorInstance(props: IProps) {
       enableLiveAutocompletion={false}
       enableSnippets={false}
       onChange={(value) => {
-        level.setLuaEditorValue(value);
+        level.setLuaEditorValue(value, visible);
       }}
       onCursorChange={(sel: Selection) => {
-        if (!sel.isMultiLine()) {
+        if (visible && !sel.isMultiLine()) {
           const step = findStepFromLua(
             { ...level.freeze, lua: [...level.lua] },
             sel.cursor.row

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -14,6 +14,7 @@ import { useDisplayMode } from "@/scale.js";
 import { LuaExecResult } from "@falling-nikochan/chart/dist/luaExec";
 import {
   ChartEditing,
+  LevelEditing,
   LevelFreeze,
   LuaExecutor,
 } from "@falling-nikochan/chart";
@@ -190,7 +191,6 @@ interface PProps {
   children: ReactNode;
 }
 export function LuaTabProvider(props: Props & PProps) {
-  const themeState = useTheme();
   const [data, setData] = useState<LuaPositionData>({
     top: 0,
     left: 0,
@@ -200,144 +200,137 @@ export function LuaTabProvider(props: Props & PProps) {
 
   const { top, left, width, height } = data;
   const { visible, chart, currentStepStr, seekStepAbs, errLine, err } = props;
-  const currentLevel = chart?.currentLevel;
-  const cur = currentLevel?.current;
-  const { rem } = useDisplayMode();
-  const t = useTranslations("edit.code");
-  const previousLevelCode = useRef<string>("");
-  const [code, setCode] = useState<string>("");
-  const [codeChanged, setCodeChanged] = useState<boolean>(false);
-
-  useEffect(() => {
-    const updateCode = () => {
-      const currentLevelCode = currentLevel?.lua.join("\n");
-      if (
-        !codeChanged &&
-        currentLevelCode !== undefined &&
-        previousLevelCode.current !== currentLevelCode
-      ) {
-        previousLevelCode.current = currentLevelCode;
-        setCode(currentLevelCode);
-      }
-    };
-    updateCode();
-    chart?.on("change", updateCode);
-    return () => {
-      chart?.off("change", updateCode);
-    };
-  }, [codeChanged, chart, currentLevel]);
-
-  const changeCodeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const changeCode = (code: string) => {
-    setCode(code);
-    setCodeChanged(true);
-    if (changeCodeTimeout.current !== null) {
-      clearTimeout(changeCodeTimeout.current);
-    }
-    changeCodeTimeout.current = setTimeout(() => {
-      changeCodeTimeout.current = null;
-      currentLevel
-        ?.updateLua(code.split("\n"))
-        .then(() => {
-          setCodeChanged(false);
-        })
-        .catch(() => {
-          setCodeChanged(false);
-        });
-    }, 500);
-  };
 
   return (
     <LuaPositionContext.Provider value={{ data, setData }}>
       {props.children}
-      <div
-        className={clsx("absolute rounded-sq-box isolate", visible || "hidden")}
-        style={{ top, left, width, height }}
-      >
-        <AceEditor
-          mode="lua"
-          theme={themeState.isDark ? "tomorrow_night" : "tomorrow"}
-          width="100%"
-          height="100%"
-          tabSize={2}
-          fontSize={1 * rem}
-          highlightActiveLine={false}
-          value={code}
-          setOptions={{ useWorker: false }}
-          annotations={[
-            ...(currentLevel?.barLines.map((bl) => ({
-              row: bl.luaLine,
-              column: 1,
-              text: `${bl.barNum};`,
-              type: "info",
-            })) || []),
-            {
-              row: cur?.line == null ? -1 : cur.line,
-              column: 1,
-              text: t("currentLine", { step: currentStepStr || "null" }),
-              type: "warning",
-            },
-            {
-              row: errLine === null ? -1 : errLine,
-              column: 1,
-              text: err[0],
-              type: "error",
-            },
-          ]}
-          markers={[
-            {
-              startRow: errLine === null ? -1 : errLine,
-              endRow: errLine === null ? -1 : errLine,
-              startCol: 0,
-              endCol: 1,
-              type: "fullLine" as const,
-              className: "absolute z-5 bg-red-200 dark:bg-red-900 ",
-            },
-            ...(currentLevel?.barLines.map((bl) => ({
-              startRow: bl.luaLine,
-              endRow: bl.luaLine,
-              startCol: 0,
-              endCol: 1,
-              type: "fullLine" as const,
-              className: clsx(
-                "absolute h-[1px]! bg-gray-500",
-                "shadow-[0_0_2px] shadow-gray-500/75"
-              ),
-            })) ?? []),
-            {
-              startRow: cur?.line == null ? -1 : cur?.line,
-              endRow: cur?.line == null ? -1 : cur?.line,
-              startCol: 0,
-              endCol: 1,
-              type: "fullLine" as const,
-              className: clsx(
-                "absolute h-0!",
-                "shadow-[0_0.7em_0.5em_0.2em] shadow-yellow-400/50"
-              ),
-            },
-          ]}
-          enableBasicAutocompletion={false}
-          enableLiveAutocompletion={false}
-          enableSnippets={false}
-          onChange={(value) => {
-            if (visible) {
-              changeCode(value);
-            }
-          }}
-          onCursorChange={(sel: Selection) => {
-            if (currentLevel && visible && !sel.isMultiLine()) {
-              const step = findStepFromLua(
-                { ...currentLevel.freeze, lua: [...currentLevel.lua] },
-                sel.cursor.row
-              );
-              if (step !== null) {
-                seekStepAbs(step);
-              }
-            }
-          }}
-        />
-      </div>
+      {chart?.levels.map((l, i) => (
+        <div
+          key={i}
+          className={clsx(
+            "absolute rounded-sq-box isolate",
+            (visible && i === chart?.currentLevelIndex) || "hidden"
+          )}
+          style={{ top, left, width, height }}
+        >
+          <AceEditorInstance
+            level={l}
+            currentStepStr={currentStepStr}
+            seekStepAbs={seekStepAbs}
+            errLine={chart.currentLevelIndex === i ? errLine : null}
+            err={chart.currentLevelIndex === i ? err : []}
+          />
+        </div>
+      ))}
     </LuaPositionContext.Provider>
+  );
+}
+
+interface IProps {
+  level: LevelEditing;
+  currentStepStr: string | null;
+  seekStepAbs: (s: Step) => void;
+  errLine: number | null;
+  err: string[];
+}
+function AceEditorInstance(props: IProps) {
+  const themeState = useTheme();
+  const { level, currentStepStr, seekStepAbs, errLine, err } = props;
+  const cur = level.current;
+  const { rem } = useDisplayMode();
+  const t = useTranslations("edit.code");
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [_rerenderIndex, setRerenderIndex] = useState<number>(0);
+  const rerender = useCallback(() => setRerenderIndex((i) => i + 1), []);
+  useEffect(() => {
+    level.on("luaEditor", rerender);
+    return () => {
+      level.off("luaEditor", rerender);
+    };
+  }, [level, rerender]);
+
+  return (
+    <AceEditor
+      mode="lua"
+      theme={themeState.isDark ? "tomorrow_night" : "tomorrow"}
+      width="100%"
+      height="100%"
+      tabSize={2}
+      fontSize={1 * rem}
+      highlightActiveLine={false}
+      value={level.luaEditorValue}
+      setOptions={{ useWorker: false }}
+      annotations={[
+        ...(level?.barLines.map((bl) => ({
+          row: bl.luaLine,
+          column: 1,
+          text: `${bl.barNum};`,
+          type: "info",
+        })) || []),
+        {
+          row: cur?.line == null ? -1 : cur.line,
+          column: 1,
+          text: t("currentLine", { step: currentStepStr || "null" }),
+          type: "warning",
+        },
+        {
+          row: errLine === null ? -1 : errLine,
+          column: 1,
+          text: err[0],
+          type: "error",
+        },
+      ]}
+      markers={[
+        {
+          startRow: errLine === null ? -1 : errLine,
+          endRow: errLine === null ? -1 : errLine,
+          startCol: 0,
+          endCol: 1,
+          type: "fullLine" as const,
+          className: "absolute z-5 bg-red-200 dark:bg-red-900 ",
+        },
+        ...(level?.barLines.map((bl) => ({
+          startRow: bl.luaLine,
+          endRow: bl.luaLine,
+          startCol: 0,
+          endCol: 1,
+          type: "fullLine" as const,
+          className: clsx(
+            "absolute h-[1px]! bg-gray-500",
+            "shadow-[0_0_2px] shadow-gray-500/75"
+          ),
+        })) ?? []),
+        {
+          startRow: cur?.line == null ? -1 : cur?.line,
+          endRow: cur?.line == null ? -1 : cur?.line,
+          startCol: 0,
+          endCol: 1,
+          type: "fullLine" as const,
+          className: clsx(
+            "absolute h-0!",
+            "shadow-[0_0.7em_0.5em_0.2em] shadow-yellow-400/50"
+          ),
+        },
+      ]}
+      enableBasicAutocompletion={false}
+      enableLiveAutocompletion={false}
+      enableSnippets={false}
+      onChange={(value) => {
+        level.setLuaEditorValue(value);
+      }}
+      onCursorChange={(sel: Selection) => {
+        if (!sel.isMultiLine()) {
+          const step = findStepFromLua(
+            { ...level.freeze, lua: [...level.lua] },
+            sel.cursor.row
+          );
+          if (step !== null) {
+            seekStepAbs(step);
+          }
+        }
+      }}
+    />
   );
 }
 

--- a/frontend/app/[locale]/edit/luaTab.tsx
+++ b/frontend/app/[locale]/edit/luaTab.tsx
@@ -68,6 +68,8 @@ export function useLuaExecutor(): LuaExecutor {
   const [result, setResult] = useState<LuaExecutorLastResult | null>(null);
   const [running, setRunning] = useState<boolean>(false);
 
+  const clearResult = useCallback(() => setResult(null), []);
+
   // workerは一度立てたら使いまわす。
   const worker = useRef<Worker | null>(null);
   // コードが実行中の場合、promiseに結果を返し上2つのstateを更新するコールバックを保持する。
@@ -162,6 +164,7 @@ export function useLuaExecutor(): LuaExecutor {
     running,
     exec,
     abortExec,
+    clearResult,
   };
 }
 

--- a/frontend/app/[locale]/edit/noteTab.tsx
+++ b/frontend/app/[locale]/edit/noteTab.tsx
@@ -7,9 +7,12 @@ import Select from "@/common/select";
 import { useTranslations } from "next-intl";
 import { HelpIcon } from "@/common/caption";
 import { ChartEditing } from "@falling-nikochan/chart";
+import type { Ace } from "ace-builds";
+import { RefObject } from "react";
 
 interface Props {
   chart?: ChartEditing;
+  aceSessionRef: RefObject<(Ace.EditSession | null)[]>;
 }
 export default function NoteTab(props: Props) {
   const t = useTranslations("edit.note");
@@ -86,6 +89,9 @@ export default function NoteTab(props: Props) {
       </div>
       <NoteEdit {...props} />
       <span className="flex-1 mb-4 " />
+      <div className="flex flex-row items-baseline mb-2">
+        <UndoRedoButton {...props} />
+      </div>
       <div className="flex flex-row ">
         <CopyPasteButton {...props} />
       </div>
@@ -123,6 +129,45 @@ function CopyPasteButton(props: Props) {
           />
         </div>
       ))}
+    </>
+  );
+}
+function UndoRedoButton(props: Props) {
+  const { chart, aceSessionRef } = props;
+  const t = useTranslations("edit.note");
+  const session =
+    chart?.currentLevelIndex !== undefined
+      ? aceSessionRef.current[chart.currentLevelIndex]
+      : undefined;
+  const undoManager = session?.getUndoManager();
+  // @ts-expect-error accessing undocumented property undoStack
+  const undoCount = undoManager?.$undoStack.length ?? 0;
+  // @ts-expect-error accessing undocumented property redoStack
+  const redoCount = undoManager?.$redoStack.length ?? 0;
+  return (
+    <>
+      <Button
+        text={t("undo")}
+        keyName="Z"
+        onClick={() => {
+          undoManager?.undo(session!);
+        }}
+        disabled={!undoManager?.canUndo()}
+      />
+      <span className="px-2">
+        ×<span className="ml-1">{undoCount}</span>
+      </span>
+      <span className="pl-2 self-stretch my-2 border-l border-current/50" />
+      {redoCount >= 1 && <span className="pr-2">{redoCount}</span>}
+      <Button
+        text={t("redo")}
+        keyName="Y"
+        onClick={() => {
+          undoManager?.redo(session!);
+        }}
+        disabled={!undoManager?.canRedo()}
+      />
+      <HelpIcon>{t.rich("undoHelp", { br: () => <br /> })}</HelpIcon>
     </>
   );
 }

--- a/frontend/app/[locale]/styles/z-index.css
+++ b/frontend/app/[locale]/styles/z-index.css
@@ -141,6 +141,9 @@
 @utility z-edit-ace-placeholder {
   z-index: -10;
 }
+@utility z-edit-error {
+  z-index: 1;
+}
 /* これはFallingWindowの中にあるので、FallingWindowにzを設定すればローカルになる */
 @utility z-edit-trace {
   z-index: -60;

--- a/i18n/en/edit.js
+++ b/i18n/en/edit.js
@@ -251,6 +251,11 @@ export default {
       noteMirror: "Mirror",
       copy: "Copy",
       paste: "Paste",
+      undo: "Undo",
+      redo: "Redo",
+      undoHelp:
+        "Revert changes made at this level <br></br>" +
+        "in the Timing, Note, and Code tabs.",
       position: "Position",
       positionHelp:
         "x is the final position to hit the note.<br></br>" +

--- a/i18n/ja/edit.js
+++ b/i18n/ja/edit.js
@@ -229,6 +229,11 @@ export default {
       noteMirror: "反転",
       copy: "コピー",
       paste: "貼り付け",
+      undo: "元に戻す",
+      redo: "やり直す",
+      undoHelp:
+        "タイミング タブ、音符 タブ、コード タブでの<br></br>" +
+        "このレベルに対する変更を元に戻します。",
       position: "位置",
       positionHelp:
         "x は音符を最終的に叩く位置です。<br></br>" +


### PR DESCRIPTION
- [x] AceEditorのインスタンスをレベルごとに作る
- [x] AceEditorの状態管理をLevelEditingクラス内部で行う
  - close #1068  
  - コード編集以外で譜面データが変更された場合:
    - luaEditorValueと#luaを即時更新
    - 実行
    - 成功時#luaもluaEditorValueもそのまま
    - 失敗時#luaをrevert, luaEditorValueはそのまま
    - abort時#luaもluaEditorValueもそのまま
  - ユーザーがコードを編集した場合:
    - luaEditorValueを即時更新
    - 500ms待つ
    - #luaを更新
    - 実行
    - 以降↑と同じ
  - undo/redo: ↑と同じ
- [x] lua実行エラーがどのレベルで起きたかを管理し、混ざらないようにする
  - close #1065
- [x] workerのエラーがどのluaの実行時に起きたかを管理し、混ざらないようにする
  - close #1210 
- [x] undo/redo ボタンの追加
  - close #762 
- [x] undo/redoの履歴がセッションに保存されるようにする
- lua実行中表示・エラーの表示をfixedにし右下に固定