### PR TITLE
briefを複数まとめて取得するAPI

### DIFF
--- a/CHANGELOG_dev.md
+++ b/CHANGELOG_dev.md
@@ -1,3 +1,7 @@
+## ver. 16.29 - 2026/07/23 [#1277](https://github.com/na-trium-144/falling-nikochan/pull/1277)
+
+* /api/briefs APIを追加 (未使用)
+
 ## ver. 16.28 - 2026/07/22
 
 * lpをassetのアーカイブから除外

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/frontend",
-  "version": "16.28.0",
+  "version": "16.29.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/route/package.json
+++ b/route/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@falling-nikochan/route",
-  "version": "16.28.0",
+  "version": "16.29.0",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/route/src/api/app.ts
+++ b/route/src/api/app.ts
@@ -26,6 +26,7 @@ import { env } from "hono/adapter";
 import { Db } from "mongodb";
 import { etag } from "hono/etag";
 import socialApp from "./social.js";
+import briefMultiApp from "./briefs.js";
 dotenv.config({ path: join(dirname(process.cwd()), ".env") });
 
 export { getBrief } from "./brief.js";
@@ -98,6 +99,7 @@ const apiApp = async (config: {
     .use("/*", decompressMiddleware)
     .use("/*", config.dbMiddleware)
     .route("/brief", await briefApp())
+    .route("/briefs", await briefMultiApp())
     .route("/ytMeta", ytMetaApp)
     .route(
       "/chartFile",

--- a/route/src/api/briefs.ts
+++ b/route/src/api/briefs.ts
@@ -1,0 +1,182 @@
+import { Hono } from "hono";
+import { cache } from "hono/cache";
+import { calcETag, ChartEntryCompressed, entryToBrief } from "./chart.js";
+import { Db } from "mongodb";
+import { backendOrigin, Bindings, cacheControl } from "../env.js";
+import { env } from "hono/adapter";
+import { ArrayDoc, CidSchema, docRefs } from "@falling-nikochan/chart";
+import * as v from "valibot";
+import { describeRoute, resolver, validator } from "hono-openapi";
+import { sValidatorHook, validationErrorSchema } from "../error.js";
+
+// Cache duration for this API endpoint (in seconds)
+const CACHE_MAX_AGE = 600;
+
+const MAX_CIDS_COUNT = 100;
+
+const Response200Doc = async () => {
+  const Response200Schema = () =>
+    v.object({
+      cid: CidSchema(),
+      status: v.literal(200),
+      response: v.any(), // replaced with ChartBrief in the doc definition below
+      etag: v.string(),
+    });
+  const schema = (await resolver(Response200Schema()).toOpenAPISchema()).schema;
+  return {
+    ...schema,
+    properties: {
+      ...schema.properties,
+      response: docRefs("ChartBrief"),
+    },
+  };
+};
+const Response404Doc = async () => {
+  const Response404Schema = () =>
+    v.object({
+      cid: CidSchema(),
+      status: v.literal(404),
+    });
+  return (await resolver(Response404Schema()).toOpenAPISchema()).schema;
+};
+
+const briefMultiApp = async () =>
+  new Hono<{
+    Bindings: Bindings;
+    Variables: { db: () => Promise<Db> };
+  }>({
+    strict: false,
+  }).get(
+    "/",
+    cache({
+      cacheName: "api-briefs",
+    }),
+    describeRoute({
+      description: "Get brief information about multiple charts.",
+      responses: {
+        200: {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: ArrayDoc(await Response200Doc()),
+            },
+          },
+          headers: {
+            "Cache-Control": {
+              description: `max-age=${CACHE_MAX_AGE}`,
+              schema: { type: "string" },
+            },
+          },
+        },
+        207: {
+          description: "One or multiple chart ids not found",
+          content: {
+            "application/json": {
+              schema: ArrayDoc({
+                anyOf: [await Response200Doc(), await Response404Doc()],
+              }),
+            },
+          },
+          headers: {
+            "Cache-Control": {
+              description: `no-cache`,
+              schema: { type: "string" },
+            },
+          },
+        },
+        308: {
+          description: "Chart ids are duplicated or not sorted",
+          headers: {
+            "Location": {
+              description: "/api/briefs?c=(sorted cids)",
+              schema: { type: "string" },
+            },
+          },
+        },
+        400: {
+          description: "invalid chart id",
+          content: {
+            "application/json": {
+              schema: resolver(await validationErrorSchema()),
+            },
+          },
+        },
+      },
+    }),
+    validator(
+      "query",
+      v.pipe(
+        v.object({
+          c: v.pipe(
+            v.union([
+              v.pipe(
+                CidSchema(),
+                v.transform((c) => [c])
+              ),
+              v.array(CidSchema()),
+            ]),
+            v.maxLength(MAX_CIDS_COUNT),
+            v.description(
+              `Up to ${MAX_CIDS_COUNT} chart IDs can be specified. To retrieve more, split into multiple requests.`
+            )
+          ),
+        })
+      ),
+      sValidatorHook()
+    ),
+    async (c) => {
+      const { c: cids } = c.req.valid("query");
+
+      // キャッシュを効かせるためにcidの並び順を正規化し重複を削除
+      const sortedCids = [...new Set(cids)].sort();
+      if (
+        cids.length !== sortedCids.length ||
+        cids.some((cid, i) => cid !== sortedCids[i])
+      ) {
+        return c.redirect(
+          new URL(
+            c.req.path +
+              "?" +
+              new URLSearchParams(
+                sortedCids.map((cid) => ["c", cid] as [string, string])
+              ).toString(),
+            backendOrigin(c)
+          ),
+          308
+        );
+      }
+
+      const db = await c.get("db")();
+      const dbEntries = await db
+        .collection<ChartEntryCompressed>("chart")
+        .find({ cid: { $in: cids }, deleted: false })
+        .toArray();
+      const entries = await Promise.all(
+        cids.map(async (cid) => {
+          const entry = dbEntries.find((e) => e.cid === cid);
+          if (entry) {
+            return {
+              cid: entry.cid,
+              status: 200 as const,
+              etag: await calcETag(entry),
+              response: entryToBrief(entry),
+            };
+          } else {
+            return { cid, status: 404 as const };
+          }
+        })
+      );
+
+      if (entries.every((e) => e.status === 200)) {
+        return c.json(entries, 200, {
+          "cache-control": cacheControl(env(c), CACHE_MAX_AGE),
+        });
+      } else {
+        return c.json(entries, 207, {
+          "cache-control": "no-cache",
+        });
+      }
+    }
+  );
+
+export default briefMultiApp;

--- a/route/tests/api/briefs.spec.ts
+++ b/route/tests/api/briefs.spec.ts
@@ -1,0 +1,153 @@
+import { test, describe } from "node:test";
+import { expect } from "chai";
+import { app, dummyChart, dummyDate, initDb } from "./init.js";
+import { ChartBrief, hashLevel } from "@falling-nikochan/chart";
+import {
+  calcETag,
+  getChartEntryCompressed,
+} from "@falling-nikochan/route/src/api/chart";
+import { MongoClient } from "mongodb";
+
+describe("GET /api/briefs", () => {
+  test("should return brief entries for valid cids", async () => {
+    await initDb();
+    const cid1 = "100000";
+    const cid2 = "100004";
+    const res = await app.request(`/api/briefs?c=${cid1}&c=${cid2}`);
+    expect(res.status).to.equal(200);
+    expect(res.headers.get("cache-control")).to.include("max-age=");
+
+    const entries = await res.json();
+    expect(entries).to.be.an("array").with.lengthOf(2);
+
+    const client = new MongoClient(process.env.MONGODB_URI!);
+    try {
+      await client.connect();
+      const db = client.db("nikochan");
+      const dbEntry1 = await getChartEntryCompressed(db, cid1, null);
+      const dbEntry2 = await getChartEntryCompressed(db, cid2, null);
+
+      expect(entries[0]).to.deep.equal({
+        cid: cid1,
+        status: 200,
+        etag: await calcETag(dbEntry1!),
+        response: {
+          ytId: dummyChart().ytId,
+          title: dummyChart().title,
+          composer: dummyChart().composer,
+          chartCreator: dummyChart().chartCreator,
+          updatedAt: dummyDate.getTime(),
+          published: true,
+          locale: dummyChart().locale,
+          levels: [
+            {
+              name: "e",
+              hash: await hashLevel(dummyChart().levelsFreeze[0]),
+              type: "Single",
+              difficulty: 1,
+              noteCount: 1,
+              bpmMin: 120,
+              bpmMax: 180,
+              length: 1.23,
+              unlisted: false,
+            },
+          ],
+        },
+      });
+
+      expect(entries[1].cid).to.equal(cid2);
+      expect(entries[1].status).to.equal(200);
+      expect(entries[1].etag).to.equal(await calcETag(dbEntry2!));
+      expect(entries[1].response).to.have.property("ytId");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("should accept a single cid parameter", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs?c=100000");
+    expect(res.status).to.equal(200);
+    const entries = await res.json();
+    expect(entries).to.be.an("array").with.lengthOf(1);
+    expect(entries[0].cid).to.equal("100000");
+    expect(entries[0].status).to.equal(200);
+  });
+
+  test("should redirect with 308 if cids are not sorted", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs?c=100004&c=100000");
+    expect(res.status).to.equal(308);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).to.equal("/api/briefs");
+    expect(location.searchParams.getAll("c")).to.deep.equal([
+      "100000",
+      "100004",
+    ]);
+  });
+
+  test("should redirect with 308 if cids contain duplicates", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs?c=100000&c=100000");
+    expect(res.status).to.equal(308);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).to.equal("/api/briefs");
+    expect(location.searchParams.getAll("c")).to.deep.equal(["100000"]);
+  });
+
+  test("should return 207 Multi-Status when some cids are not found or deleted", async () => {
+    await initDb();
+    // 100000: exists, 100001: deleted, 100002: non-existent
+    const res = await app.request("/api/briefs?c=100000&c=100001&c=100002");
+    expect(res.status).to.equal(207);
+    expect(res.headers.get("cache-control")).to.equal("no-cache");
+
+    const entries = await res.json();
+    expect(entries).to.be.an("array").with.lengthOf(3);
+    expect(entries[0]).to.have.property("status", 200);
+    expect(entries[0]).to.have.property("cid", "100000");
+    expect(entries[1]).to.deep.equal({ cid: "100001", status: 404 });
+    expect(entries[2]).to.deep.equal({ cid: "100002", status: 404 });
+  });
+
+  test("should return 207 Multi-Status when all cids are not found", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs?c=100002&c=100003");
+    expect(res.status).to.equal(207);
+    expect(res.headers.get("cache-control")).to.equal("no-cache");
+
+    const entries = await res.json();
+    expect(entries).to.deep.equal([
+      { cid: "100002", status: 404 },
+      { cid: "100003", status: 404 },
+    ]);
+  });
+
+  test("should return 400 for invalid cid format", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs?c=invalid");
+    expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+    expect(body.flattened.nested.c[0]).to.be.a("string");
+  });
+
+  test("should return 400 when c parameter is missing", async () => {
+    await initDb();
+    const res = await app.request("/api/briefs");
+    expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+  });
+
+  test("should return 400 when cids count exceeds maximum (100)", async () => {
+    await initDb();
+    // Generate 101 valid sorted CIDs: "100000", "100001", ..., "100100"
+    const cids = Array.from({ length: 101 }, (_, i) => String(100000 + i));
+    const query = cids.map((cid) => `c=${cid}`).join("&");
+    const res = await app.request(`/api/briefs?${query}`);
+    expect(res.status).to.equal(400);
+    const body = await res.json();
+    expect(body.message).to.equal("badRequest");
+  });
+});


### PR DESCRIPTION
/api/briefs APIをバックエンドだけ作った
フロントエンドも一部これに置き換えようとしたが想定以上に複雑になりそうなので諦めた (chartList.tsxのロジックが汚すぎる)
現状の/api/brief並列呼び出しでもhttp/2の多重化がきいているので、バッチ化したところでメリットそんなにない可能性もある
けどまあ作ってしまったのでバックエンドだけマージしとく