### PR TITLE
pino, axiom, structured-loggerを導入

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,7 @@ This inserts a sample chart at cid `102399` ("Get Started!").
 
 **Conventions**
 
+- `@hono/structured-logger` must be initialized in each entry point, and always use `c.var.logger` instead of `console`.
 - When code branches depending on the deployment target, the Hono App creation is made into a function. (`const fooApp = async (config: ...) => new Hono(...)`)
 - The error response must be in JSON format and be in the form of `{message: "predefined message"}`. The message must be one defined in `api` within `i18n/{ja,en}/error.js` or empty.
   - For unexpected errors, the global error handler (`src/error.ts`) formats the thrown error into JSON and returns it. Therefore, it is not necessary for each API handler to catch unexpected errors and return a 500 error response.
@@ -259,6 +260,7 @@ The service worker ([`worker/entry.ts`](worker/entry.ts), bundled into `/sw.js`)
 | `SENTRY_DSN` | secrets.`SENTRY_DSN` | optional | optional | |
 | `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`, `SENTRY_URL` | secrets.`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`, `SENTRY_URL` | optional | | |
 | `SENTRY_TUNNEL` | secrets.`SENTRY_TUNNEL` | optional | | |
+| `AXIOM_DATASET`, `AXIOM_TOKEN`, `AXIOM_EDGE` | | | required | used in `serve-bun-prod.ts` |
 | `TWITTER_API_KEY`, `TWITTER_API_KEY_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`, `GEMINI_API_KEY`, `DISCORD_WEBHOOK_ID`, `DISCORD_WEBHOOK_TOKEN`, `DISCORD_ANNOUNCE_WEBHOOK_ID`, `DISCORD_ANNOUNCE_WEBHOOK_TOKEN` |  |   | optional | used by cronjob |
 | | secrets.`ACTION_FAILURE_DISCORD_WEBHOOK` | | | Notifies when action fails |
 | | secrets.`CF_ASSETS_ACCOUNT_ID`, `CF_ASSETS_API_TOKEN`, `CF_ASSETS_PROJECT_NAME` | | | cloudflare pages deploy |

--- a/api/index.js
+++ b/api/index.js
@@ -25,6 +25,7 @@ import packageJson from "@falling-nikochan/route/package.json" with { type: "jso
 import { MongoClient } from "mongodb";
 import { createMiddleware } from "hono/factory";
 import { attachDatabasePool } from "@vercel/functions";
+import { structuredLogger } from "@hono/structured-logger";
 
 // export const config = {
 //   runtime: "nodejs",
@@ -56,6 +57,7 @@ const fetchBrief = (_e, cid) => getBrief(db, cid);
 const app = new Hono({ strict: false });
 app.use(sentryMiddleware(app));
 app
+  .use(structuredLogger({ createLogger: () => console }))
   .use(compress())
   .route("/api", await apiApp({ getConnInfo, dbMiddleware }))
   .route("/og", ogApp({ ImageResponse, fetchBrief, fetchStatic }))

--- a/frontend/app/[locale]/common/pwaInstall.tsx
+++ b/frontend/app/[locale]/common/pwaInstall.tsx
@@ -413,8 +413,14 @@ export function PWAInstallProvider(props: { children: ReactNode }) {
                 );
             }
           }
-        } else {
-          console.warn("sw:", event.data);
+        } else if (
+          typeof event.data === "object" &&
+          event.data.type === "console"
+        ) {
+          console[event.data.level as "log" | "warn" | "error" | "info"](
+            "[sw]",
+            ...event.data.args
+          );
         }
       });
     }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@falling-nikochan/route": "workspace:*",
+    "@hono/structured-logger": "catalog:",
     "@sentry/hono": "catalog:sentry",
     "@vercel/functions": "^3.6.2",
     "@vercel/og": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,9 @@ importers:
 
   route:
     dependencies:
+      '@axiomhq/pino':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@falling-nikochan/chart':
         specifier: workspace:*
         version: link:../chart
@@ -423,6 +426,9 @@ importers:
       '@hono/standard-validator':
         specifier: ^0.2.1
         version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23)
+      '@hono/structured-logger':
+        specifier: ^0.1.0
+        version: 0.1.0(hono@4.12.23)
       '@hono/swagger-ui':
         specifier: ^0.6.1
         version: 0.6.1(hono@4.12.23)
@@ -462,6 +468,9 @@ importers:
       mongodb:
         specifier: 'catalog:'
         version: 7.2.0
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       react:
         specifier: catalog:react
         version: 19.2.6
@@ -524,6 +533,14 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@axiomhq/js@1.8.0':
+    resolution: {integrity: sha512-VRkqV9XH+pkj8d9eRdw8TuWvXdCkVDMtDOz2rix5UAg7x5SlOeWhUz9fwc0ZgySosMSMA7WP7X0fFX8N/jBHtQ==}
+    engines: {node: '>=20'}
+
+  '@axiomhq/pino@1.8.0':
+    resolution: {integrity: sha512-bILt0wTEUyfOarcw7/E2gRya38GnSBVt2jOR7eGsUmCee/RgjFKMJj3ss5jwfJKOqb3yL2UJZCIKIydiMgGXJA==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1310,6 +1327,12 @@ packages:
       '@standard-schema/spec': ^1.0.0
       hono: '>=3.9.0'
 
+  '@hono/structured-logger@0.1.0':
+    resolution: {integrity: sha512-06QUXbNnvb6lSJz/79WcC8yhGCbWT4EO2Zq3rodzQLwUT40OVXNerCKXUcwv4KgVZGKhVebzv1Vr84w/GKEl6Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.0.0'
+
   '@hono/swagger-ui@0.6.1':
     resolution: {integrity: sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ==}
     peerDependencies:
@@ -1768,6 +1791,9 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2750,6 +2776,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   ace-builds@1.43.6:
     resolution: {integrity: sha512-L1ddibQ7F3vyXR2k2fg+I8TQTPWVA6CKeDQr/h2+8CeyTp3W6EQL8xNFZRTztuP8xNOAqL3IYPqdzs31GCjDvg==}
 
@@ -2862,6 +2892,10 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2916,6 +2950,9 @@ packages:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.19:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
@@ -2946,6 +2983,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3469,6 +3509,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -3514,6 +3558,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-retry@6.0.0:
+    resolution: {integrity: sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==}
 
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
@@ -3665,8 +3712,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-estree@3.1.3:
@@ -3724,6 +3771,9 @@ packages:
 
   icu-minify@4.12.0:
     resolution: {integrity: sha512-zDmM05uav3t3+kxSfRrNlmyXOdj2b+uHA+p04CG32eJabtaHbugXujuL+YfRkwP9joAnf0Uh+RMGCKD5NLa5rQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4456,6 +4506,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -4541,6 +4595,19 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@1.2.0:
+    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -4582,6 +4649,13 @@ packages:
   pretty-checkbox@3.0.3:
     resolution: {integrity: sha512-kCLsENsJ6h5Bcq106Q3YMSxuz2q3jtIXP7fgDB/+jZjUsZjRjAoL9Lr1TVwAEcugufVBhr5Mfd9L7P6d+SR+Yw==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -4607,6 +4681,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   react-ace@14.0.1:
     resolution: {integrity: sha512-z6YAZ20PNf/FqmYEic//G/UK6uw0rn21g58ASgHJHl9rfE4nITQLqthr9rHMVQK4ezwohJbp2dGrZpkq979PYQ==}
@@ -4640,9 +4717,20 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -4749,6 +4837,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -4756,6 +4847,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -4848,6 +4943,9 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4880,6 +4978,10 @@ packages:
 
   spdx-license-ids@3.0.22:
     resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -4917,6 +5019,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -5027,6 +5132,10 @@ packages:
     resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
@@ -5383,6 +5492,15 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@axiomhq/js@1.8.0':
+    dependencies:
+      fetch-retry: 6.0.0
+
+  '@axiomhq/pino@1.8.0':
+    dependencies:
+      '@axiomhq/js': 1.8.0
+      pino-abstract-transport: 1.2.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6277,6 +6395,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       hono: 4.12.23
 
+  '@hono/structured-logger@0.1.0(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
   '@hono/swagger-ui@0.6.1(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
@@ -6647,6 +6769,8 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pinojs/redact@0.4.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7493,6 +7617,10 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   ace-builds@1.43.6: {}
 
   acorn-import-attributes@1.9.5(acorn@8.17.0):
@@ -7627,6 +7755,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -7674,6 +7804,8 @@ snapshots:
 
   base64-js@0.0.8: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.19: {}
 
   boolbase@1.0.0: {}
@@ -7702,6 +7834,11 @@ snapshots:
   bson@7.2.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8001,7 +8138,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -8068,11 +8205,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -8203,7 +8340,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0)(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
-      hasown: 2.0.3
+      hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
       minimatch: 3.1.5
@@ -8231,7 +8368,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 9.39.4(jiti@2.6.1)
-      hasown: 2.0.3
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.5
@@ -8260,7 +8397,7 @@ snapshots:
       es-iterator-helpers: 1.3.2
       eslint: 9.39.4(jiti@2.6.1)
       estraverse: 5.3.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.5
       object.entries: 1.1.9
@@ -8384,6 +8521,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -8427,6 +8566,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-retry@6.0.0: {}
 
   fflate@0.7.4: {}
 
@@ -8478,7 +8619,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.3
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -8497,7 +8638,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -8570,7 +8711,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.3:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -8658,6 +8799,8 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.8
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -8688,7 +8831,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   interpret@3.1.1: {}
@@ -8736,7 +8879,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -8799,7 +8942,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-set@2.0.3: {}
 
@@ -9512,6 +9655,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-exit-leak-free@2.1.2: {}
+
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -9595,6 +9740,31 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@1.2.0:
+    dependencies:
+      readable-stream: 4.7.0
+      split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -9632,6 +9802,10 @@ snapshots:
 
   pretty-checkbox@3.0.3: {}
 
+  process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
   progress@2.0.3: {}
 
   prop-types@15.8.1:
@@ -9651,6 +9825,8 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   react-ace@14.0.1(react-dom@19.2.6)(react@19.2.6):
     dependencies:
@@ -9683,7 +9859,19 @@ snapshots:
 
   react@19.2.6: {}
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -9871,6 +10059,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -9881,6 +10071,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -10030,6 +10222,10 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -10059,6 +10255,8 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   spdx-license-ids@3.0.22: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -10122,6 +10320,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -10199,6 +10401,10 @@ snapshots:
       acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
 
   tiny-emitter@2.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ catalogs:
     '@gera2ld/tarjs':
       specifier: ^0.3.1
       version: 0.3.1
+    '@hono/structured-logger':
+      specifier: ^0.1.0
+      version: 0.1.0
     '@msgpack/msgpack':
       specifier: ^3.1.3
       version: 3.1.3
@@ -132,6 +135,9 @@ importers:
       '@falling-nikochan/route':
         specifier: workspace:*
         version: link:route
+      '@hono/structured-logger':
+        specifier: 'catalog:'
+        version: 0.1.0(hono@4.12.23)
       '@sentry/hono':
         specifier: catalog:sentry
         version: 10.56.0(@sentry/bun@10.56.0)(@sentry/cloudflare@10.56.0)(@sentry/node@10.56.0)(hono@4.12.23)
@@ -427,7 +433,7 @@ importers:
         specifier: ^0.2.1
         version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23)
       '@hono/structured-logger':
-        specifier: ^0.1.0
+        specifier: 'catalog:'
         version: 0.1.0(hono@4.12.23)
       '@hono/swagger-ui':
         specifier: ^0.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ allowBuilds:
 
 catalog:
   "@gera2ld/tarjs": ^0.3.1
+  "@hono/structured-logger": ^0.1.0
   "@msgpack/msgpack": ^3.1.3
   "@types/chai": ^5.2.3
   "@vercel/og": ^0.11.1

--- a/route/initNormalizedText.ts
+++ b/route/initNormalizedText.ts
@@ -27,7 +27,12 @@ try {
             title: chart.title,
             composer: chart.composer,
             chartCreator: chart.chartCreator,
-            ytData: await getYTDataEntry(process.env as any, db, chart.ytId),
+            ytData: await getYTDataEntry(
+              console,
+              process.env as any,
+              db,
+              chart.ytId
+            ),
           }),
         },
       }

--- a/route/package.json
+++ b/route/package.json
@@ -19,7 +19,7 @@
     "@falling-nikochan/i18n": "workspace:*",
     "@hono/node-server": "^2.0.2",
     "@hono/standard-validator": "^0.2.1",
-    "@hono/structured-logger": "^0.1.0",
+    "@hono/structured-logger": "catalog:",
     "@hono/swagger-ui": "^0.6.1",
     "@msgpack/msgpack": "catalog:",
     "@scalar/hono-api-reference": "^0.10.14",

--- a/route/package.json
+++ b/route/package.json
@@ -14,10 +14,12 @@
     "dev": "tsx watch serve-local.ts"
   },
   "dependencies": {
+    "@axiomhq/pino": "^1.8.0",
     "@falling-nikochan/chart": "workspace:*",
     "@falling-nikochan/i18n": "workspace:*",
     "@hono/node-server": "^2.0.2",
     "@hono/standard-validator": "^0.2.1",
+    "@hono/structured-logger": "^0.1.0",
     "@hono/swagger-ui": "^0.6.1",
     "@msgpack/msgpack": "catalog:",
     "@scalar/hono-api-reference": "^0.10.14",
@@ -31,6 +33,7 @@
     "isbot": "catalog:",
     "moji": "^0.5.1",
     "mongodb": "catalog:",
+    "pino": "^10.3.1",
     "react": "catalog:react",
     "sitemap": "^9.0.1",
     "twitter-text": "^3.1.0",

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -15,7 +15,6 @@ import {
   sentryBeforeSend,
 } from "./src/index.js";
 import { Hono } from "hono";
-import { logger } from "hono/logger";
 import { ImageResponse } from "@vercel/og";
 import { getConnInfo } from "hono/bun";
 import * as Sentry from "@sentry/hono/bun";
@@ -23,8 +22,24 @@ import packageJson from "./package.json" with { type: "json" };
 import { MongoClient } from "mongodb";
 import { createMiddleware } from "hono/factory";
 import { compress } from "hono/compress";
+import { requestId } from "hono/request-id";
+import { structuredLogger } from "@hono/structured-logger";
+import pino from "pino";
 
 const port = 8787;
+
+const rootLogger = pino(
+  { level: "info" },
+  pino.transport({
+    // https://axiom.co/docs/guides/pino
+    target: "@axiomhq/pino",
+    options: {
+      dataset: process.env.AXIOM_DATASET,
+      token: process.env.AXIOM_TOKEN,
+      edge: process.env.AXIOM_EDGE, // us-east-1.aws.edge.axiom.co or eu-central-1.aws.edge.axiom.co
+    },
+  })
+);
 
 const sentryMiddleware = (app) =>
   Sentry.sentry(app, {
@@ -49,7 +64,12 @@ const fetchBrief = (_e: Bindings, cid: string) => getBrief(db!, cid);
 const app = new Hono<{ Bindings: Bindings }>({ strict: false });
 app.use(sentryMiddleware(app));
 app
-  .use(logger())
+  .use(requestId())
+  .use(
+    structuredLogger({
+      createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
+    })
+  )
   .use(compress())
   .route("/api", await apiApp({ getConnInfo, dbMiddleware }))
   .route("/og", ogApp({ ImageResponse, fetchBrief, fetchStatic }))

--- a/route/serve-bun-prod.ts
+++ b/route/serve-bun-prod.ts
@@ -15,6 +15,7 @@ import {
   sentryBeforeSend,
 } from "./src/index.js";
 import { Hono } from "hono";
+import { logger } from "hono/logger";
 import { ImageResponse } from "@vercel/og";
 import { getConnInfo } from "hono/bun";
 import * as Sentry from "@sentry/hono/bun";
@@ -70,6 +71,7 @@ app
       createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
     })
   )
+  .use(logger())
   .use(compress())
   .route("/api", await apiApp({ getConnInfo, dbMiddleware }))
   .route("/og", ogApp({ ImageResponse, fetchBrief, fetchStatic }))

--- a/route/serve-cf.js
+++ b/route/serve-cf.js
@@ -21,6 +21,7 @@ import packageJson from "@falling-nikochan/route/package.json" with { type: "jso
 import { MongoClient } from "mongodb";
 import { createMiddleware } from "hono/factory";
 import { compress } from "hono/compress";
+import { structuredLogger } from "@hono/structured-logger";
 
 const fetchStatic = (e, url) => e.ASSETS.fetch(url);
 const sentryConfig = (env) => ({
@@ -67,6 +68,7 @@ const fetchBrief = async (e, cid) => {
 const app = new Hono({ strict: false });
 app.use(Sentry.sentry(app, sentryHonoConfig));
 app
+  .use(structuredLogger({ createLogger: () => console }))
   .use(async (c, next) => {
     await next();
     if (c.res.headers.has("content-encoding")) {

--- a/route/serve-local.ts
+++ b/route/serve-local.ts
@@ -16,12 +16,12 @@ import {
   getBrief,
 } from "./src/index.js";
 import { Hono } from "hono";
-import { logger } from "hono/logger";
 import { ImageResponse } from "@vercel/og";
 import { getConnInfo } from "@hono/node-server/conninfo";
 import { Db, MongoClient } from "mongodb";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
+import { structuredLogger } from "@hono/structured-logger";
 
 const port = 8787;
 
@@ -53,7 +53,12 @@ const fetchBrief = (_e: Bindings, cid: string) => getBrief(db!, cid);
 console.log(`Server is running on http://localhost:${port}`);
 
 const app = new Hono<{ Bindings: Bindings }>({ strict: false })
-  .use(logger())
+  .use(
+    structuredLogger({
+      createLogger: () => console,
+      onRequest: () => undefined,
+    })
+  )
   .route("/api", await apiApp({ getConnInfo, dbMiddleware }))
   .route("/og", ogApp({ ImageResponse, fetchBrief, fetchStatic }))
   .route("/cron", cronTestApp)

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -75,6 +75,7 @@ interface ChartFileAppVars {
   etag: string;
   db: () => Promise<Db>;
   pSecretSalt: string;
+  logger: typeof console;
 }
 const chartFileApp = async (config: {
   getConnInfo: (c: Context) => ConnInfo | null;
@@ -536,9 +537,12 @@ const chartFileApp = async (config: {
                 cid,
                 updatedAt,
                 ip,
-                await getYTDataEntry(env(c), db, newChart.ytId).catch(
-                  () => undefined
-                ),
+                await getYTDataEntry(
+                  c.var.logger,
+                  env(c),
+                  db,
+                  newChart.ytId
+                ).catch(() => undefined),
                 pSecretSalt,
                 entry,
                 newSaveHashes

--- a/route/src/api/chartFile.ts
+++ b/route/src/api/chartFile.ts
@@ -49,6 +49,7 @@ import {
   PasswdParamSchema,
 } from "./passwdAuth.js";
 import { supportedEncodings } from "./decompress.js";
+import { BaseLogger } from "@hono/structured-logger";
 dotenv.config({ path: join(dirname(process.cwd()), ".env") });
 
 /**
@@ -75,7 +76,7 @@ interface ChartFileAppVars {
   etag: string;
   db: () => Promise<Db>;
   pSecretSalt: string;
-  logger: typeof console;
+  logger: BaseLogger;
 }
 const chartFileApp = async (config: {
   getConnInfo: (c: Context) => ConnInfo | null;

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -30,13 +30,14 @@ import { errorLiteral, validationErrorSchema } from "../error.js";
 import * as v from "valibot";
 import { ConnInfo } from "hono/conninfo";
 import { supportedEncodings } from "./decompress.js";
+import { BaseLogger } from "@hono/structured-logger";
 
 const newChartFileApp = async (config: {
   getConnInfo: (c: Context) => ConnInfo | null;
 }) =>
   new Hono<{
     Bindings: Bindings;
-    Variables: { logger: typeof console; db: () => Promise<Db> };
+    Variables: { logger: BaseLogger; db: () => Promise<Db> };
   }>({
     strict: false,
   }).post(

--- a/route/src/api/newChartFile.ts
+++ b/route/src/api/newChartFile.ts
@@ -34,7 +34,10 @@ import { supportedEncodings } from "./decompress.js";
 const newChartFileApp = async (config: {
   getConnInfo: (c: Context) => ConnInfo | null;
 }) =>
-  new Hono<{ Bindings: Bindings; Variables: { db: () => Promise<Db> } }>({
+  new Hono<{
+    Bindings: Bindings;
+    Variables: { logger: typeof console; db: () => Promise<Db> };
+  }>({
     strict: false,
   }).post(
     "/",
@@ -210,9 +213,12 @@ const newChartFileApp = async (config: {
               cid,
               updatedAt,
               ip,
-              await getYTDataEntry(env(c), db, newChart.ytId).catch(
-                () => undefined
-              ),
+              await getYTDataEntry(
+                c.var.logger,
+                env(c),
+                db,
+                newChart.ytId
+              ).catch(() => undefined),
               pSecretSalt,
               null
             )

--- a/route/src/api/passwdAuth.ts
+++ b/route/src/api/passwdAuth.ts
@@ -41,9 +41,6 @@ export function getPasswdParamsFromAuthHeader(
     return undefined;
   }
 
-  console.log({
-    Authorization: Object.fromEntries([authorization.split(" ")]),
-  });
   const { Authorization: authParams } = v.parse(
     v.object({
       Authorization: v.strictObject({

--- a/route/src/api/ytData.ts
+++ b/route/src/api/ytData.ts
@@ -2,6 +2,7 @@ import { Db } from "mongodb";
 import { Bindings } from "../env.js";
 import moji from "moji";
 import { fetchError } from "../error.js";
+import { BaseLogger } from "@hono/structured-logger";
 
 export interface YTDataEntry {
   ytId: string;
@@ -50,7 +51,7 @@ export function normalizeEntry(data: {
 }
 
 export async function getYTDataEntry(
-  logger: typeof console,
+  logger: BaseLogger,
   e: Bindings,
   db: Db,
   ytId: string
@@ -77,7 +78,7 @@ export async function getYTDataEntry(
         });
       }
       const data: any = await res.json();
-      logger.log(data);
+      logger.info({ ytData: data });
       if (data.items.length !== 1) {
         throw new Error("items.length !== 1");
       }

--- a/route/src/api/ytData.ts
+++ b/route/src/api/ytData.ts
@@ -50,6 +50,7 @@ export function normalizeEntry(data: {
 }
 
 export async function getYTDataEntry(
+  logger: typeof console,
   e: Bindings,
   db: Db,
   ytId: string
@@ -76,7 +77,7 @@ export async function getYTDataEntry(
         });
       }
       const data: any = await res.json();
-      console.log(data);
+      logger.log(data);
       if (data.items.length !== 1) {
         throw new Error("items.length !== 1");
       }

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -19,7 +19,7 @@ const CACHE_MAX_AGE = 86400;
 
 const ytMetaApp = new Hono<{
   Bindings: Bindings;
-  Variables: { db: () => Promise<Db> };
+  Variables: { logger: typeof console; db: () => Promise<Db> };
 }>({
   strict: false,
 }).get(
@@ -75,7 +75,7 @@ const ytMetaApp = new Hono<{
     const db = await c.get("db")();
     const entry = await getChartEntryCompressed(db, cid, null);
     const ytId = entry.ytId;
-    const ytData = await getYTDataEntry(env(c), db, ytId);
+    const ytData = await getYTDataEntry(c.var.logger, env(c), db, ytId);
     let title =
       // exact match
       ytData.localizations[lang]?.title ??

--- a/route/src/api/ytMeta.ts
+++ b/route/src/api/ytMeta.ts
@@ -13,13 +13,14 @@ import {
   validationErrorSchema,
 } from "../error.js";
 import { getYTDataEntry } from "./ytData.js";
+import { BaseLogger } from "@hono/structured-logger";
 
 // Cache duration for this API endpoint (in seconds)
 const CACHE_MAX_AGE = 86400;
 
 const ytMetaApp = new Hono<{
   Bindings: Bindings;
-  Variables: { logger: typeof console; db: () => Promise<Db> };
+  Variables: { logger: BaseLogger; db: () => Promise<Db> };
 }>({
   strict: false,
 }).get(

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -55,6 +55,7 @@ export function cacheControl(e: Bindings, age: number, private_?: boolean) {
 export function backendOrigin(
   c:
     | Context<{ Bindings: Bindings }>
+    | Context<{ Bindings: Bindings; Variables: { logger: typeof console } }>
     | Context<{ Bindings: Bindings; Variables: { db: () => Promise<Db> } }>
 ): string {
   if (env(c).BACKEND_PREFIX) {

--- a/route/src/env.ts
+++ b/route/src/env.ts
@@ -7,6 +7,7 @@ import { fetchError } from "./error.js";
 import { env } from "hono/adapter";
 import { Db } from "mongodb";
 import type { ErrorEvent, EventHint } from "@sentry/hono/node";
+import type { BaseLogger } from "@hono/structured-logger";
 
 export interface Bindings {
   ASSETS?: { fetch: typeof fetch };
@@ -55,7 +56,7 @@ export function cacheControl(e: Bindings, age: number, private_?: boolean) {
 export function backendOrigin(
   c:
     | Context<{ Bindings: Bindings }>
-    | Context<{ Bindings: Bindings; Variables: { logger: typeof console } }>
+    | Context<{ Bindings: Bindings; Variables: { logger: BaseLogger } }>
     | Context<{ Bindings: Bindings; Variables: { db: () => Promise<Db> } }>
 ): string {
   if (env(c).BACKEND_PREFIX) {

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -63,17 +63,6 @@ export const onError =
     setTransactionName: ((name: string) => undefined) | null;
   }) =>
   async (err: unknown, c: Context) => {
-    if (err instanceof Error) {
-      if (config.isTest) {
-        console.log(`Error handler triggered in ${c.req.path}: ${err.message}`);
-      } else {
-        console.error(
-          `Error handler triggered in ${c.req.path}: ${err.message}\n${err.cause}\n${err.stack}`
-        );
-      }
-    } else {
-      console.error(`Error handler triggered in ${c.req.path}: ${err}`);
-    }
     // routeハンドラーのあとにmiddlewareがある場合があり、routePath(c, -1)で正しく取得できないので、
     // pathが最長のハンドラーを採用する
     const route = matchedRoutes(c)
@@ -152,14 +141,15 @@ export const onError =
           status
         );
       } else {
-        if (c.req.path === `/${lang}/errorPlaceholder`) {
+        if (/\/errorPlaceholder/.test(c.req.path)) {
           // エラーハンドラーがfetchに失敗して無限ループになるのを防ぐ
-          console.warn("Fallback to plain error placeholder message.");
+          c.var.logger.warn("Fallback to plain error placeholder message.");
           return c.text("Error PLACEHOLDER_STATUS: PLACEHOLDER_MESSAGE");
         } else {
           return c.body(
             await errorResponse(
               config.fetchStatic,
+              c.var.logger,
               env(c),
               backendOrigin(c),
               lang,
@@ -172,7 +162,7 @@ export const onError =
         }
       }
     } catch (e) {
-      console.error("While handling the above error, another error thrown:", e);
+      c.var.logger.error(e);
       config.captureException?.(e, { extra: { err: String(err) } });
       return c.body(null, 500);
     }
@@ -180,6 +170,7 @@ export const onError =
 
 async function errorResponse(
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>,
+  logger: typeof console,
   e: Bindings,
   origin: string,
   lang: string,
@@ -191,8 +182,8 @@ async function errorResponse(
     .then(
       (res) => res.text(),
       (e) => {
-        console.error(`Failed to fetch error placeholder: `, e);
-        console.warn("Fallback to plain error placeholder message.");
+        logger.error(e);
+        logger.warn("Fallback to plain error placeholder message.");
         return "Error PLACEHOLDER_STATUS: PLACEHOLDER_MESSAGE";
       }
     )

--- a/route/src/error.ts
+++ b/route/src/error.ts
@@ -7,6 +7,7 @@ import { getTranslations } from "@falling-nikochan/i18n/dynamic.js";
 import * as v from "valibot";
 import { ContentfulStatusCode } from "hono/utils/http-status";
 import type { captureException } from "@sentry/hono/node";
+import { BaseLogger } from "@hono/structured-logger";
 
 export function notFound(): never {
   throw new HTTPException(404);
@@ -170,7 +171,7 @@ export const onError =
 
 async function errorResponse(
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>,
-  logger: typeof console,
+  logger: BaseLogger,
   e: Bindings,
   origin: string,
   lang: string,

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -21,6 +21,7 @@ import * as v from "valibot";
 import { fetchError } from "../error.js";
 import { cache } from "hono/cache";
 import { etag } from "hono/etag";
+import { BaseLogger } from "@hono/structured-logger";
 
 const CACHE_MAX_AGE = 315360000;
 
@@ -45,7 +46,7 @@ const ogApp = (config: {
   fetchBrief: (e: Bindings, cid: string) => Promise<{ brief: ChartBrief }>;
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
 }) =>
-  new Hono<{ Bindings: Bindings; Variables: { logger: typeof console } }>({
+  new Hono<{ Bindings: Bindings; Variables: { logger: BaseLogger } }>({
     strict: false,
   })
     .use("/*", cors({ origin: "*" }))

--- a/route/src/og/app.ts
+++ b/route/src/og/app.ts
@@ -45,7 +45,9 @@ const ogApp = (config: {
   fetchBrief: (e: Bindings, cid: string) => Promise<{ brief: ChartBrief }>;
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
 }) =>
-  new Hono<{ Bindings: Bindings }>({ strict: false })
+  new Hono<{ Bindings: Bindings; Variables: { logger: typeof console } }>({
+    strict: false,
+  })
     .use("/*", cors({ origin: "*" }))
     .use(etag())
     .use(
@@ -121,7 +123,7 @@ const ogApp = (config: {
         try {
           resultParams = deserializeResultParams(qResult);
         } catch (e) {
-          console.error(e);
+          c.var.logger.error(e);
           throw new HTTPException(400, { message: "invalidResultParam" });
         }
       }
@@ -206,7 +208,7 @@ const ogApp = (config: {
             imagePath = null;
             break;
           default:
-            console.error(`unknown touch type ${resultParams.inputType}`);
+            c.var.logger.error(`unknown touch type ${resultParams.inputType}`);
             imagePath = null;
             break;
         }

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -20,6 +20,7 @@ import { env } from "hono/adapter";
 import { Context, Hono } from "hono";
 import { etag } from "hono/etag";
 import { etagContentRegex } from "./api/chart.js";
+import { BaseLogger } from "@hono/structured-logger";
 
 /*
 OGPの見た目を優先するため、shareページではクエリのlangを優先する。
@@ -37,7 +38,7 @@ const shareApp = (config: {
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
   languageDetector?: (c: Context, next: () => Promise<void>) => Promise<void>;
 }) =>
-  new Hono<{ Bindings: Bindings; Variables: { logger: typeof console } }>({
+  new Hono<{ Bindings: Bindings; Variables: { logger: BaseLogger } }>({
     strict: false,
   })
     .use(config.languageDetector || languageDetector())

--- a/route/src/share.ts
+++ b/route/src/share.ts
@@ -37,7 +37,9 @@ const shareApp = (config: {
   fetchStatic: (e: Bindings, url: URL) => Promise<ResponseOK>;
   languageDetector?: (c: Context, next: () => Promise<void>) => Promise<void>;
 }) =>
-  new Hono<{ Bindings: Bindings }>({ strict: false })
+  new Hono<{ Bindings: Bindings; Variables: { logger: typeof console } }>({
+    strict: false,
+  })
     .use(config.languageDetector || languageDetector())
     .use(etag())
     // CookieとAccept-Languageでレスポンスが変わるためprivate指定しcache middlewareは使わない
@@ -52,7 +54,7 @@ const shareApp = (config: {
         try {
           resultParams = deserializeResultParams(qResult);
         } catch (e) {
-          console.error(e);
+          c.var.logger.error(e);
           // throw new HTTPException(400, { message: "invalidResultParam" });
         }
       }

--- a/route/tests/api/init.ts
+++ b/route/tests/api/init.ts
@@ -39,6 +39,7 @@ import { inspect } from "node:util";
 import { createMiddleware } from "hono/factory";
 import { Db } from "mongodb";
 import { before, after } from "node:test";
+import { structuredLogger } from "@hono/structured-logger";
 inspect.defaultOptions.depth = null;
 
 if (typeof process.env.MONGODB_URI !== "string") {
@@ -76,6 +77,13 @@ const fetchBrief = (_e: Bindings, cid: string) => getBrief(db!, cid);
 export { db };
 
 export const app = new Hono<{ Bindings: Bindings }>({ strict: false })
+  .use(
+    structuredLogger({
+      createLogger: () => console,
+      onRequest: () => undefined,
+      onResponse: () => undefined,
+    })
+  )
   .route("/api", await apiApp({ getConnInfo: () => null, dbMiddleware }))
   .route("/share", shareApp({ fetchBrief, fetchStatic }))
   .route("/", redirectApp({ fetchStatic }))

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -23,40 +23,60 @@ const e: Bindings = {
 // なぜconsoleが無い?
 declare const self: ServiceWorkerGlobalScope & { console: Console };
 
+function safeClone(a: unknown): unknown {
+  if (a instanceof Error) {
+    // structuredClone(error) は残りのプロパティをクローンせず、JSON.stringify(error) はmessageなどをクローンしないので、明示的に全プロパティのcloneをする
+    return {
+      name: a.name,
+      message: a.message,
+      stack: a.stack,
+      ...Object.fromEntries(
+        Object.entries(a).map(([k, v]) => [k, safeClone(v)])
+      ),
+    };
+  } else {
+    try {
+      return structuredClone(a);
+    } catch {
+      try {
+        return JSON.parse(JSON.stringify(a));
+      } catch {
+        return String(a);
+      }
+    }
+  }
+}
+function transferConsole(level: string, args: unknown[]) {
+  const safeArgs = args.map(safeClone);
+  self.clients.matchAll().then((clients) => {
+    clients.forEach((client) => {
+      client.postMessage({ type: "console", level: "log", args: safeArgs });
+    });
+  });
+}
+
 const originalConsole = self.console;
 self.console = {
   ...originalConsole,
   log: (...args: unknown[]) => {
     originalConsole.log(...args);
-    self.clients.matchAll().then((clients) => {
-      clients.forEach((client) => {
-        client.postMessage({ type: "console", level: "log", args });
-      });
-    });
+    transferConsole("log", args);
   },
   error: (...args: unknown[]) => {
     originalConsole.error(...args);
-    self.clients.matchAll().then((clients) => {
-      clients.forEach((client) => {
-        client.postMessage({ type: "console", level: "error", args });
-      });
-    });
+    transferConsole("error", args);
   },
   warn: (...args: unknown[]) => {
     originalConsole.warn(...args);
-    self.clients.matchAll().then((clients) => {
-      clients.forEach((client) => {
-        client.postMessage({ type: "console", level: "warn", args });
-      });
-    });
+    transferConsole("warn", args);
   },
   info: (...args: unknown[]) => {
     originalConsole.info(...args);
-    self.clients.matchAll().then((clients) => {
-      clients.forEach((client) => {
-        client.postMessage({ type: "console", level: "info", args });
-      });
-    });
+    transferConsole("info", args);
+  },
+  debug: (...args: unknown[]) => {
+    originalConsole.debug(...args);
+    transferConsole("debug", args);
   },
 };
 

--- a/worker/entry.ts
+++ b/worker/entry.ts
@@ -13,6 +13,7 @@ import { locales } from "@falling-nikochan/i18n/staticMin.js";
 import { TarFileType, TarReader } from "@gera2ld/tarjs";
 import cfBeaconHtml from "./beacon.html?raw";
 import { getMimeType, mimes } from "hono/utils/mime";
+import { structuredLogger } from "@hono/structured-logger";
 
 const e: Bindings = {
   MONGODB_URI: "",
@@ -29,7 +30,7 @@ self.console = {
     originalConsole.log(...args);
     self.clients.matchAll().then((clients) => {
       clients.forEach((client) => {
-        client.postMessage(args.map((a) => String(a)).join(" "));
+        client.postMessage({ type: "console", level: "log", args });
       });
     });
   },
@@ -37,7 +38,7 @@ self.console = {
     originalConsole.error(...args);
     self.clients.matchAll().then((clients) => {
       clients.forEach((client) => {
-        client.postMessage(args.map((a) => String(a)).join(" "));
+        client.postMessage({ type: "console", level: "error", args });
       });
     });
   },
@@ -45,7 +46,7 @@ self.console = {
     originalConsole.warn(...args);
     self.clients.matchAll().then((clients) => {
       clients.forEach((client) => {
-        client.postMessage(args.map((a) => String(a)).join(" "));
+        client.postMessage({ type: "console", level: "warn", args });
       });
     });
   },
@@ -53,7 +54,7 @@ self.console = {
     originalConsole.info(...args);
     self.clients.matchAll().then((clients) => {
       clients.forEach((client) => {
-        client.postMessage(args.map((a) => String(a)).join(" "));
+        client.postMessage({ type: "console", level: "info", args });
       });
     });
   },
@@ -451,6 +452,13 @@ async function fetchAPI(input: string | URL | Request, init?: RequestInit) {
   return res;
 }
 const app = new Hono({ strict: false })
+  .use(
+    structuredLogger({
+      createLogger: () => console,
+      onRequest: () => undefined,
+      onResponse: () => undefined,
+    })
+  )
   .use(async (c, next) => {
     await next();
     if (c.res.headers.get("Content-Type")?.includes("text/html")) {


### PR DESCRIPTION
- 本番環境(serve-bun-prod)でログをaxiomに送信する
- 全5環境にstructured logger middlewareを導入し、consoleをc.var.loggerで置き換え
- service worker→フロントエンドへのconsole転送において、引数が文字列でない場合も考慮しオブジェクトをそのまま送る仕様に変更
